### PR TITLE
Let table generator support custom score-columns in result XMLs.

### DIFF
--- a/benchexec/tablegenerator/__init__.py
+++ b/benchexec/tablegenerator/__init__.py
@@ -697,10 +697,10 @@ class RunResult(object):
 
             if column.title.lower() == 'score':
                 if value is None:
+                    # If no score column exists in the xml, take the internally computed score,
+                    # if available
                     value = str(score) if score is not None else None
                 else:
-                    # If a score column exists in the xml, we use that column's value for the score, instead of
-                    # the computed score.
                     score = float(value)
             values.append(value)
 

--- a/benchexec/tablegenerator/__init__.py
+++ b/benchexec/tablegenerator/__init__.py
@@ -698,7 +698,7 @@ class RunResult(object):
             if column.title.lower() == 'score' and value is None and score is not None:
                 # If no score column exists in the xml, take the internally computed score,
                 # if available
-                value = str(score) if score is not None else None
+                value = str(score)
             values.append(value)
 
         sourcefiles = sourcefileTag.get('files')

--- a/benchexec/tablegenerator/__init__.py
+++ b/benchexec/tablegenerator/__init__.py
@@ -700,12 +700,6 @@ class RunResult(object):
                     # If no score column exists in the xml, take the internally computed score,
                     # if available
                     value = str(score) if score is not None else None
-                else:
-                    try:
-                        score = float(value)
-                    except ValueError:
-                        logging.error("Column 'score' is selected, but contains non-number value: %s", value)
-                        exit(1)
             values.append(value)
 
         sourcefiles = sourcefileTag.get('files')

--- a/benchexec/tablegenerator/__init__.py
+++ b/benchexec/tablegenerator/__init__.py
@@ -695,8 +695,7 @@ class RunResult(object):
 
                     value = get_value_from_logfile(logfileLines, column.pattern)
 
-            if column.title.lower() == 'score':
-                if value is None:
+            if column.title.lower() == 'score' and value is None and score is not None:
                     # If no score column exists in the xml, take the internally computed score,
                     # if available
                     value = str(score) if score is not None else None

--- a/benchexec/tablegenerator/__init__.py
+++ b/benchexec/tablegenerator/__init__.py
@@ -681,9 +681,7 @@ class RunResult(object):
 
         for column in listOfColumns: # for all columns that should be shown
             value = None # default value
-            if column.title.lower() == 'score':
-                value = str(score) if score is not None else None
-            elif column.title.lower() == 'status':
+            if column.title.lower() == 'status':
                 value = status
 
             elif not correct_only or category == result.CATEGORY_CORRECT:
@@ -697,6 +695,13 @@ class RunResult(object):
 
                     value = get_value_from_logfile(logfileLines, column.pattern)
 
+            if column.title.lower() == 'score':
+                if value is None:
+                    value = str(score) if score is not None else None
+                else:
+                    # If a score column exists in the xml, we use that column's value for the score, instead of
+                    # the computed score.
+                    score = float(value)
             values.append(value)
 
         sourcefiles = sourcefileTag.get('files')

--- a/benchexec/tablegenerator/__init__.py
+++ b/benchexec/tablegenerator/__init__.py
@@ -701,7 +701,11 @@ class RunResult(object):
                     # if available
                     value = str(score) if score is not None else None
                 else:
-                    score = float(value)
+                    try:
+                        score = float(value)
+                    except ValueError:
+                        logging.error("Column 'score' is selected, but contains non-number value: %s", value)
+                        exit(1)
             values.append(value)
 
         sourcefiles = sourcefileTag.get('files')

--- a/benchexec/tablegenerator/__init__.py
+++ b/benchexec/tablegenerator/__init__.py
@@ -696,9 +696,9 @@ class RunResult(object):
                     value = get_value_from_logfile(logfileLines, column.pattern)
 
             if column.title.lower() == 'score' and value is None and score is not None:
-                    # If no score column exists in the xml, take the internally computed score,
-                    # if available
-                    value = str(score) if score is not None else None
+                # If no score column exists in the xml, take the internally computed score,
+                # if available
+                value = str(score) if score is not None else None
             values.append(value)
 
         sourcefiles = sourcefileTag.get('files')

--- a/benchexec/tablegenerator/test_integration/__init__.py
+++ b/benchexec/tablegenerator/test_integration/__init__.py
@@ -181,6 +181,12 @@ class TableGeneratorIntegrationTests(unittest.TestCase):
             'test.2015-03-03_1613.results.predicateAnalysis.all-columns',
             )
 
+    def test_simple_table_custom_score(self):
+        self.generate_tables_and_compare_content(
+            [result_file('test.2015-03-03_1613.results.predicateAnalysis.custom-score.xml')],
+            'test.2015-03-03_1613.results.predicateAnalysis.custom-score',
+            )
+
     def test_simple_table_xml(self):
         self.generate_tables_and_compare_content(
             ['-x', os.path.join(here, 'simple-table.xml')],

--- a/benchexec/tablegenerator/test_integration/expected/test.2015-03-03_1613.results.predicateAnalysis.custom-score.csv
+++ b/benchexec/tablegenerator/test_integration/expected/test.2015-03-03_1613.results.predicateAnalysis.custom-score.csv
@@ -1,0 +1,6 @@
+tool	CPAchecker 1.4-svn 15944M	CPAchecker 1.4-svn 15944M	CPAchecker 1.4-svn 15944M	CPAchecker 1.4-svn 15944M	CPAchecker 1.4-svn 15944M
+run set	predicateAnalysis.0	predicateAnalysis.0	predicateAnalysis.0	predicateAnalysis.0	predicateAnalysis.0
+benchexec/tablegenerator/test_integration/results/test/programs/simple/	status	cputime (s)	walltime (s)	memUsage	score
+bitvectors/implicitunsignedconversion_false-unreach-label.i	true	2.169189428	2.1783649921417236	128032768	0
+switch_test_default_fallthrough_false-unreach-label.c	false(reach)	2.189887353	2.1968865394592285	129118208	10
+compoundLiteral_true-unreach-label.c	true	2.22954344	2.237081289291382	132337664	-2.5

--- a/benchexec/tablegenerator/test_integration/expected/test.2015-03-03_1613.results.predicateAnalysis.custom-score.html
+++ b/benchexec/tablegenerator/test_integration/expected/test.2015-03-03_1613.results.predicateAnalysis.custom-score.html
@@ -1,0 +1,147 @@
+<table id="dataTable">
+<thead>
+  <tr id="tool" class="tool collapsable-header">
+<td colspan="1">Tool</td>
+<td colspan="5">CPAchecker 1.4-svn 15944M</td>
+</tr>
+  <tr id="limits" class="limits collapsable-header">
+<td colspan="1">Limits</td>
+<td colspan="5">timelimit: 10 s, memlimit: 3000 MB, CPU core limit: 1</td>
+</tr>
+  <tr id="host" class="host collapsable-header">
+<td colspan="1">Host</td>
+<td colspan="5">tortuga</td>
+</tr>
+  <tr id="os" class="os collapsable-header">
+<td colspan="1">OS</td>
+<td colspan="5">Linux 3.13.0-45-generic x86_64</td>
+</tr>
+  <tr id="system" class="system collapsable-header">
+<td colspan="1">System</td>
+<td colspan="5">CPU: Intel Core i7-2600 CPU @ 3.40GHz, cores: 8, frequency: 3401 MHz; RAM: 16389384 kB</td>
+</tr>
+  <tr id="date" class="date collapsable-header">
+<td colspan="1">Date of execution</td>
+<td colspan="5">2015-03-03 16:13:02 CET</td>
+</tr>
+  <tr id="run" class="run ">
+<td colspan="1">Run set</td>
+<td colspan="5">predicateAnalysis.0</td>
+</tr>
+  <tr id="options" class="options collapsable-header">
+<td colspan="1">Options</td>
+<td colspan="5"><span style="display:block">-noout</span><span style="display:block"> -setprop log.consoleLevel=WARNING</span><span style="display:block"> -predicateAnalysis</span></td>
+</tr>
+  <tr id="columnTitles" class="columnTitles ">
+<td colspan="1">benchexec/tablegenerator/test_integration/results/test/programs/simple/</td>
+<td colspan="1">status</td>
+<td colspan="1">cputime (s)</td>
+<td colspan="1">walltime (s)</td>
+<td colspan="1">memUsage</td>
+<td colspan="1">score</td>
+</tr>
+</thead>
+
+<tbody>
+<tr><td title="Click here to show source code"><a href="../results/test/programs/simple/bitvectors/implicitunsignedconversion_false-unreach-label.i">bitvectors/implicitunsignedconversion_false-unreach-label.i</a></td>
+<td class="wrong main_status link" title="Click here to show output of tool"><a href="../results/test.2015-03-03_1613.logfiles/predicateAnalysis.implicitunsignedconversion_false-unreach-label.i.log">true</a></td>
+<td class="wrong measure">2.17</td>
+<td class="wrong measure">2.18</td>
+<td class="wrong count">128032768</td>
+<td class="wrong measure">0&#x2008;&#x2007;&#x2007;</td>
+</tr>
+<tr><td title="Click here to show source code"><a href="../results/test/programs/simple/switch_test_default_fallthrough_false-unreach-label.c">switch_test_default_fallthrough_false-unreach-label.c</a></td>
+<td class="correct main_status link" title="Click here to show output of tool"><a href="../results/test.2015-03-03_1613.logfiles/predicateAnalysis.switch_test_default_fallthrough_false-unreach-label.c.log">false(reach)</a></td>
+<td class="correct measure">2.19</td>
+<td class="correct measure">2.20</td>
+<td class="correct count">129118208</td>
+<td class="correct measure">10&#x2008;&#x2007;&#x2007;</td>
+</tr>
+<tr><td title="Click here to show source code"><a href="../results/test/programs/simple/compoundLiteral_true-unreach-label.c">compoundLiteral_true-unreach-label.c</a></td>
+<td class="correct main_status link" title="Click here to show output of tool"><a href="../results/test.2015-03-03_1613.logfiles/predicateAnalysis.compoundLiteral_true-unreach-label.c.log">true</a></td>
+<td class="correct measure">2.23</td>
+<td class="correct measure">2.24</td>
+<td class="correct count">132337664</td>
+<td class="correct measure">-2.5&#x2007;</td>
+</tr>
+</tbody>
+
+<tfoot>
+<tr class="columnTitles">
+<td colspan="1">benchexec/tablegenerator/test_integration/results/test/programs/simple/</td>
+<td colspan="1">status</td>
+<td colspan="1">cputime (s)</td>
+<td colspan="1">walltime (s)</td>
+<td colspan="1">memUsage</td>
+<td colspan="1">score</td>
+</tr>
+<tr class="statistics">
+<td colspan="1" title="in total 1 true tasks, 2 false tasks">total</td>
+<td class="main_status">3</td>
+<td class="measure" title="Min: 2.17, Max: 2.23, Average: 2.2, Median: 2.19, StDev: 0.03">6.59</td>
+<td class="measure" title="Min: 2.18, Max: 2.24, Average: 2.2, Median: 2.20, StDev: 0.02">6.61</td>
+<td class="count" title="Min: 128032768, Max: 132337664, Average: 129829546.67, Median: 129118208, StDev: 1828028.89">389488640</td>
+<td class="measure" title="Min: -2.5, Max: 10, Average: 2.5, Median: 0, StDev: 5.4">7.5&#x2007;</td>
+</tr>
+<tr class="statistics">
+<td colspan="1" title="(property holds + result is true) OR (property does not hold + result is false)">&nbsp;&nbsp;&nbsp;&nbsp;correct results</td>
+<td class="main_status">2</td>
+<td class="measure" title="Min: 2.19, Max: 2.23, Average: 2.21, Median: 2.21, StDev: 0.02">4.42</td>
+<td class="measure" title="Min: 2.20, Max: 2.24, Average: 2.22, Median: 2.22, StDev: 0.02">4.43</td>
+<td class="count" title="Min: 129118208, Max: 132337664, Average: 130727936.0, Median: 130727936, StDev: 1609728.0">261455872</td>
+<td class="measure" title="Min: -2.5, Max: 10, Average: 3.75, Median: 3.75, StDev: 6.25">7.5&#x2007;</td>
+</tr>
+<tr class="statistics">
+<td colspan="1" title="property holds + result is true">&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;correct true</td>
+<td class="main_status">1</td>
+<td class="measure" title="Min: 2.23, Max: 2.23, Average: 2.23, Median: 2.23, StDev: 0.0">2.23</td>
+<td class="measure" title="Min: 2.24, Max: 2.24, Average: 2.24, Median: 2.24, StDev: 0.0">2.24</td>
+<td class="count" title="Min: 132337664, Max: 132337664, Average: 132337664.0, Median: 132337664, StDev: 0.0">132337664</td>
+<td class="measure" title="Min: -2.5, Max: -2.5, Average: -2.5, Median: -2.5, StDev: 0.0">-2.5&#x2007;</td>
+</tr>
+<tr class="statistics">
+<td colspan="1" title="property does not hold + result is false">&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;correct false</td>
+<td class="main_status">1</td>
+<td class="measure" title="Min: 2.19, Max: 2.19, Average: 2.19, Median: 2.19, StDev: 0.0">2.19</td>
+<td class="measure" title="Min: 2.20, Max: 2.20, Average: 2.2, Median: 2.20, StDev: 0.0">2.20</td>
+<td class="count" title="Min: 129118208, Max: 129118208, Average: 129118208.0, Median: 129118208, StDev: 0.0">129118208</td>
+<td class="measure" title="Min: 10, Max: 10, Average: 10.0, Median: 10, StDev: 0.0">10&#x2008;&#x2007;&#x2007;</td>
+</tr>
+<tr class="statistics">
+<td colspan="1" title="(property holds + result is false) OR (property does not hold + result is true)">&nbsp;&nbsp;&nbsp;&nbsp;incorrect results</td>
+<td class="main_status">1</td>
+<td class="measure" title="Min: 2.17, Max: 2.17, Average: 2.17, Median: 2.17, StDev: 0.0">2.17</td>
+<td class="measure" title="Min: 2.18, Max: 2.18, Average: 2.18, Median: 2.18, StDev: 0.0">2.18</td>
+<td class="count" title="Min: 128032768, Max: 128032768, Average: 128032768.0, Median: 128032768, StDev: 0.0">128032768</td>
+<td class="measure">0&#x2008;&#x2007;&#x2007;</td>
+</tr>
+<tr class="statistics">
+<td colspan="1" title="property does not hold + result is true">&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;incorrect true</td>
+<td class="main_status">1</td>
+<td class="measure" title="Min: 2.17, Max: 2.17, Average: 2.17, Median: 2.17, StDev: 0.0">2.17</td>
+<td class="measure" title="Min: 2.18, Max: 2.18, Average: 2.18, Median: 2.18, StDev: 0.0">2.18</td>
+<td class="count" title="Min: 128032768, Max: 128032768, Average: 128032768.0, Median: 128032768, StDev: 0.0">128032768</td>
+<td class="measure">0&#x2008;&#x2007;&#x2007;</td>
+</tr>
+<tr class="statistics">
+<td colspan="1" title="property holds + result is false">&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;incorrect false</td>
+<td class="main_status">0</td>
+<td class="measure novalue"></td>
+<td class="measure novalue"></td>
+<td class="count novalue"></td>
+<td class="measure novalue"></td>
+</tr>
+<tr class="statistics">
+<td colspan="1" title="in total 1 true tasks, 2 false tasks">score (3 tasks, max score: 4)</td>
+<td class="score main_status">7.5</td>
+<td class="score measure novalue"></td>
+<td class="score measure novalue"></td>
+<td class="score count novalue"></td>
+<td class="score measure novalue"></td>
+</tr>
+<tr class="run">
+<td colspan="1">Run set</td>
+<td colspan="5">predicateAnalysis.0</td>
+</tr>
+</tfoot>
+</table>

--- a/benchexec/tablegenerator/test_integration/expected/test.2015-03-03_1613.results.predicateAnalysis.custom-score.html
+++ b/benchexec/tablegenerator/test_integration/expected/test.2015-03-03_1613.results.predicateAnalysis.custom-score.html
@@ -133,7 +133,7 @@
 </tr>
 <tr class="statistics">
 <td colspan="1" title="in total 1 true tasks, 2 false tasks">score (3 tasks, max score: 4)</td>
-<td class="score main_status">7.5</td>
+<td class="score main_status">-29</td>
 <td class="score measure novalue"></td>
 <td class="score measure novalue"></td>
 <td class="score count novalue"></td>

--- a/benchexec/tablegenerator/test_integration/results/test.2015-03-03_1613.results.predicateAnalysis.custom-score.xml
+++ b/benchexec/tablegenerator/test_integration/results/test.2015-03-03_1613.results.predicateAnalysis.custom-score.xml
@@ -1,0 +1,40 @@
+<?xml version="1.0" ?>
+<result benchmarkname="test" block="0" cpuCores="1" date="2015-03-03 16:13:02 CET" memlimit="3000 MB" name="predicateAnalysis.0" options="-noout -setprop log.consoleLevel=WARNING -predicateAnalysis" timelimit="10 s" tool="CPAchecker" toolmodule="benchexec.tools.cpachecker" version="1.4-svn 15944M">
+  <columns>
+    <column title="status"/>
+    <column title="cputime"/>
+    <column title="walltime"/>
+  </columns>
+  <systeminfo hostname="tortuga">
+    <os name="Linux 3.13.0-45-generic x86_64"/>
+    <cpu cores="8" frequency="3401 MHz" model="Intel Core i7-2600 CPU @ 3.40GHz"/>
+    <ram size="16389384 kB"/>
+  </systeminfo>
+  <run files="[test/programs/simple/bitvectors/implicitunsignedconversion_false-unreach-label.i]" name="test/programs/simple/bitvectors/implicitunsignedconversion_false-unreach-label.i" properties="unreach-label">
+    <column title="status" value="true"/>
+    <column title="score" value="0" />
+    <column title="cputime" value="2.169189428s"/>
+    <column title="walltime" value="2.1783649921417236s"/>
+    <column hidden="true" title="category" value="wrong"/>
+    <column hidden="true" title="exitcode" value="0"/>
+    <column title="memUsage" value="128032768"/>
+  </run>
+  <run files="[test/programs/simple/switch_test_default_fallthrough_false-unreach-label.c]" name="test/programs/simple/switch_test_default_fallthrough_false-unreach-label.c" properties="unreach-label">
+    <column title="status" value="false(reach)"/>
+    <column title="score" value="10" />
+    <column title="cputime" value="2.189887353s"/>
+    <column title="walltime" value="2.1968865394592285s"/>
+    <column hidden="true" title="category" value="correct"/>
+    <column hidden="true" title="exitcode" value="0"/>
+    <column title="memUsage" value="129118208"/>
+  </run>
+  <run files="[test/programs/simple/compoundLiteral_true-unreach-label.c]" name="test/programs/simple/compoundLiteral_true-unreach-label.c" properties="unreach-label">
+    <column title="status" value="true"/>
+    <column title="score" value="-2.5" />
+    <column title="cputime" value="2.22954344s"/>
+    <column title="walltime" value="2.237081289291382s"/>
+    <column hidden="true" title="category" value="correct"/>
+    <column hidden="true" title="exitcode" value="0"/>
+    <column title="memUsage" value="132337664"/>
+  </run>
+</result>


### PR DESCRIPTION
Currently, table-generator computes a score internally and does not use columns titled 'score', if they exist in the given result XML.
This makes it impossible to create own score-schema without using names that are different from the established 'score'.
This PR lets table-generator favor such columns over an internally computed score.