### PR TITLE
Let test-comp versions of tbf use given property files

### DIFF
--- a/benchexec/tools/tbf.py
+++ b/benchexec/tools/tbf.py
@@ -95,8 +95,12 @@ class Tool(benchexec.tools.template.BaseTool):
             else:
                 options = options + ["--timelimit", str(rlimits[SOFTTIMELIMIT])]
         if propertyfile:
-            logging.warning('Propertyfile given, but tbf ignores property files'
-                    ' and always checks for calls to __VERIFIER_error()')
+            if 'testcomp' in self.version(executable):
+                options = options + ["--spec", propertyfile]
+
+            else:
+                logging.warning('Propertyfile given, but tbf ignores property files'
+                        ' and always checks for calls to __VERIFIER_error()')
 
         return super().cmdline(executable, options, tasks, propertyfile,
                                rlimits)


### PR DESCRIPTION
This is currently the case for all versions tagged with 'testcomp',
so we use this to differentiate whether parameter '--spec' is viable.