### PR TITLE
Get tool name from executable

### DIFF
--- a/benchexec/tools/cpachecker.py
+++ b/benchexec/tools/cpachecker.py
@@ -83,15 +83,15 @@ class Tool(benchexec.tools.template.BaseTool):
 
     def version(self, executable):
         stdout = self._version_from_tool(executable, '-help')
-        line = next(l for l in stdout.splitlines() if l.startswith('CPAchecker'))
-        line = line.replace('CPAchecker' , '')
+        line = next(l for l in stdout.splitlines() if l.startswith('CPA'))
+        line = line.replace(self.name() , '')
         line = line.split('(')[0]
         return line.strip()
 
     def name(self):
         executable = self.executable()
         stdout = self._version_from_tool(executable, '-help')
-        line = next(l for l in stdout.splitlines() if l.startswith('CPAchecker'))
+        line = next(l for l in stdout.splitlines() if l.startswith('CPA'))
         line = line.split(' ')[0]
         return line.strip()
 

--- a/benchexec/tools/cpachecker.py
+++ b/benchexec/tools/cpachecker.py
@@ -89,7 +89,11 @@ class Tool(benchexec.tools.template.BaseTool):
         return line.strip()
 
     def name(self):
-        return 'CPAchecker'
+        executable = self.executable()
+        stdout = self._version_from_tool(executable, '-help')
+        line = next(l for l in stdout.splitlines() if l.startswith('CPAchecker'))
+        line = line.split(' ')[0]
+        return line.strip()
 
     def _get_additional_options(self, existing_options, propertyfile, rlimits):
         options = []


### PR DESCRIPTION
Get tool name from executable, instead of having it hard-coded in the tool-info module; fixes #397.