### PR TITLE
remove witness hack from ultimate.py

### DIFF
--- a/benchexec/tools/ultimate.py
+++ b/benchexec/tools/ultimate.py
@@ -34,11 +34,6 @@ class UltimateTool(benchexec.tools.template.BaseTool):
         return self._version_from_tool(executable)
 
     def cmdline(self, executable, options, tasks, spec, rlimits):
-        # search for witness in options and put it at the end / together with tasks
-        for option in options:
-            if option.endswith('.graphml'):
-                options.remove(option)
-                return [executable] + [spec] + options + ['--full-output'] + tasks + [option]
         return [executable] + [spec] + options + ['--full-output'] + tasks
 
     def determine_result(self, returncode, returnsignal, output, isTimeout):


### PR DESCRIPTION
With the new CLI interface and the witness being specified as argument to --validate, the hack to shift the position of the witness argument is no longer required