### PR TITLE
witness2test uses pycparser

### DIFF
--- a/benchexec/tools/witness2test.py
+++ b/benchexec/tools/witness2test.py
@@ -30,7 +30,7 @@ class Tool(benchexec.tools.template.BaseTool):
     (https://github.com/diffblue/cprover-sv-comp/pull/14).
     """
 
-    REQUIRED_PATHS = ['test-gen.sh', 'process_witness.py', 'TestEnvGenerator.pl']
+    REQUIRED_PATHS = ['test-gen.sh', 'process_witness.py', 'TestEnvGenerator.pl', 'pycparser-master']
 
     def executable(self):
         """


### PR DESCRIPTION
Although test-gen.sh would take care of downloading it, the container-based set up requires preparation beforehand.