### PR TITLE
add support for merging hostnames in HTML tables.

### DIFF
--- a/benchexec/tablegenerator/__init__.py
+++ b/benchexec/tablegenerator/__init__.py
@@ -71,7 +71,6 @@ TEMPLATE_NAMESPACE={
    'json': Util.to_json,
    'create_link': Util.create_link,
    'format_options': Util.format_options,
-   'format_host': Util.format_host,
    }
 
 _BYTE_FACTOR = 1000 # bytes in a kilobyte

--- a/benchexec/tablegenerator/__init__.py
+++ b/benchexec/tablegenerator/__init__.py
@@ -963,7 +963,7 @@ def get_table_head(runSetResults, commonFileNamePrefix):
                 runSetResult.attributes[key] = Util.prettylist(map(round_to_MHz, values))
 
             elif key == 'host':
-                runSetResult.attributes[key] = Util.prettylist(values, True)
+                runSetResult.attributes[key] = Util.prettylist(Util.merge_entries_with_common_prefixes(values))
 
             else:
                 runSetResult.attributes[key] = Util.prettylist(values)

--- a/benchexec/tablegenerator/__init__.py
+++ b/benchexec/tablegenerator/__init__.py
@@ -962,6 +962,9 @@ def get_table_head(runSetResults, commonFileNamePrefix):
                         return value
                 runSetResult.attributes[key] = Util.prettylist(map(round_to_MHz, values))
 
+            elif key == 'host':
+                runSetResult.attributes[key] = Util.prettylist(values, True)
+
             else:
                 runSetResult.attributes[key] = Util.prettylist(values)
 

--- a/benchexec/tablegenerator/template.html
+++ b/benchexec/tablegenerator/template.html
@@ -224,7 +224,7 @@
   <tr id="{{line.id}}" class="{{line.id}} {{if not lineName in ['runset', 'title']}}collapsable-header{{endif}}">
 <td colspan="{{count_id_columns}}">{{line.name}}</td>
     {{for cell, width in line.content}}
-<td colspan="{{width}}">{{html(format_options(html_quote(cell))) if line.id == 'options' else format_host(cell) if lineName == 'host' else cell}}</td>
+<td colspan="{{width}}">{{html(format_options(html_quote(cell))) if line.id == 'options' else cell}}</td>
     {{endfor}}
 </tr>
   {{endif}}

--- a/benchexec/tablegenerator/test/expected/big-table.diff.html
+++ b/benchexec/tablegenerator/test/expected/big-table.diff.html
@@ -14,9 +14,9 @@
 </tr>
   <tr id="host" class="host collapsable-header">
 <td colspan="2">Host</td>
-<td colspan="9">[aal; aesche; aitel; babylon5; barbe; barsch; brachse; cayman1; cayman2; cayman3; cayman4; cayman5; cayman6; cayman7; cayman8; cs-sel-05; cs-sel-06; deathstar; ds9; elysium; empoknor; excelsior; falcon; forelle; hausen; hecht; huchen; mt-farm01; mt-farm02; mt-farm03; mt-farm04; nervling; neunauge; node-02; node-03; node-05; node-06; node-08; node-09; node-10; node-11; node-12; node-13; node-14; node-15; node-16; node-17; node-18; node-20; node-21; node-24; node-25; saibling; saratoga; sovereign; tardis; voyager; zeus01; zeus03; zeus04; zeus05; zeus06; zeus08; zeus10; zeus11; zeus12; zeus13; zeus14; zeus15; zeus17; zeus18; zeus19; zeus20; zeus21; zeus22; zeus23]</td>
+<td colspan="9">[aal; aesche; aitel; babylon5; barbe; barsch; brachse; cayman*; cs-sel-05; cs-sel-06; deathstar; ds9; elysium; empoknor; excelsior; falcon; forelle; hausen; hecht; huchen; mt-farm01; mt-farm02; mt-farm03; mt-farm04; nervling; neunauge; node-*; saibling; saratoga; sovereign; tardis; voyager; zeus*]</td>
 <td colspan="4">[mt-farm01; mt-farm02; mt-farm03; mt-farm04]</td>
-<td colspan="5">[node-01; node-02; node-03; node-04; node-05; node-06; node-07; node-08; node-09; node-10; node-11; node-12; node-13; node-14; node-15; node-16; node-17; node-18; node-19; node-20; node-21; node-22; node-23; node-24; node-25]</td>
+<td colspan="5">node-*</td>
 </tr>
   <tr id="os" class="os collapsable-header">
 <td colspan="2">OS</td>

--- a/benchexec/tablegenerator/test/expected/big-table.table.html
+++ b/benchexec/tablegenerator/test/expected/big-table.table.html
@@ -14,9 +14,9 @@
 </tr>
   <tr id="host" class="host collapsable-header">
 <td colspan="2">Host</td>
-<td colspan="9">[aal; aesche; aitel; babylon5; barbe; barsch; brachse; cayman1; cayman2; cayman3; cayman4; cayman5; cayman6; cayman7; cayman8; cs-sel-05; cs-sel-06; deathstar; ds9; elysium; empoknor; excelsior; falcon; forelle; hausen; hecht; huchen; mt-farm01; mt-farm02; mt-farm03; mt-farm04; nervling; neunauge; node-02; node-03; node-05; node-06; node-08; node-09; node-10; node-11; node-12; node-13; node-14; node-15; node-16; node-17; node-18; node-20; node-21; node-24; node-25; saibling; saratoga; sovereign; tardis; voyager; zeus01; zeus03; zeus04; zeus05; zeus06; zeus08; zeus10; zeus11; zeus12; zeus13; zeus14; zeus15; zeus17; zeus18; zeus19; zeus20; zeus21; zeus22; zeus23]</td>
+<td colspan="9">[aal; aesche; aitel; babylon5; barbe; barsch; brachse; cayman*; cs-sel-05; cs-sel-06; deathstar; ds9; elysium; empoknor; excelsior; falcon; forelle; hausen; hecht; huchen; mt-farm01; mt-farm02; mt-farm03; mt-farm04; nervling; neunauge; node-*; saibling; saratoga; sovereign; tardis; voyager; zeus*]</td>
 <td colspan="4">[mt-farm01; mt-farm02; mt-farm03; mt-farm04]</td>
-<td colspan="5">[node-01; node-02; node-03; node-04; node-05; node-06; node-07; node-08; node-09; node-10; node-11; node-12; node-13; node-14; node-15; node-16; node-17; node-18; node-19; node-20; node-21; node-22; node-23; node-24; node-25]</td>
+<td colspan="5">node-*</td>
 </tr>
   <tr id="os" class="os collapsable-header">
 <td colspan="2">OS</td>

--- a/benchexec/tablegenerator/test_util.py
+++ b/benchexec/tablegenerator/test_util.py
@@ -1,0 +1,66 @@
+# BenchExec is a framework for reliable benchmarking.
+# This file is part of BenchExec.
+#
+# Copyright (C) 2007-2016  Dirk Beyer
+# All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# prepare for Python 3
+from __future__ import absolute_import, division, print_function, unicode_literals
+
+import sys
+import unittest
+sys.dont_write_bytecode = True # prevent creation of .pyc files
+
+from benchexec.tablegenerator import util
+
+class TestUnit(unittest.TestCase):
+
+    @classmethod
+    def setUpClass(cls):
+        cls.longMessage = True
+        cls.maxDiff = None
+
+    def assertEqualNumberAndUnit(self, value, number, unit):
+        self.assertEqual(util.split_number_and_unit(value), (number, unit))
+        self.assertEqual(util.split_string_at_suffix(value, False), (number, unit))
+
+    def assertEqualTextAndNumber(self, value, text, number):
+        self.assertEqual(util.split_string_at_suffix(value, True), (text, number))
+
+    def test_split_number_and_unit(self):
+        self.assertEqualNumberAndUnit("", "", "")
+        self.assertEqualNumberAndUnit("1", "1", "")
+        self.assertEqualNumberAndUnit("1s", "1", "s")
+        self.assertEqualNumberAndUnit("111s", "111", "s")
+        self.assertEqualNumberAndUnit("s1", "s1", "")
+        self.assertEqualNumberAndUnit("s111", "s111", "")
+        self.assertEqualNumberAndUnit("-1s", "-1", "s")
+        self.assertEqualNumberAndUnit("1abc", "1", "abc")
+        self.assertEqualNumberAndUnit("abc", "", "abc")
+        self.assertEqualNumberAndUnit("abc1abc", "abc1", "abc")
+        self.assertEqualNumberAndUnit("abc1abc1abc", "abc1abc1", "abc")
+
+    def test_split_string_at_suffix(self):
+        self.assertEqualTextAndNumber("", "", "")
+        self.assertEqualTextAndNumber("1", "", "1")
+        self.assertEqualTextAndNumber("1s", "1s", "")
+        self.assertEqualTextAndNumber("111s", "111s", "")
+        self.assertEqualTextAndNumber("s1", "s", "1")
+        self.assertEqualTextAndNumber("s111", "s", "111")
+        self.assertEqualTextAndNumber("-1s", "-1s", "")
+        self.assertEqualTextAndNumber("abc1", "abc", "1")
+        self.assertEqualTextAndNumber("abc", "abc", "")
+        self.assertEqualTextAndNumber("abc1abc", "abc1abc", "")
+        self.assertEqualTextAndNumber("abc1abc1", "abc1abc", "1")

--- a/benchexec/tablegenerator/util.py
+++ b/benchexec/tablegenerator/util.py
@@ -103,7 +103,6 @@ def split_number_and_unit(s):
     Splitting is done from the end, so the split is where the last digit
     in the string is (that means the prefix may include non-digit characters,
     if they are followed by at least one digit).
-    In 'reverse' mode we split the element into the string and a postfix number.
     """
     return split_string_at_suffix(s,False)
 

--- a/benchexec/tablegenerator/util.py
+++ b/benchexec/tablegenerator/util.py
@@ -33,7 +33,6 @@ import re
 from urllib.parse import quote as url_quote
 import urllib.request
 import tempita
-import ast
 
 from benchexec import model
 
@@ -150,13 +149,6 @@ def format_options(options):
             lines[-1] += token
     # join all non-empty lines and wrap them into 'span'-tags
     return '<span style="display:block">' + '</span><span style="display:block">'.join(line for line in lines if line.strip()) + '</span>'
-
-def format_host(host_line):
-    '''Helper function for formatting the content of the host line'''
-    host_list = [item.strip() for item in host_line.replace('[', '').replace(']', '').split(';')];
-    if len(host_list) < 10:
-        return host_line
-    return '[' + '; '.join(host_list[0:5]) + '; ...; '+ host_list[-1] + ']'
 
 def to_decimal(s):
     # remove whitespaces and trailing units (e.g., in '1.23s')


### PR DESCRIPTION
With an increasing number of machines (e.g., apollon001-150) the table
gets crowded with many hostnames. As all machines are identical and a
user does not read all hostnames, we can also merge the hostnames.

Example: ['test', 'pc1', 'pc2', 'pc3'] -> ['test', 'pc*']