### PR TITLE
Add note on cgroup_enable=memory for debian kernels and those derived from these

### DIFF
--- a/doc/INSTALL.md
+++ b/doc/INSTALL.md
@@ -102,6 +102,11 @@ To do so, you typically need to edit your bootloader configuration
 (under Ubuntu for example in `/etc/default/grub`, line `GRUB_CMDLINE_LINUX`),
 update the bootloader (`sudo update-grub`), and reboot.
 
+In some debian kernels (and those derived from them, e.g. Raspberry Pi kernel),
+some memory cgroup controller should be disabled by default, and can be enabled
+with `cgroup_enable=memory` option on the kernel command line, similar to
+`swapaccount=1` above.
+
 All the above requirements can be checked easily by running
 
     python3 -m benchexec.check_cgroups


### PR DESCRIPTION
This is unfortunately still a problem on some platforms (e.g. all Raspberry Pi's) where debian patches are used, and I think would be worth a few lines to save users some frustration, as this kernel option isn't really documented anywhere (except for docs on other cgroup-related apps, e.g. LXC - https://wiki.debian.org/LXC#Prepare_the_host ).
