### PR TITLE
Add a specific error result for witnesses that are structurally incorrect witnesses

### DIFF
--- a/benchexec/tools/cpachecker.py
+++ b/benchexec/tools/cpachecker.py
@@ -140,13 +140,19 @@ class Tool(benchexec.tools.template.BaseTool):
                 status = 'JAVA HEAP ERROR'
             elif line.startswith('Error: ') and not status:
                 status = result.RESULT_ERROR
-                if 'Unsupported' in line:
+                if 'Cannot parse witness' in line:
+                    status += '(invalid witness file)'
+                elif 'Unsupported' in line:
                     if 'recursion' in line:
                         status += ' (recursion)'
                     elif 'threads' in line:
                         status += ' (threads)'
                 elif 'Parsing failed' in line:
                     status += ' (parsing failed)'
+            elif line.startswith('Invalid configuration: ') and not status:
+                if 'Cannot parse witness' in line:
+                    status = result.RESULT_ERROR
+                    status += '(invalid witness file)'
             elif line.startswith('For your information: CPAchecker is currently hanging at') and not status and isTimeout:
                 status = 'TIMEOUT'
 

--- a/benchexec/tools/cpachecker.py
+++ b/benchexec/tools/cpachecker.py
@@ -141,7 +141,7 @@ class Tool(benchexec.tools.template.BaseTool):
             elif line.startswith('Error: ') and not status:
                 status = result.RESULT_ERROR
                 if 'Cannot parse witness' in line:
-                    status += '(invalid witness file)'
+                    status += ' (invalid witness file)'
                 elif 'Unsupported' in line:
                     if 'recursion' in line:
                         status += ' (recursion)'
@@ -152,7 +152,7 @@ class Tool(benchexec.tools.template.BaseTool):
             elif line.startswith('Invalid configuration: ') and not status:
                 if 'Cannot parse witness' in line:
                     status = result.RESULT_ERROR
-                    status += '(invalid witness file)'
+                    status += ' (invalid witness file)'
             elif line.startswith('For your information: CPAchecker is currently hanging at') and not status and isTimeout:
                 status = 'TIMEOUT'
 


### PR DESCRIPTION
Add a specific error result for witnesses that are structurally incorrect witnesses.
This implements a feature for witness validation requested for SVCOMP'17.