### PR TITLE
recognize invalid witness and produce appropriate result 

### DIFF
--- a/benchexec/tools/ultimate.py
+++ b/benchexec/tools/ultimate.py
@@ -64,7 +64,10 @@ class UltimateTool(benchexec.tools.template.BaseTool):
                 status = result.RESULT_UNKNOWN
                 break
             elif line.startswith('ERROR'):
-                status = 'ERROR'
+                if line.startswith('ERROR: INVALID WITNESS FILE'):
+                    status = line
+                else:
+                    status = 'ERROR'
                 break
 
         return status


### PR DESCRIPTION
change string (L68) at your convenience for compatibility with other witness validators; now its just 'ERROR: INVALID WITNESS FILE'