### PR TITLE
Add goto-cc to required paths for CBMC

### DIFF
--- a/benchexec/tools/cbmc.py
+++ b/benchexec/tools/cbmc.py
@@ -34,7 +34,8 @@ class Tool(benchexec.tools.template.BaseTool):
 
     REQUIRED_PATHS = [
                   "cbmc",
-                  "cbmc-binary"
+                  "cbmc-binary",
+                  "goto-cc"
                   ]
     def executable(self):
         return util.find_executable('cbmc')


### PR DESCRIPTION
goto-cc is now required by the wrapper script, and seemingly isn't actually found at runtime (although I don't understand where "required_files" would even be used in a meaningful way).