### PR TITLE
Update systemd install docs section

### DIFF
--- a/doc/INSTALL.md
+++ b/doc/INSTALL.md
@@ -136,43 +136,37 @@ The following steps are necessary:
    This setting needs a reboot to take effect,
    and [potentially a regeneration of your initramdisk](http://www.freedesktop.org/software/systemd/man/systemd-system.conf.html#Options).
 
- * Put the following into a file `/usr/local/sbin/benchexec-cgroup.sh`.
-   By default, this gives permissions to use the BenchExec cgroup
-   to users of the group `benchexec`, please adjust this as necessary.
-   Do not forget to make the file executable.
-```
-#!/bin/bash
-# Fill in set of allowed CPUs and memory regions (default is empty).
-cp /sys/fs/cgroup/cpuset/cpuset.cpus /sys/fs/cgroup/cpuset/system.slice/
-cp /sys/fs/cgroup/cpuset/cpuset.mems /sys/fs/cgroup/cpuset/system.slice/
-cp /sys/fs/cgroup/cpuset/cpuset.cpus /sys/fs/cgroup/cpuset/system.slice/benchexec-cgroup.service/
-cp /sys/fs/cgroup/cpuset/cpuset.mems /sys/fs/cgroup/cpuset/system.slice/benchexec-cgroup.service/
-
-echo $$ > /sys/fs/cgroup/cpuset/system.slice/benchexec-cgroup.service/tasks
-
-# Adjust permissions of cgroup (change as appropriate for you).
-chgrp -vR benchexec /sys/fs/cgroup/*/system.slice/benchexec-cgroup.service/
-chmod -vR g+w /sys/fs/cgroup/*/system.slice/benchexec-cgroup.service/
-
-# Sleep for 10 years.
-exec sleep $(( 10 * 365 * 24 * 3600 ))
-```
-
  * Put the following into a file `/etc/systemd/system/benchexec-cgroup.service`
-   and enable the service with `systemctl daemon-reload; systemctl enable benchexec-cgroup; systemctl start benchexec-cgroup`:
+   and enable the service with `systemctl enable benchexec-cgroup; systemctl start benchexec-cgroup`.
+
+   By default, this gives permissions to use the BenchExec cgroup to users of
+   the group `benchexec`, please adjust this as necessary or create this group
+   by running `groupadd benchexec` command beforehand.
+
+
 ```
 [Unit]
-Description=Cgroup for BenchExec
+Description=Cgroup setup for BenchExec
 Documentation=https://github.com/sosy-lab/benchexec/blob/master/doc/INSTALL.md
 Documentation=https://github.com/sosy-lab/benchexec/blob/master/doc/INDEX.md
 
 [Service]
-Type=simple
-ExecStart=/usr/local/sbin/benchexec-cgroup.sh
 Restart=always
 Delegate=true
 CPUAccounting=true
 MemoryAccounting=true
+
+ExecStart=/bin/bash -c '\
+set -e;\
+cd /sys/fs/cgroup/cpuset/;\
+cp cpuset.cpus system.slice/;\
+cp cpuset.mems system.slice/;\
+cp cpuset.cpus system.slice/benchexec-cgroup.service/;\
+cp cpuset.mems system.slice/benchexec-cgroup.service/;\
+echo $$$$ > system.slice/benchexec-cgroup.service/tasks;\
+chgrp -R benchexec /sys/fs/cgroup/*/system.slice/benchexec-cgroup.service/;\
+chmod -R g+w /sys/fs/cgroup/*/system.slice/benchexec-cgroup.service/;\
+exec sleep $(( 10 * 365 * 24 * 3600 ))'
 
 [Install]
 WantedBy=multi-user.target


### PR DESCRIPTION
This is a sqashed list changes for relatively-small systemd-related INSTALL.md section:

* Don't create a separate script to go with systemd unit, keep it all contained within.
* Use `set -e` in the script, so it'd fail properly if any/all commands in it don't work.
* Do not add script itself to the cgroup, to avoid accounting for it in any way.
* Add mention for `groupadd benchexec` command, required for this script to make sense.
* Avoid flooding logs (esp. on boot, where it's bad as it is) with pointless verbose output from chgrp/chmod, drowning-out any potential errors in hundred lines of noise.
* Drop `Type=simple` unit line, as it is the default for systemd services, and has always been.
* Drop `*Accounting=true` unit lines, as these are redundant with `Delegate=true`.
* Remove `systemctl daemon-reload` command, as it is redundant with `systemctl enable benchexec-cgroup` that follows it.

Squashed together due to each being very minor tweak by itself, to avoid spamming git-log with this stuff.

Please feel free to pick only the changes you think make sense (no need for attribution), or I can tweak the commit based on the comments before merging of course, to leave some of this stuff as-is or add more info on all/any of these to commit msg/log.