### PR TITLE
Tool wrappers for JPF,  Jayhorn and JBMC

### DIFF
--- a/benchexec/result.py
+++ b/benchexec/result.py
@@ -75,6 +75,7 @@ RESULT_CLASS_ERROR   = 'error'
 
 # This maps content of property files to property name.
 _PROPERTY_NAMES = {'LTL(G ! label(':                    _PROP_LABEL,
+                   'LTL(G assert)':                     _PROP_ASSERT,
                    'LTL(G ! call(__VERIFIER_error()))': _PROP_CALL,
                    'LTL(F end)':                        _PROP_TERMINATION,
                    'LTL(G valid-free)':                 _PROP_FREE,
@@ -90,7 +91,7 @@ _PROPERTY_NAMES = {'LTL(G ! label(':                    _PROP_LABEL,
 _FILE_RESULTS = {
               '_true-unreach-label':   (RESULT_TRUE_PROP, {_PROP_LABEL}),
               '_true-unreach-call':    (RESULT_TRUE_PROP, {_PROP_CALL}),
-              '_true_assert':          (RESULT_TRUE_PROP, {_PROP_ASSERT}),
+              '_true-assert':          (RESULT_TRUE_PROP, {_PROP_ASSERT}),
               '_true-termination':     (RESULT_TRUE_PROP, {_PROP_TERMINATION}),
               '_true-valid-deref':     (RESULT_TRUE_PROP, {_PROP_DEREF}),
               '_true-valid-free':      (RESULT_TRUE_PROP, {_PROP_FREE}),
@@ -99,7 +100,7 @@ _FILE_RESULTS = {
 
               '_false-unreach-label':  (RESULT_FALSE_REACH,       {_PROP_LABEL}),
               '_false-unreach-call':   (RESULT_FALSE_REACH,       {_PROP_CALL}),
-              '_false_assert':         (RESULT_FALSE_REACH,       {_PROP_ASSERT}),
+              '_false-assert':         (RESULT_FALSE_REACH,       {_PROP_ASSERT}),
               '_false-termination':    (RESULT_FALSE_TERMINATION, {_PROP_TERMINATION}),
               '_false-valid-deref':    (RESULT_FALSE_DEREF,       {_PROP_DEREF}),
               '_false-valid-free':     (RESULT_FALSE_FREE,        {_PROP_FREE}),
@@ -199,10 +200,6 @@ def score_for_task(filename, properties, category):
     else:
         assert False, "unexpected return value from satisfies_file_property: " + expected
 
-def _file_is_java(filename):
-    # Java benchmarks have as filename their main class, so we cannot check for '.java'
-    return '_assert' in filename
-
 
 def get_result_classification(result):
     '''
@@ -237,11 +234,6 @@ def get_result_category(filename, result, properties):
 
     if result == RESULT_UNKNOWN:
         return CATEGORY_UNKNOWN
-
-    if _file_is_java(filename) and not properties:
-        # Currently, no property files for checking Java programs exist,
-        # so we hard-code a check for _PROP_ASSERT for these
-        properties = [_PROP_ASSERT]
 
     if not properties:
         # Without property we cannot return correct or wrong results.

--- a/benchexec/tools/jayhorn.py
+++ b/benchexec/tools/jayhorn.py
@@ -1,0 +1,76 @@
+"""
+BenchExec is a framework for reliable benchmarking.
+This file is part of BenchExec.
+Copyright (C) 2007-2015  Dirk Beyer
+All rights reserved.
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+    http://www.apache.org/licenses/LICENSE-2.0
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+"""
+import logging
+import xml.etree.ElementTree as ET
+import os
+import shutil
+import zipfile
+
+import benchexec.util as util
+import benchexec.tools.template
+import benchexec.result as result
+
+class Tool(benchexec.tools.template.BaseTool):
+    """
+    Tool info for JayHorn (https://github.com/jayhorn/jayhorn).
+    JayHorn does not support jar files yet;
+    we therefore unpack the benchmark jar file.
+    """
+
+    REQUIRED_PATHS = [
+                  "jayhorn.jar"
+                  "jayhorn" # contains: java -jar jayhorn.jar
+                  ]
+    def executable(self):
+        return util.find_executable('jayhorn')
+
+
+    def version(self, executable):
+        return "5.1" # --version not supported by JayHorn
+
+
+    def name(self):
+        return 'JayHorn'
+
+
+    def cmdline(self, executable, options, tasks, propertyfile, rlimits):
+        # unpack jar
+        os.mkdir('tmp')
+        zip_ref = zipfile.ZipFile(tasks[0], 'r')
+        zip_ref.extractall('tmp')
+        zip_ref.close()
+
+        options = ['-j', 'tmp']
+
+        self.options = options
+
+        return [executable] + options
+
+
+    def determine_result(self, returncode, returnsignal, output, isTimeout):
+        # clean up
+        shutil.rmtree('tmp')
+
+        # parse output
+        status = result.RESULT_UNKNOWN
+
+        for line in output:
+            if 'Safety Result ... SAFE' in line:
+                status = result.RESULT_TRUE_PROP
+            elif 'Safety Result ... UNSAFE' in line:
+                status = result.RESULT_FALSE_REACH
+
+        return status

--- a/benchexec/tools/jbmc.py
+++ b/benchexec/tools/jbmc.py
@@ -1,0 +1,148 @@
+"""
+BenchExec is a framework for reliable benchmarking.
+This file is part of BenchExec.
+Copyright (C) 2007-2015  Dirk Beyer
+All rights reserved.
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+    http://www.apache.org/licenses/LICENSE-2.0
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+"""
+import logging
+import xml.etree.ElementTree as ET
+
+import benchexec.util as util
+import benchexec.tools.template
+import benchexec.result as result
+
+class Tool(benchexec.tools.template.BaseTool):
+    """
+    Tool info for JBMC (http://www.cprover.org/cbmc/).
+    It always adds --xml-ui to the command-line arguments for easier parsing of
+    the output, unless a propertyfile is passed -- in which case running under
+    SV-COMP conditions is assumed.
+    """
+
+    REQUIRED_PATHS = [
+                  "jbmc",
+                  "jbmc-binary"
+                  ]
+    def executable(self):
+        return util.find_executable('jbmc')
+
+
+    def version(self, executable):
+        return self._version_from_tool(executable)
+
+
+    def name(self):
+        return 'JBMC'
+
+
+    def cmdline(self, executable, options, tasks, propertyfile, rlimits):
+        if propertyfile:
+            options = options + ['--propertyfile', propertyfile]
+        elif ("--xml-ui" not in options):
+            options = options + ["--xml-ui"]
+
+        self.options = options
+
+        return [executable] + options + tasks
+
+
+    def parse_XML(self, output, returncode, isTimeout):
+        #an empty tag cannot be parsed into a tree
+        def sanitizeXML(s):
+            return s.replace("<>", "<emptyTag>") \
+                    .replace("</>", "</emptyTag>")
+
+        try:
+            tree = ET.fromstringlist(map(sanitizeXML, output))
+            status = tree.findtext('cprover-status')
+
+            if status is None:
+                def isErrorMessage(msg):
+                    return msg.get('type', None) == 'ERROR'
+
+                messages = list(filter(isErrorMessage, tree.getiterator('message')))
+                if messages:
+                    # for now, use only the first error message if there are several
+                    msg = messages[0].findtext('text')
+                    if msg == 'Out of memory':
+                        status = 'OUT OF MEMORY'
+                    elif msg:
+                        status = 'ERROR ({0})'.format(msg)
+                    else:
+                        status = 'ERROR'
+                else:
+                    status = 'INVALID OUTPUT'
+
+            elif status == "FAILURE":
+                assert returncode == 10
+                reason = tree.find('goto_trace').find('failure').findtext('reason')
+                if not reason:
+                    reason = tree.find('goto_trace').find('failure').get('reason')
+                if 'unwinding assertion' in reason:
+                    status = result.RESULT_UNKNOWN
+                else:
+                    status = result.RESULT_FALSE_REACH
+
+            elif status == "SUCCESS":
+                assert returncode == 0
+                if "--unwinding-assertions" in self.options:
+                    status = result.RESULT_TRUE_PROP
+                else:
+                    status = result.RESULT_UNKNOWN
+
+        except Exception:
+            if isTimeout:
+                # in this case an exception is expected as the XML is invalid
+                status = 'TIMEOUT'
+            elif 'Minisat::OutOfMemoryException' in output:
+                status = 'OUT OF MEMORY'
+            else:
+                status = 'INVALID OUTPUT'
+                logging.exception("Error parsing JBMC output for returncode %d", returncode)
+
+        return status
+
+
+
+    def determine_result(self, returncode, returnsignal, output, isTimeout):
+
+        if returnsignal == 0 and ((returncode == 0) or (returncode == 10)):
+            status = result.RESULT_UNKNOWN
+            if ('--xml-ui' in self.options):
+                status = self.parse_XML(output, returncode, isTimeout)
+            elif len(output) > 0:
+                # SV-COMP mode
+                result_str = output[-1].strip()
+
+                if result_str == 'TRUE' :
+                    status = result.RESULT_TRUE_PROP
+                elif 'FALSE' in result_str:
+                    if result_str == 'FALSE(valid-memtrack)':
+                        status = result.RESULT_FALSE_MEMTRACK
+                    elif result_str == 'FALSE(valid-deref)':
+                        status = result.RESULT_FALSE_DEREF
+                    elif result_str == 'FALSE(valid-free)':
+                        status = result.RESULT_FALSE_FREE
+                    elif result_str == 'FALSE(no-overflow)':
+                        status = result.RESULT_FALSE_OVERFLOW
+                    else:
+                        status = result.RESULT_FALSE_REACH
+                elif 'UNKNOWN' in output:
+                    status = result.RESULT_UNKNOWN
+
+        elif returncode == 64 and 'Usage error!' in output:
+            status = 'INVALID ARGUMENTS'
+
+        else:
+            status = result.RESULT_UNKNOWN
+
+        return status

--- a/benchexec/tools/jpf.py
+++ b/benchexec/tools/jpf.py
@@ -1,0 +1,75 @@
+"""
+BenchExec is a framework for reliable benchmarking.
+This file is part of BenchExec.
+Copyright (C) 2007-2015  Dirk Beyer
+All rights reserved.
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+    http://www.apache.org/licenses/LICENSE-2.0
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+"""
+import logging
+import xml.etree.ElementTree as ET
+import os
+
+import benchexec.util as util
+import benchexec.tools.template
+import benchexec.result as result
+
+class Tool(benchexec.tools.template.BaseTool):
+    """
+    Tool info for JPF (https://babelfish.arc.nasa.gov/hg/jpf).
+    It creates a temporary .jpf configuration file.
+    """
+
+    REQUIRED_PATHS = [
+                  "jpf-core/bin/jpf",
+                  "jpf-core/build/RunJPF.jar"
+                  ]
+    def executable(self):
+        return util.find_executable('jpf-core/bin/jpf')
+
+
+    def version(self, executable):
+        return self._version_from_tool(executable, '-version').split()[2]
+
+
+    def name(self):
+        return 'JPF'
+
+
+    def cmdline(self, executable, options, tasks, propertyfile, rlimits):
+        # create configuration file
+        with open('config.jpf', 'w') as ofile:
+            ofile.write(
+                'target=Main\n'
+                'classpath=' + tasks[0] + '\n'
+                'symbolic.dp=z3\n'
+                'listener = .symbc.SymbolicListener\n')
+
+        options = options + ['config.jpf']
+
+        self.options = options
+
+        return [executable] + options
+
+
+    def determine_result(self, returncode, returnsignal, output, isTimeout):
+        # clean up
+        os.unlink('config.jpf')
+
+        # parse output
+        status = result.RESULT_UNKNOWN
+
+        for line in output:
+            if 'no errors detected' in line:
+                status = result.RESULT_TRUE_PROP
+            elif 'AssertionError' in line:
+                status = result.RESULT_FALSE_REACH
+
+        return status


### PR DESCRIPTION
and a small adaptation to enable the "assert" property for use with Java benchmarks

Results of a run using JPF, JayHorn and JBMC can be found here:
https://pschrammel.bitbucket.io/schrammel-it/research/sv-comp-java-2018/
The benchmarks are in this PR: https://github.com/sosy-lab/sv-benchmarks/pull/565

Benchmark definitions for JPF, JayHorn and JBMC are in this PR: https://github.com/sosy-lab/sv-comp/pull/82
