### PR TITLE
Fix a bug in the output parsing for VVT

### DIFF
--- a/benchexec/tools/vvt.py
+++ b/benchexec/tools/vvt.py
@@ -52,11 +52,11 @@ class Tool(benchexec.tools.template.BaseTool):
 
     def determine_result(self, returncode, returnsignal, output, isTimeOut):
         try:
-            if "No bug found.\n" in output:
-                return result.RESULT_TRUE_PROP
-            elif "Bug found:\n" in output:
-                return result.RESULT_FALSE_REACH
-            else:
-                return result.RESULT_UNKNOWN
+            for line in output:
+                if line.startswith("No bug found"):
+                    return result.RESULT_TRUE_PROP
+                elif line.startswith("Bug found:"):
+                    return result.RESULT_FALSE_REACH
+            return result.RESULT_UNKNOWN
         except Exception:
             return result.RESULT_UNKNOWN


### PR DESCRIPTION
Fix a bug in the output parsing for VVT: the line with the result sometimes contains more details, which did not match the previous check.

This bug has been confirmed to me via email by the original author @hguenther.