### PR TITLE
Update tool-info for Ultimate

### DIFF
--- a/benchexec/tools/ultimate.py
+++ b/benchexec/tools/ultimate.py
@@ -19,6 +19,7 @@ limitations under the License.
 """
 
 import functools
+import logging
 import os
 import re
 import subprocess
@@ -112,7 +113,7 @@ class UltimateTool(benchexec.tools.template.BaseTool):
 
             cmdline += [option for option in options if option not in _SVCOMP17_FORBIDDEN_FLAGS]
 
-            cmdlinea.append("--full-output")
+            cmdline.append("--full-output")
 
             cmdline += tasks
             return cmdline

--- a/benchexec/tools/ultimateautomizer.py
+++ b/benchexec/tools/ultimateautomizer.py
@@ -22,7 +22,7 @@ from . import ultimate
 
 class Tool(ultimate.UltimateTool):
 
-    REQUIRED_PATHS = [
+    REQUIRED_PATHS_SVCOMP17 = [
                   "artifacts.xml",
                   "AutomizerTermination.xml",
                   "AutomizerWitnessValidation.xml",
@@ -47,7 +47,7 @@ class Tool(ultimate.UltimateTool):
                   "svcomp-Reach-32bit-Automizer_Default.epf",
                   "svcomp-Reach-64bit-Automizer_Bitvector.epf",
                   "svcomp-Reach-64bit-Automizer_Default.epf",
-                  "svcomp-Termination-32bit-Automizer_Default.epf",                  
+                  "svcomp-Termination-32bit-Automizer_Default.epf",
                   "svcomp-Termination-64bit-Automizer_Default.epf",
                   "Ultimate",
                   "Ultimate.ini",

--- a/benchexec/tools/ultimatekojak.py
+++ b/benchexec/tools/ultimatekojak.py
@@ -22,7 +22,7 @@ from . import ultimate
 
 class Tool(ultimate.UltimateTool):
 
-    REQUIRED_PATHS = [
+    REQUIRED_PATHS_SVCOMP17 = [
                   "artifacts.xml",
                   "configuration",
                   "cvc4",

--- a/benchexec/tools/ultimatetaipan.py
+++ b/benchexec/tools/ultimatetaipan.py
@@ -22,7 +22,7 @@ from . import ultimate
 
 class Tool(ultimate.UltimateTool):
 
-    REQUIRED_PATHS = [
+    REQUIRED_PATHS_SVCOMP17 = [
                   "artifacts.xml",
                   "configuration",
                   "cvc4",


### PR DESCRIPTION
The current version of Ultimate needs a different command-line syntax.

We continue supporting the SV-COMP'17 version of Ultimate for backwards compatibility, but other old versions are not supported anymore (but could be by whitelisting their version numbers).

This replaces #241.