### PR TITLE
CBMC no longer defaults to inserting unwinding assertions

### DIFF
--- a/benchexec/tools/cbmc.py
+++ b/benchexec/tools/cbmc.py
@@ -98,10 +98,10 @@ class Tool(benchexec.tools.template.BaseTool):
 
             elif status == "SUCCESS":
                 assert returncode == 0
-                if "--no-unwinding-assertions" in self.options:
-                    status = result.RESULT_UNKNOWN
-                else:
+                if "--unwinding-assertions" in self.options:
                     status = result.RESULT_TRUE_PROP
+                else:
+                    status = result.RESULT_UNKNOWN
 
         except Exception:
             if isTimeout:


### PR DESCRIPTION
A "SUCCESS" result is thus only guaranteed to be sound if the additional
--unwinding-assertions option had been used.

This should have been fixed a while ago, but only the discussion in #166 got me to review the script properly.