### PR TITLE
use only first line of output for parsing final answer

### DIFF
--- a/benchexec/tools/aprove.py
+++ b/benchexec/tools/aprove.py
@@ -39,14 +39,13 @@ class Tool(benchexec.tools.template.BaseTool):
 
 
     def determine_result(self, returncode, returnsignal, output, isTimeout):
-        output = '\n'.join(output)
-        if "YES" in output:
+        if "YES" in output[0]:
             return result.RESULT_TRUE_PROP
-        elif "TRUE" in output:
+        elif "TRUE" in output[0]:
             return result.RESULT_TRUE_PROP
-        elif "FALSE" in output:
+        elif "FALSE" in output[0]:
             return result.RESULT_FALSE_TERMINATION
-        elif "NO" in output:
+        elif "NO" in output[0]:
             return result.RESULT_FALSE_TERMINATION
         else:
             return result.RESULT_UNKNOWN


### PR DESCRIPTION
We had to fix our wrapper script so that only the first line is considered as an answer (else, e.g. for all examples that have "true" in their names we find this keyword and return "true").

Sorry for the late fix and any inconvenience caused!