### PR TITLE
Fix typo in the install doc

### DIFF
--- a/doc/INSTALL.md
+++ b/doc/INSTALL.md
@@ -103,8 +103,8 @@ To do so, you typically need to edit your bootloader configuration
 update the bootloader (`sudo update-grub`), and reboot.
 
 In some debian kernels (and those derived from them, e.g. Raspberry Pi kernel),
-some memory cgroup controller should be disabled by default, and can be enabled
-with `cgroup_enable=memory` option on the kernel command line, similar to
+memory cgroup controller should be disabled by default, and can be enabled with
+`cgroup_enable=memory` option on the kernel command line, similar to
 `swapaccount=1` above.
 
 All the above requirements can be checked easily by running


### PR DESCRIPTION
Unfortunate "... **some** memory cgroup controller should be disabled ..." (but rather irrelevant) typo in the doc during one of the late PRs.
Spotted only now when re-reading the resulting md on github. Sorry about that.