### PR TITLE
Add additional error values for out-of-mem and overflow

### DIFF
--- a/benchexec/tools/klee.py
+++ b/benchexec/tools/klee.py
@@ -96,6 +96,10 @@ class Tool(benchexec.tools.template.BaseTool):
             if line.startswith('KLEE: ERROR: '):
                 if line.find('ASSERTION FAIL:')!=-1:
                     return result.RESULT_FALSE_REACH
+                elif line.find('memory error: out of bound pointer')!=-1:
+                    return result.RESULT_FALSE_DEREF
+                elif line.find('overflow')!=-1:
+                    return result.RESULT_FALSE_OVERFLOW
                 else:
                     return "ERROR ({0})".format(returncode)
             if line.startswith('KLEE: done'):


### PR DESCRIPTION
In case different errors are detected by KLEE,
return a more diverse error code.