### PR TITLE
Allow statistics-tex.py to handle missing results

### DIFF
--- a/contrib/statistics-tex.py
+++ b/contrib/statistics-tex.py
@@ -147,7 +147,8 @@ def main(args=None):
 
     for (category, counts) in sorted(category_stats.items()):
         print(counts.to_latex(basenames + [category]))
-        for (status, counts2) in sorted(status_stats[category].items()):
+        categories = [(s, c) for (s, c) in status_stats[category].items() if s]
+        for (status, counts2) in sorted(categories):
             print(counts2.to_latex(basenames + [category, status]))
             if category == "correct" and status_stats["wrong"].get(status) is None:
                 print(StatAccumulator().to_latex(basenames + ["wrong", status]))


### PR DESCRIPTION
Fixes a bug that made produced latex code uncompilable if run results
were missing.
If this was the case, the latex commands for missing results were defined twice, and thus,
the produced latex code was uncompilable.

This error can be reproduced by starting any benchmark, aborting it before it is finished, and running `contrib/statistics-tex.py` on it.