### PR TITLE
Simplify method program_files for tbf and tbf_testsuite_validator

### DIFF
--- a/benchexec/tools/tbf.py
+++ b/benchexec/tools/tbf.py
@@ -34,13 +34,10 @@ class Tool(benchexec.tools.template.BaseTool):
     REQUIRED_PATHS = ["tbf", "lib"]
 
     def program_files(self, executable):
-        files = super().program_files(executable)
-
         # Get parent of directory of `executable`
-        dir_of_exec = os.path.dirname(os.path.abspath(executable))
-        base_dir = os.path.dirname(dir_of_exec)
+        install_dir = os.path.join(os.path.dirname(executable), os.path.pardir)
 
-        return files + [os.path.join(base_dir, p) for p in self.REQUIRED_PATHS]
+        return util.flatten(util.expand_filename_pattern(p, install_dir) for p in self.REQUIRED_PATHS)
 
     def executable(self):
         return util.find_executable('tbf', 'bin/tbf')

--- a/benchexec/tools/tbf.py
+++ b/benchexec/tools/tbf.py
@@ -34,10 +34,7 @@ class Tool(benchexec.tools.template.BaseTool):
     REQUIRED_PATHS = ["tbf", "lib"]
 
     def program_files(self, executable):
-        # Get parent of directory of `executable`
-        install_dir = os.path.join(os.path.dirname(executable), os.path.pardir)
-
-        return util.flatten(util.expand_filename_pattern(p, install_dir) for p in self.REQUIRED_PATHS)
+        return self._program_files_from_executable(executable, self.REQUIRED_PATHS, parent_dir=True)
 
     def executable(self):
         return util.find_executable('tbf', 'bin/tbf')

--- a/benchexec/tools/tbf_testsuite_validator.py
+++ b/benchexec/tools/tbf_testsuite_validator.py
@@ -31,13 +31,10 @@ class Tool(benchexec.tools.template.BaseTool):
     REQUIRED_PATHS = ["python_modules", "lib"]
 
     def program_files(self, executable):
-        files = super().program_files(executable)
-
         # Get parent of directory of `executable`
-        dir_of_exec = os.path.dirname(os.path.abspath(executable))
-        base_dir = os.path.dirname(dir_of_exec)
+        install_dir = os.path.join(os.path.dirname(executable), os.path.pardir)
 
-        return files + [os.path.join(base_dir, p) for p in self.REQUIRED_PATHS]
+        return util.flatten(util.expand_filename_pattern(p, install_dir) for p in self.REQUIRED_PATHS)
 
     def executable(self):
         return util.find_executable('tbf-testsuite-validator', 'bin/tbf-testsuite-validator')

--- a/benchexec/tools/tbf_testsuite_validator.py
+++ b/benchexec/tools/tbf_testsuite_validator.py
@@ -31,10 +31,7 @@ class Tool(benchexec.tools.template.BaseTool):
     REQUIRED_PATHS = ["python_modules", "lib"]
 
     def program_files(self, executable):
-        # Get parent of directory of `executable`
-        install_dir = os.path.join(os.path.dirname(executable), os.path.pardir)
-
-        return util.flatten(util.expand_filename_pattern(p, install_dir) for p in self.REQUIRED_PATHS)
+        return self._program_files_from_executable(executable, self.REQUIRED_PATHS, parent_dir=True)
 
     def executable(self):
         return util.find_executable('tbf-testsuite-validator', 'bin/tbf-testsuite-validator')


### PR DESCRIPTION
Do not run the template's `program_files` method first,
as this produces an invalid, and thus unnecessary, file list.

Create relative paths instead of absolute paths.
This is required by the interface and was ignored before.

Also use the util-methods of benchexec to support potential wildcards in future changes.