### PR TITLE
Fix location of logfiles.zip

### DIFF
--- a/benchexec/tablegenerator/__init__.py
+++ b/benchexec/tablegenerator/__init__.py
@@ -754,8 +754,7 @@ class RunResult(object):
             log_file_url = Util.make_url(log_file)
             url_parts = urllib.parse.urlparse(log_file_url, allow_fragments=False)
             log_zip_path = os.path.dirname(url_parts.path) + ".zip"
-            log_zip_url = urllib.parse.urlunparse((url_parts.scheme, url_parts.netloc,
-                log_zip_path, url_parts.params, url_parts.query, url_parts.fragment))
+            log_zip_url = Util.make_url(log_zip_path)
             path_in_zip = urllib.parse.unquote(
                 os.path.relpath(url_parts.path, os.path.dirname(log_zip_path)))
 


### PR DESCRIPTION
Creating a table with additional columns parsed from the logfiles fails due to a wrong path:

WARNING: Could not find logfile
'test/results/predicate_bitprecise_CNF_KIND.2016-09-04_1153.logfiles/CNF_KIND-path.linux-4.2-rc1.tar.xz-43_2a-drivers--usb--host--xhci-hcd.ko-entry_point_true-unreach-call.cil.out.c.log'
nor log archive
'file:///test/results/predicate_bitprecise_CNF_KIND.2016-09-04_1153.logfiles.zip'.

It seems that the ```file:///``` is too much. I changed this behaviour to match the one for unzipped logfiles. Now I can create the table with the additional columns without problems.