### PR TITLE
tbf: Rename and use result DONE

### DIFF
--- a/benchexec/tools/tbf.py
+++ b/benchexec/tools/tbf.py
@@ -71,6 +71,8 @@ class Tool(benchexec.tools.template.BaseTool):
                 return result.RESULT_FALSE_REACH
             elif line.startswith('TBF') and 'TRUE' in line:
                 return result.RESULT_TRUE_PROP
+            elif line.startswith('TBF') and 'DONE' in line:
+                return result.RESULT_DONE
         return result.RESULT_UNKNOWN
 
     def get_value_from_output(self, lines, identifier):

--- a/benchexec/tools/tbf.py
+++ b/benchexec/tools/tbf.py
@@ -49,7 +49,7 @@ class Tool(benchexec.tools.template.BaseTool):
         return self._version_from_tool(executable)
 
     def name(self):
-        return 'TBF'
+        return 'tbf'
 
     def determine_result(self, returncode, returnsignal, output, isTimeout):
         """


### PR DESCRIPTION
Let tbf tool-info module recognize tbf verdict "DONE" as return result 'done'.

While we're at it, let the tool-info module for tbf return name "tbf" instead of uppercase "TBF",
as it's more widely used and easier on the eyes (imo).