### PR TITLE
Symbiotic4 fix

### DIFF
--- a/benchexec/tools/symbiotic4.py
+++ b/benchexec/tools/symbiotic4.py
@@ -32,6 +32,7 @@ class Tool(benchexec.tools.template.BaseTool):
     REQUIRED_PATHS = [
                   "bin",
                   "include",
+                  "share",
                   "instrumentations",
                   "lib",
                   "lib32",

--- a/benchexec/tools/symbiotic4.py
+++ b/benchexec/tools/symbiotic4.py
@@ -89,6 +89,8 @@ class Tool(benchexec.tools.template.BaseTool):
             return result.RESULT_FALSE_FREE
           elif line.startswith('FALSE (valid-memtrack)'):
             return result.RESULT_FALSE_MEMTRACK
+          elif line.startswith('FALSE (overflow)'):
+            return result.RESULT_FALSE_OVERFLOW
           elif line.startswith('FALSE'):
             return result.RESULT_FALSE_REACH
 


### PR DESCRIPTION
Hi,

I went through the last test run and found out that I forgot to add parsing of overflow results. I also added back the "share" directory back (commit 56b0ff7), because it really should not be empty. The problem was caused by Archive Manager that for some reason transformed a symbolic link to regular directory (kind of "inlined" the directory instead of symbolic link). The new archives are packed with tar from command line, which should keep the original structure (thus share should not be empty).

Could we get this updated?

Thanks,
Marek