### PR TITLE
Implement a CLI option to set particular CPU cores for BenchExec

### DIFF
--- a/benchexec/benchexec.py
+++ b/benchexec/benchexec.py
@@ -152,6 +152,13 @@ class BenchExec(object):
                           metavar="N",
                           help="Limit each run of the tool to N CPU cores (-1 to disable).")
 
+        parser.add_argument("-s", "--allowedCores", dest="coreset",
+                            default=None,
+                            metavar="n",
+                            nargs='+',
+                            type=int,
+                            help="Limit each run of the tool to a subset of particular CPU cores.")
+
         parser.add_argument("--user",
                             dest="users",
                             action="append",

--- a/benchexec/benchexec.py
+++ b/benchexec/benchexec.py
@@ -152,12 +152,11 @@ class BenchExec(object):
                           metavar="N",
                           help="Limit each run of the tool to N CPU cores (-1 to disable).")
 
-        parser.add_argument("-s", "--allowedCores", dest="coreset",
-                            default=None,
-                            metavar="n",
-                            nargs='+',
-                            type=int,
-                            help="Limit each run of the tool to a subset of particular CPU cores.")
+        parser.add_argument("--allowedCores",
+                          dest="coreset", default=None, type=util.parse_int_list,
+                          help="Limit the set of cores BenchExec will use for all runs "
+                               "(Applied only if the number of CPU cores is limited).",
+                          metavar="N,M-K",)
 
         parser.add_argument("--user",
                             dest="users",

--- a/benchexec/localexecution.py
+++ b/benchexec/localexecution.py
@@ -103,6 +103,8 @@ def execute_benchmark(benchmark, output_handler):
         coreAssignment = get_cpu_cores_per_run(benchmark.rlimits[CORELIMIT], benchmark.num_of_threads, my_cgroups, benchmark.config.coreset)
         memoryAssignment = get_memory_banks_per_run(coreAssignment, my_cgroups)
         cpu_packages = set(get_cpu_package_for_core(core) for cores_of_run in coreAssignment for core in cores_of_run)
+    elif benchmark.config.coreset:
+        sys.exit('Please limit the number of cores first if you also want to limit the set of available cores.')
 
     if MEMLIMIT in benchmark.rlimits:
         # check whether we have enough memory in the used memory banks for all runs

--- a/benchexec/localexecution.py
+++ b/benchexec/localexecution.py
@@ -100,7 +100,7 @@ def execute_benchmark(benchmark, output_handler):
     if CORELIMIT in benchmark.rlimits:
         if not my_cgroups.require_subsystem(cgroups.CPUSET):
             sys.exit("Cgroup subsystem cpuset is required for limiting the number of CPU cores/memory nodes.")
-        coreAssignment = get_cpu_cores_per_run(benchmark.rlimits[CORELIMIT], benchmark.num_of_threads, my_cgroups)
+        coreAssignment = get_cpu_cores_per_run(benchmark.rlimits[CORELIMIT], benchmark.num_of_threads, my_cgroups, benchmark.config.coreset)
         memoryAssignment = get_memory_banks_per_run(coreAssignment, my_cgroups)
         cpu_packages = set(get_cpu_package_for_core(core) for cores_of_run in coreAssignment for core in cores_of_run)
 

--- a/benchexec/resources.py
+++ b/benchexec/resources.py
@@ -68,7 +68,7 @@ def get_cpu_cores_per_run(coreLimit, num_of_threads, my_cgroups, coreSet=None):
 
     @param coreLimit: the number of cores for each run
     @param num_of_threads: the number of parallel benchmark executions
-    @param coreSet: the list of CPU cores identifiers provided by a user
+    @param coreSet: the list of CPU cores identifiers provided by a user, None makes benchexec using all cores
     @return a list of lists, where each inner list contains the cores for one run
     """
     try:
@@ -77,7 +77,7 @@ def get_cpu_cores_per_run(coreLimit, num_of_threads, my_cgroups, coreSet=None):
 
         # Filter CPU cores according to the list of identifiers provided by a user
         if coreSet:
-            invalid_cores = list(map(str, sorted(set(coreSet).difference(set(allCpus)))))
+            invalid_cores = sorted(set(coreSet).difference(set(allCpus)))
             if len(invalid_cores) > 0:
                 raise ValueError("The following provided CPU cores are not available: {}".format(', '.join(map(str, invalid_cores))))
             allCpus = [core for core in allCpus if core in coreSet]

--- a/benchexec/resources.py
+++ b/benchexec/resources.py
@@ -40,7 +40,7 @@ __all__ = [
            'get_cpu_package_for_core',
            ]
 
-def get_cpu_cores_per_run(coreLimit, num_of_threads, my_cgroups):
+def get_cpu_cores_per_run(coreLimit, num_of_threads, my_cgroups, coreSet=None):
     """
     Calculate an assignment of the available CPU cores to a number
     of parallel benchmark executions such that each run gets its own cores
@@ -68,11 +68,20 @@ def get_cpu_cores_per_run(coreLimit, num_of_threads, my_cgroups):
 
     @param coreLimit: the number of cores for each run
     @param num_of_threads: the number of parallel benchmark executions
+    @param coreSet: the list of CPU cores identifiers provided by a user
     @return a list of lists, where each inner list contains the cores for one run
     """
     try:
         # read list of available CPU cores
         allCpus = util.parse_int_list(my_cgroups.get_value(cgroups.CPUSET, 'cpus'))
+
+        # Filter CPU cores according to the list of identifiers provided by a user
+        if coreSet:
+            invalid_cores = list(map(str, sorted(set(coreSet).difference(set(allCpus)))))
+            if len(invalid_cores) > 0:
+                raise ValueError("The following provided CPU cores are not available: {}".format(', '.join(map(str, invalid_cores))))
+            allCpus = [core for core in allCpus if core in coreSet]
+
         logging.debug("List of available CPU cores is %s.", allCpus)
 
         # read mapping of core to CPU ("physical package")


### PR DESCRIPTION
This adds an option to provide the set of particular CPU cores identifiers to BenchExec. The option implements separating available CPU cores for independent BenchExec instances to avoid usage of the same CPUs.  