### PR TITLE
Fix #246: Don't use relative path for standard output

### DIFF
--- a/benchexec/outputhandler.py
+++ b/benchexec/outputhandler.py
@@ -287,7 +287,9 @@ class OutputHandler(object):
         identifier_names = [run.identifier for run in runSet.runs]
 
         # common prefix of file names
-        runSet.common_prefix = util.common_base_dir(identifier_names) + os.path.sep
+        runSet.common_prefix = util.common_base_dir(identifier_names)
+        if runSet.common_prefix:
+            runSet.common_prefix += os.path.sep
 
         # length of the first column in terminal
         runSet.max_length_of_filename = max(len(file) for file in identifier_names) if identifier_names else 20

--- a/benchexec/outputhandler.py
+++ b/benchexec/outputhandler.py
@@ -284,7 +284,7 @@ class OutputHandler(object):
         """
         xml_file_name = self.get_filename(runSet.name, "xml")
 
-        identifier_names = [util.relative_path(run.identifier, xml_file_name) for run in runSet.runs]
+        identifier_names = [run.identifier for run in runSet.runs]
 
         # common prefix of file names
         runSet.common_prefix = util.common_base_dir(identifier_names) + os.path.sep


### PR DESCRIPTION
Full task name (- common prefix) is used in standard output.
This fixes #246 since column sizes are correct again.
In addition, don't use any common prefix if none exists. Previously, '/' was always added as common prefix, even if it initially was empty.