### PR TITLE
Add tool-info module for CBMC Path

### DIFF
--- a/benchexec/tools/cbmc-path.py
+++ b/benchexec/tools/cbmc-path.py
@@ -1,0 +1,30 @@
+"""
+BenchExec is a framework for reliable benchmarking.
+This file is part of BenchExec.
+Copyright (C) 2007-2018  Dirk Beyer
+All rights reserved.
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+    http://www.apache.org/licenses/LICENSE-2.0
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+"""
+
+import benchexec.util as util
+
+from . import cbmc
+
+class Tool(cbmc.Tool):
+    """
+    Tool info for CBMC Path (http://www.cprover.org/cbmc/).
+    It always adds --xml-ui to the command-line arguments for easier parsing of
+    the output, unless a propertyfile is passed -- in which case running under
+    SV-COMP conditions is assumed.
+    """
+
+    def name(self):
+        return 'CBMC Path'


### PR DESCRIPTION
This module is identical to CBMC's tool-info module, except that it
returns "CBMC Path" as the tool name. The `--paths` switch is specified
in the wrapper script `cbmc`, which invokes `cbmc-binary`.