### PR TITLE
Improve tool-info module divine4

### DIFF
--- a/benchexec/tools/template.py
+++ b/benchexec/tools/template.py
@@ -80,7 +80,7 @@ class BaseTool(object):
         """
         return ''
 
-    def _version_from_tool(self, executable, arg='--version', use_stderr=False):
+    def _version_from_tool(self, executable, arg='--version', use_stderr=False, ignore_stderr=False):
         """
         Get version of a tool by executing it with argument "--version"
         and returning stdout.
@@ -97,7 +97,7 @@ class BaseTool(object):
             logging.warning('Cannot run {0} to determine version: {1}'.
                             format(executable, e.strerror))
             return ''
-        if stderr and not use_stderr:
+        if stderr and not use_stderr and not ignore_stderr:
             logging.warning('Cannot determine {0} version, error output: {1}'.
                             format(executable, util.decode_to_string(stderr)))
             return ''


### PR DESCRIPTION
- Simplify method "executable" to standard format.
- Avoid copied code from helper method "_version_from_tool".
- String superfluous space from version number.
- Fix crash if tool does not output a version number.
- Simplify the definition of the program files by using the "lib" directory
  as a whole instead of enumerating all individual files.
  This allows to remove the method program_files completely.

@vlstill Please review this.

When executing `test_tool_info` using the verifier archive from SV-COMP'19, the output is as follows:
<pre>
Name of tool module: “divine4”
Full name of tool module: “benchexec.tools.divine4”
Documentation of tool module:
        DIVINE tool info object
Name of tool: “DIVINE”
Executable: “./divine”
Executable (absolute path): “/home/wendler/tmp/divine-svc/divine”
Version: “4.1.16+b96a8a5c7ee6”
Working directory: “.”
Working directory (absolute path): “/home/wendler/tmp/divine-svc”
Program files:
        “./divine”
        “divine”
        “divine-svc”
        “lib”
Program files (absolute paths):
        “/home/wendler/tmp/divine-svc/divine”
        “/home/wendler/tmp/divine-svc/divine”
        “/home/wendler/tmp/divine-svc/divine-svc”
        “/home/wendler/tmp/divine-svc/lib”
Minimal command line:
        “['./divine-svc', './divine', '-', 'INPUT.FILE']”
Command line with parameter:
        “['./divine-svc', './divine', '-', '-SOME_OPTION', 'INPUT.FILE']”
Command line with property file:
        “['./divine-svc', './divine', 'PROPERTY.PRP', 'INPUT.FILE']”
Command line with multiple input files:
        “['./divine-svc', './divine', '-', 'INPUT1.FILE', 'INPUT2.FILE']”
Command line CPU-time limit:
        “['./divine-svc', './divine', '-', 'INPUT.FILE']”
</pre>