### PR TITLE
statistics-tex supports multiple input files

### DIFF
--- a/contrib/statistics-tex.py
+++ b/contrib/statistics-tex.py
@@ -158,7 +158,7 @@ def main(args=None):
     # load results
     stats = list()
     for result in options.result:
-        stats.append(load_results(result, stats))
+        stats.append(load_results(result, options.status))
 
     print(HEADER)
     for curr_stats in stats:


### PR DESCRIPTION
This change allows the user to hand `contrib/statistics-tex.py` multiple result files at once for processing, which allows easier handling of multiple runs at once and which is common practice on the command line.