### PR TITLE
CBMC: report "OUT OF MEMORY" instead of generic ERROR(6)

### DIFF
--- a/benchexec/tools/cbmc.py
+++ b/benchexec/tools/cbmc.py
@@ -143,8 +143,11 @@ class Tool(benchexec.tools.template.BaseTool):
                 elif 'UNKNOWN' in output:
                     status = result.RESULT_UNKNOWN
 
-        elif returncode == 64 and 'Usage error!' in output:
+        elif returncode == 64 and 'Usage error!\n' in output:
             status = 'INVALID ARGUMENTS'
+
+        elif returncode == 6 and 'Out of memory\n' in output:
+            status = 'OUT OF MEMORY'
 
         else:
             status = result.RESULT_ERROR


### PR DESCRIPTION
Out-of-memory is reported and can be detected; this had always been the
case for the XML output, now it's done for plain-text output as well.

Also fixes a missing newline character in invalid-arguments cases.