### PR TITLE
Optional separate file for stderr of run and optional header information in output files

### DIFF
--- a/benchexec/runexecutor.py
+++ b/benchexec/runexecutor.py
@@ -695,21 +695,20 @@ class RunExecutor(containerexecutor.ContainerExecutor):
 
     # --- run execution ---
 
-    def execute_run(self, args, output_filename, error_filename=None, stdin=None, write_header=True,
+    def execute_run(self, args, output_filename, stdin=None,
                     hardtimelimit=None, softtimelimit=None, walltimelimit=None,
                    cores=None, memlimit=None, memory_nodes=None,
                    environments={}, workingDir=None, maxLogfileSize=None,
                    cgroupValues={},
                    files_count_limit=None, files_size_limit=None,
+                   error_filename=None, write_header=True,
                    **kwargs):
         """
         This function executes a given command with resource limits,
         and writes the output to a file.
         @param args: the command line to run
         @param output_filename: the file where the output should be written to
-        @param error_filename: the file where the error output should be written to (default: same as output_filename)
         @param stdin: What to uses as stdin for the process (None: /dev/null, a file descriptor, or a file object)
-        @param stdin: Write informational headers to the output and the error file
         @param hardtimelimit: None or the CPU time in seconds after which the tool is forcefully killed.
         @param softtimelimit: None or the CPU time in seconds after which the tool is sent a kill signal.
         @param walltimelimit: None or the wall time in seconds after which the tool is forcefully killed (default: hardtimelimit + a few seconds)
@@ -722,6 +721,8 @@ class RunExecutor(containerexecutor.ContainerExecutor):
         @param cgroupValues: dict of additional cgroup values to set (key is tuple of subsystem and option, respective subsystem needs to be enabled in RunExecutor; cannot be used to override values set by BenchExec)
         @param files_count_limit: None or maximum number of files that may be written.
         @param files_size_limit: None or maximum size of files that may be written.
+        @param error_filename: the file where the error output should be written to (default: same as output_filename)
+        @param write_headers: Write informational headers to the output and the error file if separate (default: True)
         @param **kwargs: further arguments for ContainerExecutor.execute_run()
         @return: dict with result of run (measurement results and process exitcode)
         """
@@ -956,6 +957,9 @@ class RunExecutor(containerexecutor.ContainerExecutor):
         if swap_check.has_swapped():
             logging.warning('System has swapped during benchmarking. '
                             'Benchmark results are unreliable!')
+
+        if error_filename is not None:
+            _reduce_file_size_if_necessary(error_filename, max_output_size)
 
         _reduce_file_size_if_necessary(output_filename, max_output_size)
 

--- a/benchexec/runexecutor.py
+++ b/benchexec/runexecutor.py
@@ -608,7 +608,7 @@ class RunExecutor(containerexecutor.ContainerExecutor):
         return run_environment
 
 
-    def _setup_output_file(self, output_filename, args, write_header = True):
+    def _setup_output_file(self, output_filename, args, write_header=True):
         """Open and prepare output file."""
         # write command line into outputFile
         # (without environment variables, they are documented by benchexec)
@@ -695,7 +695,7 @@ class RunExecutor(containerexecutor.ContainerExecutor):
 
     # --- run execution ---
 
-    def execute_run(self, args, output_filename, error_filename=None, stdin=None, write_header = True,
+    def execute_run(self, args, output_filename, error_filename=None, stdin=None, write_header=True,
                     hardtimelimit=None, softtimelimit=None, walltimelimit=None,
                    cores=None, memlimit=None, memory_nodes=None,
                    environments={}, workingDir=None, maxLogfileSize=None,
@@ -872,7 +872,7 @@ class RunExecutor(containerexecutor.ContainerExecutor):
         run_environment = self._setup_environment(environments)
         outputFile = self._setup_output_file(output_filename, args, write_header=write_header)
         if error_filename is None:
-            errorFile = output_filename
+            errorFile = outputFile
         else:
             errorFile = self._setup_output_file(error_filename, args, write_header=write_header)
 

--- a/benchexec/test_runexecutor.py
+++ b/benchexec/test_runexecutor.py
@@ -131,6 +131,44 @@ class TestRunExecutor(unittest.TestCase):
         for line in output[1:-1]:
             self.assertRegex(line, '^-*$', 'unexpected text in run output')
 
+    def test_command_error_output(self):
+        if not os.path.exists('/bin/echo'):
+            self.skipTest('missing /bin/echo')
+        if not os.path.exists('/bin/sh'):
+            self.skipTest('missing /bin/sh')
+
+        def execute_Run_intern(cmd):
+            (output_fd, output_filename) = tempfile.mkstemp('.log', 'output_', text=True)
+            (error_fd, error_filename) = tempfile.mkstemp('.log', 'error_', text=True)
+            try:
+                self.runexecutor.execute_run(cmd,
+                                             output_filename=output_filename,
+                                             error_filename=error_filename)
+                output_lines = os.read(output_fd, 4096).decode().splitlines()
+                error_lines = os.read(error_fd, 4096).decode().splitlines()
+                return (output_lines, error_lines)
+            finally:
+                os.close(output_fd)
+                os.remove(output_filename)
+                os.close(error_fd)
+                os.remove(error_filename)
+
+        (output_lines, error_lines) = execute_Run_intern(['/bin/sh', '-c', '""/bin/echo ERROR_TOKEN >&2""'])
+        self.assertEqual(error_lines[-1], 'ERROR_TOKEN', 'run error output misses command output')
+        for line in output_lines[1:]:
+            self.assertRegex(line, '^-*$', 'unexpected text in run output')
+        for line in error_lines[1:-1]:
+            self.assertRegex(line, '^-*$', 'unexpected text in run error output')
+
+        (output_lines, error_lines) = execute_Run_intern(['/bin/echo', 'OUT_TOKEN'])
+        self.check_command_in_output(output_lines, '/bin/echo OUT_TOKEN')
+        self.check_command_in_output(error_lines, '/bin/echo OUT_TOKEN')
+        self.assertEqual(output_lines[-1], 'OUT_TOKEN', 'run output misses command output')
+        for line in output_lines[1:-1]:
+            self.assertRegex(line, '^-*$', 'unexpected text in run output')
+        for line in error_lines[1:]:
+            self.assertRegex(line, '^-*$', 'unexpected text in run error output')
+
     def test_command_result(self):
         if not os.path.exists('/bin/echo'):
             self.skipTest('missing /bin/echo')


### PR DESCRIPTION
As previously discussed in #103, we would like to have stderr written to a different file than stdout. Further, we want the possibility to remove the header runexec is writing in the output files. The proposed parameters default to the current behavior but allow finer control.