### PR TITLE
Fix path handling in benchexec run result xml files

### DIFF
--- a/benchexec/model.py
+++ b/benchexec/model.py
@@ -432,7 +432,7 @@ class RunSet(object):
 
             currentRuns = []
             for sourcefile in sourcefiles:
-                currentRuns.append(Run(sourcefile, fileOptions, self, propertyfile,
+                currentRuns.append(Run(sourcefile[0], sourcefile, fileOptions, self, propertyfile,
                                        global_required_files_pattern.union(required_files_pattern)))
 
             blocks.append(SourcefileSet(sourcefileSetName, index, currentRuns))
@@ -568,7 +568,7 @@ class Run(object):
     A Run contains some sourcefile, some options, propertyfiles and some other stuff, that is needed for the Run.
     """
 
-    def __init__(self, sourcefiles, fileOptions, runSet, propertyfile=None, required_files_patterns=[]):
+    def __init__(self, identifier, sourcefiles, fileOptions, runSet, propertyfile=None, required_files_patterns=[]):
         assert sourcefiles
         self.identifier = sourcefiles[0] # used for name of logfile, substitution, result-category
         self.sourcefiles = util.get_files(sourcefiles) # expand directories to get their sub-files

--- a/benchexec/outputhandler.py
+++ b/benchexec/outputhandler.py
@@ -309,8 +309,7 @@ class OutputHandler(object):
         for run in runSet.runs:
             run.resultline = self.format_sourcefile_name(run.identifier, runSet)
 
-            adjusted_sourcefiles = [util.relative_path(s, xml_file_name) for s in run.sourcefiles]
-            if adjusted_sourcefiles:
+            if run.sourcefiles:
                 adjusted_identifier = util.relative_path(run.identifier, xml_file_name)
             else:
                 # If no source files exist the task doesn't point to any file that could be downloaded.
@@ -318,8 +317,11 @@ class OutputHandler(object):
                 adjusted_identifier = run.identifier
 
         # prepare XML structure for each run and runSet
-            run.xml = ET.Element("run",
-                                 {"name": adjusted_identifier, "files": "[" + ", ".join(adjusted_sourcefiles) + "]"})
+            run_attributes = {'name': adjusted_identifier}
+            if run.sourcefiles:
+                adjusted_sourcefiles = [util.relative_path(s, xml_file_name) for s in run.sourcefiles]
+                run_attributes['files'] = '[' + ', '.join(adjusted_sourcefiles) + ']'
+            run.xml = ET.Element("run", run_attributes)
             if run.specific_options:
                 run.xml.set("options", " ".join(run.specific_options))
             if run.properties:

--- a/benchexec/outputhandler.py
+++ b/benchexec/outputhandler.py
@@ -310,7 +310,13 @@ class OutputHandler(object):
             run.resultline = self.format_sourcefile_name(run.identifier, runSet)
 
             adjusted_sourcefiles = [util.relative_path(s, xml_file_name) for s in run.sourcefiles]
-            adjusted_identifier = util.relative_path(run.identifier, xml_file_name)
+            if adjusted_sourcefiles:
+                adjusted_identifier = util.relative_path(run.identifier, xml_file_name)
+            else:
+                # If no source files exist the task doesn't point to any file that could be downloaded.
+                # In this case, the name doesn't have to be adjusted because it's no path.
+                adjusted_identifier = run.identifier
+
         # prepare XML structure for each run and runSet
             run.xml = ET.Element("run",
                                  {"name": adjusted_identifier, "files": "[" + ", ".join(adjusted_sourcefiles) + "]"})

--- a/benchexec/outputhandler.py
+++ b/benchexec/outputhandler.py
@@ -283,13 +283,13 @@ class OutputHandler(object):
         about the runSet in XML.
         @param runSet: current run set
         """
-        sourcefiles = [run.identifier for run in runSet.runs]
+        identifier_names = [run.identifier for run in runSet.runs]
 
         # common prefix of file names
-        runSet.common_prefix = util.common_base_dir(sourcefiles) + os.path.sep
+        runSet.common_prefix = util.common_base_dir(identifier_names) + os.path.sep
 
         # length of the first column in terminal
-        runSet.max_length_of_filename = max(len(file) for file in sourcefiles) if sourcefiles else 20
+        runSet.max_length_of_filename = max(len(file) for file in identifier_names) if identifier_names else 20
         runSet.max_length_of_filename = max(20, runSet.max_length_of_filename - len(runSet.common_prefix))
 
         # write run set name to terminal

--- a/benchexec/tablegenerator/template.html
+++ b/benchexec/tablegenerator/template.html
@@ -234,7 +234,7 @@
 
 <tbody>
 {{for line in body}}
-<tr><td title="Click here to show source code"><a href="{{line.file_path|url}}">{{line.short_filename}}</a></td>
+<tr>{{if line.has_sourcefile}}<td title="Click here to show source code"><a href="{{line.file_path|url}}">{{line.short_filename}}</a>{{else}}<td title="This task has no associated file">{{line.short_filename}}{{endif}}</td>
   {{for id, show in zip(line.id[1:], relevant_id_columns[1:])}}
     {{if show}}
 <td>{{id}}</td>

--- a/benchexec/test_analyze_run_result.py
+++ b/benchexec/test_analyze_run_result.py
@@ -58,7 +58,7 @@ class TestResult(unittest.TestCase):
             return info_result
         runSet.benchmark.tool.determine_result = determine_result
 
-        return Run(sourcefiles=['test.c'], fileOptions=[], runSet=runSet)
+        return Run(identifier='test.c', sourcefiles=['test.c'], fileOptions=[], runSet=runSet)
 
     def test_simple(self):
         run = self.create_run(info_result=RESULT_UNKNOWN)

--- a/benchexec/test_benchexec_integration.py
+++ b/benchexec/test_benchexec_integration.py
@@ -35,7 +35,7 @@ sys.dont_write_bytecode = True # prevent creation of .pyc files
 here = os.path.dirname(__file__)
 base_dir = os.path.join(here, '..')
 bin_dir = os.path.join(base_dir, 'bin')
-tmp_dir = os.path.join(here, 'test_integration')
+benchmarks_dir = os.path.join(base_dir, 'doc')
 benchexec = os.path.join(bin_dir, 'benchexec')
 result_dtd = os.path.join(base_dir, 'doc', 'result.dtd')
 result_dtd_public_id = '+//IDN sosy-lab.org//DTD BenchExec result 1.9//EN'
@@ -52,8 +52,27 @@ class BenchExecIntegrationTests(unittest.TestCase):
         cls.longMessage = True
         cls.maxDiff = None
 
+    def _build_tmp_dir(self):
+        """
+        Initializes the temporary directory structure for testing.
+        Current structure:
+            $TMP_DIR$
+                |-- doc                                # contains benchmark definitions
+                |-- benchexec/test_integration/actual  # output directory for benchexec runs
+        """
+        tmp_dir = tempfile.mkdtemp(prefix="BenchExec.benchexec.integration_test")
+        relative_benchmark_dir = os.path.relpath(benchmarks_dir, base_dir)
+        tmp_benchmarks_dir = os.path.join(tmp_dir, relative_benchmark_dir)
+        shutil.copytree(benchmarks_dir, tmp_benchmarks_dir)
+        output_dir = os.path.join(tmp_dir, 'benchexec', 'test_integration', 'actual')
+        os.makedirs(output_dir)
+        self.tmp = tmp_dir
+        self.benchmarks_dir = tmp_benchmarks_dir
+        self.output_dir = output_dir
+        self.benchmark_test_file = os.path.join(self.tmp, os.path.relpath(benchmark_test_file, base_dir))
+
     def setUp(self):
-        self.tmp = tempfile.mkdtemp(prefix="BenchExec.benchexec.integration_test", dir=tmp_dir)
+        self._build_tmp_dir()
 
     def tearDown(self):
         shutil.rmtree(self.tmp)
@@ -71,15 +90,17 @@ class BenchExecIntegrationTests(unittest.TestCase):
                                                  tasks=benchmark_test_tasks,
                                                  rundefs=benchmark_test_rundefs,
                                                  test_name=benchmark_test_name,
-                                                 test_file=benchmark_test_file,
+                                                 test_file=None,
                                                  compress=False):
+        if not test_file:  # Assign default test file
+            test_file = self.benchmark_test_file
         self.run_cmd(*[benchexec, test_file,
-                       '--outputpath', self.tmp,
+                       '--outputpath', self.output_dir,
                        '--startTime', '2015-01-01 00:00',
                        ]
                        + ([] if compress else ['--no-compress-results'])
                        + list(args))
-        generated_files = set(os.listdir(self.tmp))
+        generated_files = set(os.listdir(self.output_dir))
 
         xml_suffix = '.xml.bz2' if compress else '.xml'
 
@@ -110,7 +131,7 @@ class BenchExecIntegrationTests(unittest.TestCase):
         # TODO find way to compare expected output to generated output
 
         if compress:
-            with zipfile.ZipFile(os.path.join(self.tmp, basename + "logfiles.zip")) as log_zip:
+            with zipfile.ZipFile(os.path.join(self.output_dir, basename + "logfiles.zip")) as log_zip:
                 self.assertIsNone(log_zip.testzip(), "Logfiles zip archive is broken")
                 for file in log_zip.namelist():
                     self.assertTrue(file.startswith(basename + "logfiles" + os.sep),
@@ -119,7 +140,7 @@ class BenchExecIntegrationTests(unittest.TestCase):
             for file in generated_files:
                 if file.endswith(".bz2"):
                     # try to decompress and read to see if there are any errors with it
-                    with bz2.BZ2File(os.path.join(self.tmp, file)) as bz2file:
+                    with bz2.BZ2File(os.path.join(self.output_dir, file)) as bz2file:
                         bz2file.read()
 
     def _assertEqualXmlTree(self, actual_tree, expected_tree):
@@ -232,14 +253,14 @@ class BenchExecIntegrationTests(unittest.TestCase):
             raise e
 
     def test_validate_result_xml(self):
-        self.run_cmd(benchexec, benchmark_test_file,
-                     '--outputpath', self.tmp,
+        self.run_cmd(benchexec, self.benchmark_test_file,
+                     '--outputpath', self.output_dir,
                      '--startTime', '2015-01-01 00:00',
                      '--no-compress-results',
                      )
         basename = 'benchmark-example-rand.2015-01-01_0000.'
         xml_files = ['results.xml'] + ['results.'+files+'.xml' for files in benchmark_test_tasks]
-        xml_files = map(lambda x : os.path.join(self.tmp, basename + x), xml_files)
+        xml_files = map(lambda x : os.path.join(self.output_dir, basename + x), xml_files)
 
         # setup parser with DTD validation
         from lxml import etree
@@ -256,12 +277,12 @@ class BenchExecIntegrationTests(unittest.TestCase):
 
     def test_run_results_information(self):
         expected_xml = os.path.join(here, 'test_integration/expected/benchmark-example-true.2015-01-01_0000.results.no options.xml')
-        benchmark_xml = os.path.join(base_dir, 'doc', 'benchmark-example-true.xml')
+        benchmark_xml = os.path.join(self.benchmarks_dir, 'benchmark-example-true.xml')
         self.run_cmd(benchexec, benchmark_xml,
-                     '--outputpath', self.tmp,
+                     '--outputpath', self.output_dir,
                      '--startTime', '2015-01-01 00:00',
                      '--no-compress-results',
                      '--rundefinition', 'no options')
-        actual_xml = os.path.join(self.tmp, 'benchmark-example-true.2015-01-01_0000.results.no options.xml')
+        actual_xml = os.path.join(self.output_dir, 'benchmark-example-true.2015-01-01_0000.results.no options.xml')
 
         self.assertSameRunResults(actual_xml, expected_xml)

--- a/benchexec/test_integration/__init__.py
+++ b/benchexec/test_integration/__init__.py
@@ -33,15 +33,15 @@ from xml.etree import ElementTree
 sys.dont_write_bytecode = True # prevent creation of .pyc files
 
 here = os.path.dirname(__file__)
-base_dir = os.path.join(here, '..')
+base_dir = os.path.join(here, '..', '..')
 bin_dir = os.path.join(base_dir, 'bin')
-benchmarks_dir = os.path.join(base_dir, 'doc')
+benchmarks_dir = here
 benchexec = os.path.join(bin_dir, 'benchexec')
 result_dtd = os.path.join(base_dir, 'doc', 'result.dtd')
 result_dtd_public_id = '+//IDN sosy-lab.org//DTD BenchExec result 1.9//EN'
 
 benchmark_test_name = 'benchmark-example-rand'
-benchmark_test_file = os.path.join(base_dir, 'doc', 'benchmark-example-rand.xml')
+benchmark_test_file = os.path.join(here, 'benchmark-example-rand.xml')
 benchmark_test_tasks = ['DTD files', 'Markdown files', 'XML files', 'Dummy tasks']
 benchmark_test_rundefs = None
 
@@ -57,13 +57,16 @@ class BenchExecIntegrationTests(unittest.TestCase):
         Initializes the temporary directory structure for testing.
         Current structure:
             $TMP_DIR$
-                |-- doc                                # contains benchmark definitions
-                |-- benchexec/test_integration/actual  # output directory for benchexec runs
+                |-- doc                                # contains some files used as pseudo-benchmark tasks
+                |-- benchexec/test_integration
+                     |-- actual                        # output directory for benchexec runs
+                     |-- *.xml                         # benchmark definitions used
         """
         tmp_dir = tempfile.mkdtemp(prefix="BenchExec.benchexec.integration_test")
         relative_benchmark_dir = os.path.relpath(benchmarks_dir, base_dir)
         tmp_benchmarks_dir = os.path.join(tmp_dir, relative_benchmark_dir)
         shutil.copytree(benchmarks_dir, tmp_benchmarks_dir)
+        shutil.copytree(os.path.join(base_dir, 'doc'), os.path.join(tmp_dir, 'doc'))
         output_dir = os.path.join(tmp_dir, 'benchexec', 'test_integration', 'actual')
         os.makedirs(output_dir)
         self.tmp = tmp_dir
@@ -170,7 +173,7 @@ class BenchExecIntegrationTests(unittest.TestCase):
 
 
     def test_same_results_file(self):
-        results_file = os.path.join(here, 'test_integration/expected/benchmark-example-true.2015-01-01_0000.results.no options.xml')
+        results_file = os.path.join(here, 'expected/benchmark-example-true.2015-01-01_0000.results.no options.xml')
         self.assertSameRunResults(results_file, results_file)
 
     def test_simple(self):
@@ -276,7 +279,7 @@ class BenchExecIntegrationTests(unittest.TestCase):
             etree.parse(xml_file, parser=parser)
 
     def test_run_results_information(self):
-        expected_xml = os.path.join(here, 'test_integration/expected/benchmark-example-true.2015-01-01_0000.results.no options.xml')
+        expected_xml = os.path.join(here, 'expected/benchmark-example-true.2015-01-01_0000.results.no options.xml')
         benchmark_xml = os.path.join(self.benchmarks_dir, 'benchmark-example-true.xml')
         self.run_cmd(benchexec, benchmark_xml,
                      '--outputpath', self.output_dir,

--- a/benchexec/test_integration/benchmark-example-rand.xml
+++ b/benchexec/test_integration/benchmark-example-rand.xml
@@ -1,0 +1,36 @@
+<?xml version="1.0"?>
+<!DOCTYPE benchmark PUBLIC "+//IDN sosy-lab.org//DTD BenchExec benchmark 1.9//EN" "https://www.sosy-lab.org/benchexec/benchmark-1.9.dtd">
+<!-- Example file for benchmark definition for BenchExec
+     with dummy tool that simply returns random answers.
+     No resource limits are specified. -->
+<benchmark tool="dummy">
+
+  <!-- For dummy tool, we specify options that define the tool output. -->
+  <option>true</option>
+  <option>false(unreach-call)</option>
+
+  <!-- <rundefinition> defines a tool configuration to benchmark -->
+  <rundefinition/>
+
+  <!-- <tasks> defines a set of tasks:
+       we define three sets of some arbitrary example files here. -->
+  <tasks name="DTD files">
+    <include>../../doc/*.dtd</include>
+  </tasks>
+
+  <tasks name="Markdown files">
+    <include>../../doc/*.md</include>
+  </tasks>
+
+  <tasks name="XML files">
+    <include>../../doc/*.xml</include>
+  </tasks>
+
+  <!-- <tasks> with <withoutfile> allows to define tasks without input files,
+       if the tool supports this. -->
+  <tasks name="Dummy tasks">
+    <withoutfile>dummy task 1</withoutfile>
+    <withoutfile>dummy task 2</withoutfile>
+    <withoutfile>dummy task 3</withoutfile>
+  </tasks>
+</benchmark>

--- a/benchexec/test_integration/benchmark-example-true.xml
+++ b/benchexec/test_integration/benchmark-example-true.xml
@@ -1,0 +1,45 @@
+<?xml version="1.0"?>
+<!DOCTYPE benchmark PUBLIC "+//IDN sosy-lab.org//DTD BenchExec benchmark 1.9//EN" "https://www.sosy-lab.org/benchexec/benchmark-1.9.dtd">
+<!-- Example file for benchmark definition for BenchExec
+     with dummy tool that simply returns TRUE.
+     No resource limits are specified. -->
+<benchmark tool="dummy">
+
+  <!-- For dummy tool, we specify an option that defines the tool output. -->
+  <option>true</option>
+
+  <!-- <rundefinition> defines a tool configuration to benchmark -->
+  <rundefinition name="no options"/>
+
+  <rundefinition name="some options">
+    <option name="--opt1">value1</option>
+    <option name="--opt2">value2</option>
+  </rundefinition>
+
+  <rundefinition name="other options">
+    <option name="--opt3"/>
+    <option name="--opt4"/>
+  </rundefinition>
+
+  <!-- <tasks> defines a set of tasks:
+       we define three sets of some arbitrary example files here. -->
+  <tasks name="DTD files">
+    <include>../../doc/*.dtd</include>
+  </tasks>
+
+  <tasks name="Markdown files">
+    <include>../../doc/*.md</include>
+  </tasks>
+
+  <tasks name="XML files">
+    <include>../../doc/*.xml</include>
+  </tasks>
+
+  <!-- <tasks> with <withoutfile> allows to define tasks without input files,
+       if the tool supports this. -->
+  <tasks name="Dummy tasks">
+    <withoutfile>dummy task 1</withoutfile>
+    <withoutfile>dummy task 2</withoutfile>
+    <withoutfile>dummy task 3</withoutfile>
+  </tasks>
+</benchmark>

--- a/benchexec/test_integration/expected/benchmark-example-true.2015-01-01_0000.results.no options.xml
+++ b/benchexec/test_integration/expected/benchmark-example-true.2015-01-01_0000.results.no options.xml
@@ -1,0 +1,323 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!DOCTYPE result
+  PUBLIC '+//IDN sosy-lab.org//DTD BenchExec result 1.9//EN'
+  'https://www.sosy-lab.org/benchexec/result-1.9.dtd'>
+<result benchmarkname="benchmark-example-true" date="2015-01-01 00:00:00 " generator="BenchExec 1.11-dev" name="no options" options="true" tool="DummyTool" toolmodule="benchexec.tools.dummy" version="">
+  <columns>
+    <column title="status"/>
+    <column title="cputime"/>
+    <column title="walltime"/>
+  </columns>
+  <systeminfo hostname="cortana-ubuntu-vm">
+    <os name="Linux-4.4.0-75-generic-x86_64-with-Ubuntu-16.04-xenial"/>
+    <cpu cores="2" frequency="2494000000" model="Intel Core i7-4870HQ CPU @ 2.50GHz"/>
+    <ram size="8172240896"/>
+    <environment>
+      <var name="CLUTTER_BACKEND">x11</var>
+      <var name="COLORTERM">mate-terminal</var>
+      <var name="COMPIZ_CONFIG_PROFILE">mate</var>
+      <var name="DBUS_SESSION_BUS_ADDRESS">unix:abstract=/tmp/dbus-7PFlAjDDhL,guid=3314dd936c9265ec2e10f78459103285</var>
+      <var name="DEFAULTS_PATH">/usr/share/gconf/mate.default.path</var>
+      <var name="DESKTOP_SESSION">mate</var>
+      <var name="DISPLAY">:0.0</var>
+      <var name="GDMSESSION">mate</var>
+      <var name="GDM_LANG">en_US</var>
+      <var name="GTK_MODULES">gail:atk-bridge:canberra-gtk-module:topmenu-gtk-module</var>
+      <var name="GTK_OVERLAY_SCROLLING">0</var>
+      <var name="LANG">en_US.UTF-8</var>
+      <var name="LANGUAGE">en_US</var>
+      <var name="LC_ADDRESS">de_DE.UTF-8</var>
+      <var name="LC_IDENTIFICATION">de_DE.UTF-8</var>
+      <var name="LC_MEASUREMENT">de_DE.UTF-8</var>
+      <var name="LC_MONETARY">de_DE.UTF-8</var>
+      <var name="LC_NAME">de_DE.UTF-8</var>
+      <var name="LC_NUMERIC">de_DE.UTF-8</var>
+      <var name="LC_PAPER">de_DE.UTF-8</var>
+      <var name="LC_TELEPHONE">de_DE.UTF-8</var>
+      <var name="LC_TIME">de_DE.UTF-8</var>
+      <var name="LESSCLOSE">/usr/bin/lesspipe %s %s</var>
+      <var name="LESSOPEN">| /usr/bin/lesspipe %s</var>
+      <var name="LOGNAME">leostrakosch</var>
+      <var name="LS_COLORS">rs=0:di=01;34:ln=01;36:mh=00:pi=40;33:so=01;35:do=01;35:bd=40;33;01:cd=40;33;01:or=40;31;01:mi=00:su=37;41:sg=30;43:ca=30;41:tw=30;42:ow=34;42:st=37;44:ex=01;32:*.tar=01;31:*.tgz=01;31:*.arc=01;31:*.arj=01;31:*.taz=01;31:*.lha=01;31:*.lz4=01;31:*.lzh=01;31:*.lzma=01;31:*.tlz=01;31:*.txz=01;31:*.tzo=01;31:*.t7z=01;31:*.zip=01;31:*.z=01;31:*.Z=01;31:*.dz=01;31:*.gz=01;31:*.lrz=01;31:*.lz=01;31:*.lzo=01;31:*.xz=01;31:*.bz2=01;31:*.bz=01;31:*.tbz=01;31:*.tbz2=01;31:*.tz=01;31:*.deb=01;31:*.rpm=01;31:*.jar=01;31:*.war=01;31:*.ear=01;31:*.sar=01;31:*.rar=01;31:*.alz=01;31:*.ace=01;31:*.zoo=01;31:*.cpio=01;31:*.7z=01;31:*.rz=01;31:*.cab=01;31:*.jpg=01;35:*.jpeg=01;35:*.gif=01;35:*.bmp=01;35:*.pbm=01;35:*.pgm=01;35:*.ppm=01;35:*.tga=01;35:*.xbm=01;35:*.xpm=01;35:*.tif=01;35:*.tiff=01;35:*.png=01;35:*.svg=01;35:*.svgz=01;35:*.mng=01;35:*.pcx=01;35:*.mov=01;35:*.mpg=01;35:*.mpeg=01;35:*.m2v=01;35:*.mkv=01;35:*.webm=01;35:*.ogm=01;35:*.mp4=01;35:*.m4v=01;35:*.mp4v=01;35:*.vob=01;35:*.qt=01;35:*.nuv=01;35:*.wmv=01;35:*.asf=01;35:*.rm=01;35:*.rmvb=01;35:*.flc=01;35:*.avi=01;35:*.fli=01;35:*.flv=01;35:*.gl=01;35:*.dl=01;35:*.xcf=01;35:*.xwd=01;35:*.yuv=01;35:*.cgm=01;35:*.emf=01;35:*.ogv=01;35:*.ogx=01;35:*.aac=00;36:*.au=00;36:*.flac=00;36:*.m4a=00;36:*.mid=00;36:*.midi=00;36:*.mka=00;36:*.mp3=00;36:*.mpc=00;36:*.ogg=00;36:*.ra=00;36:*.wav=00;36:*.oga=00;36:*.opus=00;36:*.spx=00;36:*.xspf=00;36:</var>
+      <var name="MANDATORY_PATH">/usr/share/gconf/mate.mandatory.path</var>
+      <var name="MATE_DESKTOP_SESSION_ID">this-is-deprecated</var>
+      <var name="PATH">/home/leostrakosch/bin:/home/leostrakosch/.local/bin:/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin:/usr/games:/usr/local/games:/snap/bin</var>
+      <var name="PS1">\[\e[38;5;26m\]@\h: \[\e[38;5;106m\]\u\[\e[38;5;239m\]:\[\e[38;5;106m\]\w\[\e[38;5;239m\]${text}$\[\e[m\] </var>
+      <var name="PWD">/home/leostrakosch/Documents/SV/benchexec-fork</var>
+      <var name="QT_ACCESSIBILITY">1</var>
+      <var name="QT_LINUX_ACCESSIBILITY_ALWAYS_ON">1</var>
+      <var name="QT_STYLE_OVERRIDE">gtk</var>
+      <var name="SESSION_MANAGER">local/cortana-ubuntu-vm:@/tmp/.ICE-unix/977,unix/cortana-ubuntu-vm:/tmp/.ICE-unix/977</var>
+      <var name="SHELL">/bin/bash</var>
+      <var name="SHLVL">1</var>
+      <var name="SSH_AGENT_PID">1196</var>
+      <var name="SSH_AUTH_SOCK">/run/user/1000/keyring/ssh</var>
+      <var name="TERM">xterm</var>
+      <var name="USER">leostrakosch</var>
+      <var name="WINDOWID">56700873</var>
+      <var name="XAUTHORITY">/home/leostrakosch/.Xauthority</var>
+      <var name="XDG_CONFIG_DIRS">/etc/xdg/xdg-mate:/etc/xdg</var>
+      <var name="XDG_CURRENT_DESKTOP">MATE</var>
+      <var name="XDG_DATA_DIRS">/usr/share/mate:/usr/share/mate:/usr/local/share/:/usr/share/:/var/lib/snapd/desktop</var>
+      <var name="XDG_GREETER_DATA_DIR">/var/lib/lightdm-data/leostrakosch</var>
+      <var name="XDG_RUNTIME_DIR">/run/user/1000</var>
+      <var name="XDG_SEAT">seat0</var>
+      <var name="XDG_SEAT_PATH">/org/freedesktop/DisplayManager/Seat0</var>
+      <var name="XDG_SESSION_DESKTOP">mate</var>
+      <var name="XDG_SESSION_ID">c1</var>
+      <var name="XDG_SESSION_PATH">/org/freedesktop/DisplayManager/Session0</var>
+      <var name="XDG_SESSION_TYPE">x11</var>
+      <var name="XDG_VTNR">7</var>
+      <var name="_">bin/benchexec</var>
+    </environment>
+  </systeminfo>
+  <run files="[../../../doc/benchmark.dtd]" name="../../../doc/benchmark.dtd">
+    <column title="status" value="true"/>
+    <column title="cputime" value="0.001260699s"/>
+    <column title="walltime" value="0.016400819004047662s"/>
+    <column hidden="true" title="category" value="missing"/>
+    <column hidden="true" title="exitcode" value="0"/>
+    <column hidden="true" title="returnvalue" value="0"/>
+    <column hidden="true" title="cputime-cpu1" value="0.001260699s"/>
+  </run>
+  <run files="[../../../doc/result.dtd]" name="../../../doc/result.dtd">
+    <column title="status" value="true"/>
+    <column title="cputime" value="0.001240142s"/>
+    <column title="walltime" value="0.016066495001723524s"/>
+    <column hidden="true" title="category" value="missing"/>
+    <column hidden="true" title="exitcode" value="0"/>
+    <column hidden="true" title="returnvalue" value="0"/>
+    <column hidden="true" title="cputime-cpu0" value="0.001033569s"/>
+    <column hidden="true" title="cputime-cpu1" value="0.000206573s"/>
+  </run>
+  <run files="[../../../doc/table.dtd]" name="../../../doc/table.dtd">
+    <column title="status" value="true"/>
+    <column title="cputime" value="0.00134092s"/>
+    <column title="walltime" value="0.012851725005020853s"/>
+    <column hidden="true" title="category" value="missing"/>
+    <column hidden="true" title="exitcode" value="0"/>
+    <column hidden="true" title="returnvalue" value="0"/>
+    <column hidden="true" title="cputime-cpu1" value="0.00134092s"/>
+  </run>
+  <run files="[../../../doc/DEVELOPMENT.md]" name="../../../doc/DEVELOPMENT.md">
+    <column title="status" value="true"/>
+    <column title="cputime" value="0.001674691s"/>
+    <column title="walltime" value="0.02337122099561384s"/>
+    <column hidden="true" title="category" value="missing"/>
+    <column hidden="true" title="exitcode" value="0"/>
+    <column hidden="true" title="returnvalue" value="0"/>
+    <column hidden="true" title="cputime-cpu0" value="0.001145824s"/>
+    <column hidden="true" title="cputime-cpu1" value="0.000528867s"/>
+  </run>
+  <run files="[../../../doc/INDEX.md]" name="../../../doc/INDEX.md">
+    <column title="status" value="true"/>
+    <column title="cputime" value="0.00154363s"/>
+    <column title="walltime" value="0.01897307499893941s"/>
+    <column hidden="true" title="category" value="missing"/>
+    <column hidden="true" title="exitcode" value="0"/>
+    <column hidden="true" title="returnvalue" value="0"/>
+    <column hidden="true" title="cputime-cpu0" value="0.000300951s"/>
+    <column hidden="true" title="cputime-cpu1" value="0.001242679s"/>
+  </run>
+  <run files="[../../../doc/INSTALL.md]" name="../../../doc/INSTALL.md">
+    <column title="status" value="true"/>
+    <column title="cputime" value="0.002223072s"/>
+    <column title="walltime" value="0.02362731599714607s"/>
+    <column hidden="true" title="category" value="missing"/>
+    <column hidden="true" title="exitcode" value="0"/>
+    <column hidden="true" title="returnvalue" value="0"/>
+    <column hidden="true" title="cputime-cpu0" value="0.000453064s"/>
+    <column hidden="true" title="cputime-cpu1" value="0.001770008s"/>
+  </run>
+  <run files="[../../../doc/benchexec.md]" name="../../../doc/benchexec.md">
+    <column title="status" value="true"/>
+    <column title="cputime" value="0.001475503s"/>
+    <column title="walltime" value="0.013747818004048895s"/>
+    <column hidden="true" title="category" value="missing"/>
+    <column hidden="true" title="exitcode" value="0"/>
+    <column hidden="true" title="returnvalue" value="0"/>
+    <column hidden="true" title="cputime-cpu0" value="0.000251865s"/>
+    <column hidden="true" title="cputime-cpu1" value="0.001223638s"/>
+  </run>
+  <run files="[../../../doc/benchmarking.md]" name="../../../doc/benchmarking.md">
+    <column title="status" value="true"/>
+    <column title="cputime" value="0.001427537s"/>
+    <column title="walltime" value="0.013341778998437803s"/>
+    <column hidden="true" title="category" value="missing"/>
+    <column hidden="true" title="exitcode" value="0"/>
+    <column hidden="true" title="returnvalue" value="0"/>
+    <column hidden="true" title="cputime-cpu0" value="0.000250596s"/>
+    <column hidden="true" title="cputime-cpu1" value="0.001176941s"/>
+  </run>
+  <run files="[../../../doc/container.md]" name="../../../doc/container.md">
+    <column title="status" value="true"/>
+    <column title="cputime" value="0.001358947s"/>
+    <column title="walltime" value="0.017253097998036537s"/>
+    <column hidden="true" title="category" value="missing"/>
+    <column hidden="true" title="exitcode" value="0"/>
+    <column hidden="true" title="returnvalue" value="0"/>
+    <column hidden="true" title="cputime-cpu0" value="0.000274527s"/>
+    <column hidden="true" title="cputime-cpu1" value="0.00108442s"/>
+  </run>
+  <run files="[../../../doc/resources.md]" name="../../../doc/resources.md">
+    <column title="status" value="true"/>
+    <column title="cputime" value="0.001409421s"/>
+    <column title="walltime" value="0.01802882099582348s"/>
+    <column hidden="true" title="category" value="missing"/>
+    <column hidden="true" title="exitcode" value="0"/>
+    <column hidden="true" title="returnvalue" value="0"/>
+    <column hidden="true" title="cputime-cpu0" value="0.00023835s"/>
+    <column hidden="true" title="cputime-cpu1" value="0.001171071s"/>
+  </run>
+  <run files="[../../../doc/run-results.md]" name="../../../doc/run-results.md">
+    <column title="status" value="true"/>
+    <column title="cputime" value="0.001348846s"/>
+    <column title="walltime" value="0.011520747000759002s"/>
+    <column hidden="true" title="category" value="missing"/>
+    <column hidden="true" title="exitcode" value="0"/>
+    <column hidden="true" title="returnvalue" value="0"/>
+    <column hidden="true" title="cputime-cpu0" value="0.000264745s"/>
+    <column hidden="true" title="cputime-cpu1" value="0.001084101s"/>
+  </run>
+  <run files="[../../../doc/runexec.md]" name="../../../doc/runexec.md">
+    <column title="status" value="true"/>
+    <column title="cputime" value="0.001532083s"/>
+    <column title="walltime" value="0.019191640996723436s"/>
+    <column hidden="true" title="category" value="missing"/>
+    <column hidden="true" title="exitcode" value="0"/>
+    <column hidden="true" title="returnvalue" value="0"/>
+    <column hidden="true" title="cputime-cpu0" value="0.000272383s"/>
+    <column hidden="true" title="cputime-cpu1" value="0.0012597s"/>
+  </run>
+  <run files="[../../../doc/separate-user.md]" name="../../../doc/separate-user.md">
+    <column title="status" value="true"/>
+    <column title="cputime" value="0.001868046s"/>
+    <column title="walltime" value="0.024449299002299085s"/>
+    <column hidden="true" title="category" value="missing"/>
+    <column hidden="true" title="exitcode" value="0"/>
+    <column hidden="true" title="returnvalue" value="0"/>
+    <column hidden="true" title="cputime-cpu0" value="0.000317561s"/>
+    <column hidden="true" title="cputime-cpu1" value="0.001550485s"/>
+  </run>
+  <run files="[../../../doc/table-generator.md]" name="../../../doc/table-generator.md">
+    <column title="status" value="true"/>
+    <column title="cputime" value="0.00148108s"/>
+    <column title="walltime" value="0.013145516000804491s"/>
+    <column hidden="true" title="category" value="missing"/>
+    <column hidden="true" title="exitcode" value="0"/>
+    <column hidden="true" title="returnvalue" value="0"/>
+    <column hidden="true" title="cputime-cpu0" value="0.001228005s"/>
+    <column hidden="true" title="cputime-cpu1" value="0.000253075s"/>
+  </run>
+  <run files="[../../../doc/tool-integration.md]" name="../../../doc/tool-integration.md">
+    <column title="status" value="true"/>
+    <column title="cputime" value="0.001560931s"/>
+    <column title="walltime" value="0.013174797997635324s"/>
+    <column hidden="true" title="category" value="missing"/>
+    <column hidden="true" title="exitcode" value="0"/>
+    <column hidden="true" title="returnvalue" value="0"/>
+    <column hidden="true" title="cputime-cpu0" value="0.001231552s"/>
+    <column hidden="true" title="cputime-cpu1" value="0.000329379s"/>
+  </run>
+  <run files="[../../../doc/benchmark-example-calculatepi.xml]" name="../../../doc/benchmark-example-calculatepi.xml">
+    <column title="status" value="true"/>
+    <column title="cputime" value="0.001621305s"/>
+    <column title="walltime" value="0.015723706004791893s"/>
+    <column hidden="true" title="category" value="missing"/>
+    <column hidden="true" title="exitcode" value="0"/>
+    <column hidden="true" title="returnvalue" value="0"/>
+    <column hidden="true" title="cputime-cpu0" value="0.001621305s"/>
+  </run>
+  <run files="[../../../doc/benchmark-example-cbmc.xml]" name="../../../doc/benchmark-example-cbmc.xml">
+    <column title="status" value="true"/>
+    <column title="cputime" value="0.001558586s"/>
+    <column title="walltime" value="0.020105710995267145s"/>
+    <column hidden="true" title="category" value="missing"/>
+    <column hidden="true" title="exitcode" value="0"/>
+    <column hidden="true" title="returnvalue" value="0"/>
+    <column hidden="true" title="cputime-cpu0" value="0.001287119s"/>
+    <column hidden="true" title="cputime-cpu1" value="0.000271467s"/>
+  </run>
+  <run files="[../../../doc/benchmark-example-rand.xml]" name="../../../doc/benchmark-example-rand.xml">
+    <column title="status" value="true"/>
+    <column title="cputime" value="0.001525362s"/>
+    <column title="walltime" value="0.01601748199755093s"/>
+    <column hidden="true" title="category" value="missing"/>
+    <column hidden="true" title="exitcode" value="0"/>
+    <column hidden="true" title="returnvalue" value="0"/>
+    <column hidden="true" title="cputime-cpu0" value="0.001236029s"/>
+    <column hidden="true" title="cputime-cpu1" value="0.000289333s"/>
+  </run>
+  <run files="[../../../doc/benchmark-example-true.xml]" name="../../../doc/benchmark-example-true.xml">
+    <column title="status" value="true"/>
+    <column title="cputime" value="0.001461364s"/>
+    <column title="walltime" value="0.020981645997380838s"/>
+    <column hidden="true" title="category" value="missing"/>
+    <column hidden="true" title="exitcode" value="0"/>
+    <column hidden="true" title="returnvalue" value="0"/>
+    <column hidden="true" title="cputime-cpu0" value="0.001174937s"/>
+    <column hidden="true" title="cputime-cpu1" value="0.000286427s"/>
+  </run>
+  <run files="[../../../doc/benchmark.xml]" name="../../../doc/benchmark.xml">
+    <column title="status" value="true"/>
+    <column title="cputime" value="0.001430293s"/>
+    <column title="walltime" value="0.01755224200314842s"/>
+    <column hidden="true" title="category" value="missing"/>
+    <column hidden="true" title="exitcode" value="0"/>
+    <column hidden="true" title="returnvalue" value="0"/>
+    <column hidden="true" title="cputime-cpu0" value="0.001151359s"/>
+    <column hidden="true" title="cputime-cpu1" value="0.000278934s"/>
+  </run>
+  <run files="[../../../doc/table-generator-example.xml]" name="../../../doc/table-generator-example.xml">
+    <column title="status" value="true"/>
+    <column title="cputime" value="0.001738972s"/>
+    <column title="walltime" value="0.020196247998683248s"/>
+    <column hidden="true" title="category" value="missing"/>
+    <column hidden="true" title="exitcode" value="0"/>
+    <column hidden="true" title="returnvalue" value="0"/>
+    <column hidden="true" title="cputime-cpu0" value="0.001449767s"/>
+    <column hidden="true" title="cputime-cpu1" value="0.000289205s"/>
+  </run>
+  <run files="[../../../doc/table-generator.xml]" name="../../../doc/table-generator.xml">
+    <column title="status" value="true"/>
+    <column title="cputime" value="0.001582704s"/>
+    <column title="walltime" value="0.013517523002519738s"/>
+    <column hidden="true" title="category" value="missing"/>
+    <column hidden="true" title="exitcode" value="0"/>
+    <column hidden="true" title="returnvalue" value="0"/>
+    <column hidden="true" title="cputime-cpu0" value="0.001327093s"/>
+    <column hidden="true" title="cputime-cpu1" value="0.000255611s"/>
+  </run>
+  <run files="[]" name="dummy task 1">
+    <column title="status" value="true"/>
+    <column title="cputime" value="0.00140483s"/>
+    <column title="walltime" value="0.015512489000684582s"/>
+    <column hidden="true" title="category" value="missing"/>
+    <column hidden="true" title="exitcode" value="0"/>
+    <column hidden="true" title="returnvalue" value="0"/>
+    <column hidden="true" title="cputime-cpu0" value="0.001133126s"/>
+    <column hidden="true" title="cputime-cpu1" value="0.000271704s"/>
+  </run>
+  <run files="[]" name="dummy task 2">
+    <column title="status" value="true"/>
+    <column title="cputime" value="0.001430999s"/>
+    <column title="walltime" value="0.014083044996368699s"/>
+    <column hidden="true" title="category" value="missing"/>
+    <column hidden="true" title="exitcode" value="0"/>
+    <column hidden="true" title="returnvalue" value="0"/>
+    <column hidden="true" title="cputime-cpu0" value="0.0011589s"/>
+    <column hidden="true" title="cputime-cpu1" value="0.000272099s"/>
+  </run>
+  <run files="[]" name="dummy task 3">
+    <column title="status" value="true"/>
+    <column title="cputime" value="0.001451007s"/>
+    <column title="walltime" value="0.011977390000538435s"/>
+    <column hidden="true" title="category" value="missing"/>
+    <column hidden="true" title="exitcode" value="0"/>
+    <column hidden="true" title="returnvalue" value="0"/>
+    <column hidden="true" title="cputime-cpu0" value="0.001198229s"/>
+    <column hidden="true" title="cputime-cpu1" value="0.000252778s"/>
+  </run>
+  <column title="cputime" value="0.004s"/>
+  <column title="walltime" value="3.3272243259998504s"/>
+</result>

--- a/benchexec/test_integration/expected/benchmark-example-true.2015-01-01_0000.results.no options.xml
+++ b/benchexec/test_integration/expected/benchmark-example-true.2015-01-01_0000.results.no options.xml
@@ -288,7 +288,7 @@
     <column hidden="true" title="cputime-cpu0" value="0.001327093s"/>
     <column hidden="true" title="cputime-cpu1" value="0.000255611s"/>
   </run>
-  <run files="[]" name="dummy task 1">
+  <run name="dummy task 1">
     <column title="status" value="true"/>
     <column title="cputime" value="0.00140483s"/>
     <column title="walltime" value="0.015512489000684582s"/>
@@ -298,7 +298,7 @@
     <column hidden="true" title="cputime-cpu0" value="0.001133126s"/>
     <column hidden="true" title="cputime-cpu1" value="0.000271704s"/>
   </run>
-  <run files="[]" name="dummy task 2">
+  <run name="dummy task 2">
     <column title="status" value="true"/>
     <column title="cputime" value="0.001430999s"/>
     <column title="walltime" value="0.014083044996368699s"/>
@@ -308,7 +308,7 @@
     <column hidden="true" title="cputime-cpu0" value="0.0011589s"/>
     <column hidden="true" title="cputime-cpu1" value="0.000272099s"/>
   </run>
-  <run files="[]" name="dummy task 3">
+  <run name="dummy task 3">
     <column title="status" value="true"/>
     <column title="cputime" value="0.001451007s"/>
     <column title="walltime" value="0.011977390000538435s"/>

--- a/benchexec/util.py
+++ b/benchexec/util.py
@@ -304,6 +304,11 @@ def common_base_dir(l):
     # os.path.commonprefix returns the common prefix, not the common directory
     return os.path.dirname(os.path.commonprefix(l))
 
+
+def relative_path(destination, start):
+    return os.path.relpath(destination, os.path.dirname(start))
+
+
 def log_rmtree_error(func, arg, exc_info):
     """Suited as onerror handler for (sh)util.rmtree() that logs a warning."""
     logging.warning("Failure during '%s(%s)': %s", func.__name__, arg, exc_info[1])


### PR DESCRIPTION
According to #220 , path references in result xmls are fixed.
This influences the <run> tags in created xml files.

1. Files of run tasks are correctly referenced in the result xml.
2. Run tasks that are specified `<withoutfile>` do not point to any file anymore.
Previously, the text inside the `<withoutfile>` tag, e.g. for `<withoutfile>dummy</withoutfile>` the text `dummy`, was used as a source file in the task list and result xml. Now no sourcefile is referenced.
3. A small integration test to check this is added, which checks the column names of the run result, the run information inside the `<run>` tags and the values of columns `status`, `category`, `exitcode` and `returnvalue` against the expected results.
\
I'm open for proposals to perform this test in a more elegant way.
