### PR TITLE
no-hyperthreading feature added

### DIFF
--- a/benchexec/benchexec.py
+++ b/benchexec/benchexec.py
@@ -164,7 +164,9 @@ class BenchExec(object):
                           help="Limit the set of cores BenchExec will use for all runs "
                                "(Applied only if the number of CPU cores is limited).",
                           metavar="N,M-K",)
-
+        parser.add_argument("--no-hyperthreading",
+                          dest="nohyperthreading", action="store_true", default=False,
+                          help="Disable assignment of more than one sibling virtual core")
         parser.add_argument("--user",
                             dest="users",
                             action="append",

--- a/benchexec/benchexec.py
+++ b/benchexec/benchexec.py
@@ -165,8 +165,8 @@ class BenchExec(object):
                                "(Applied only if the number of CPU cores is limited).",
                           metavar="N,M-K",)
         parser.add_argument("--no-hyperthreading",
-                          dest="nohyperthreading", action="store_true", default=False,
-                          help="Disable assignment of more than one sibling virtual core")
+                          dest="use_hyperthreading", action="store_false", default=True,
+                          help="Disable assignment of more than one sibling virtual core to a single run")
         parser.add_argument("--user",
                             dest="users",
                             action="append",

--- a/benchexec/localexecution.py
+++ b/benchexec/localexecution.py
@@ -101,7 +101,7 @@ def execute_benchmark(benchmark, output_handler):
     if CORELIMIT in benchmark.rlimits:
         if not my_cgroups.require_subsystem(cgroups.CPUSET):
             sys.exit("Cgroup subsystem cpuset is required for limiting the number of CPU cores/memory nodes.")
-        coreAssignment = get_cpu_cores_per_run(benchmark.rlimits[CORELIMIT], benchmark.num_of_threads, my_cgroups, benchmark.config.nohyperthreading, benchmark.config.coreset)
+        coreAssignment = get_cpu_cores_per_run(benchmark.rlimits[CORELIMIT], benchmark.num_of_threads, my_cgroups, benchmark.config.use_hyperthreading, benchmark.config.coreset)
         memoryAssignment = get_memory_banks_per_run(coreAssignment, my_cgroups)
         cpu_packages = set(get_cpu_package_for_core(core) for cores_of_run in coreAssignment for core in cores_of_run)
     elif benchmark.config.coreset:

--- a/benchexec/localexecution.py
+++ b/benchexec/localexecution.py
@@ -101,7 +101,7 @@ def execute_benchmark(benchmark, output_handler):
     if CORELIMIT in benchmark.rlimits:
         if not my_cgroups.require_subsystem(cgroups.CPUSET):
             sys.exit("Cgroup subsystem cpuset is required for limiting the number of CPU cores/memory nodes.")
-        coreAssignment = get_cpu_cores_per_run(benchmark.rlimits[CORELIMIT], benchmark.num_of_threads, my_cgroups, benchmark.config.coreset)
+        coreAssignment = get_cpu_cores_per_run(benchmark.rlimits[CORELIMIT], benchmark.num_of_threads, my_cgroups, benchmark.config.nohyperthreading, benchmark.config.coreset)
         memoryAssignment = get_memory_banks_per_run(coreAssignment, my_cgroups)
         cpu_packages = set(get_cpu_package_for_core(core) for cores_of_run in coreAssignment for core in cores_of_run)
     elif benchmark.config.coreset:

--- a/benchexec/localexecution.py
+++ b/benchexec/localexecution.py
@@ -101,7 +101,7 @@ def execute_benchmark(benchmark, output_handler):
     if CORELIMIT in benchmark.rlimits:
         if not my_cgroups.require_subsystem(cgroups.CPUSET):
             sys.exit("Cgroup subsystem cpuset is required for limiting the number of CPU cores/memory nodes.")
-        coreAssignment = get_cpu_cores_per_run(benchmark.rlimits[CORELIMIT], benchmark.num_of_threads, my_cgroups, benchmark.config.use_hyperthreading, benchmark.config.coreset)
+        coreAssignment = get_cpu_cores_per_run(benchmark.rlimits[CORELIMIT], benchmark.num_of_threads, benchmark.config.use_hyperthreading, my_cgroups, benchmark.config.coreset)
         memoryAssignment = get_memory_banks_per_run(coreAssignment, my_cgroups)
         cpu_packages = set(get_cpu_package_for_core(core) for cores_of_run in coreAssignment for core in cores_of_run)
     elif benchmark.config.coreset:

--- a/benchexec/resources.py
+++ b/benchexec/resources.py
@@ -40,7 +40,7 @@ __all__ = [
            'get_cpu_package_for_core',
            ]
 
-def get_cpu_cores_per_run(coreLimit, num_of_threads, my_cgroups, use_hyperthreading, coreSet=None):
+def get_cpu_cores_per_run(coreLimit, num_of_threads, use_hyperthreading, my_cgroups, coreSet=None):
     """
     Calculate an assignment of the available CPU cores to a number
     of parallel benchmark executions such that each run gets its own cores
@@ -99,18 +99,18 @@ def get_cpu_cores_per_run(coreLimit, num_of_threads, my_cgroups, use_hyperthread
         logging.debug("Siblings of cores are %s.", siblings_of_core)
     except ValueError as e:
         sys.exit("Could not read CPU information from kernel: {0}".format(e))
-    return _get_cpu_cores_per_run0(coreLimit, num_of_threads, allCpus, cores_of_package, siblings_of_core, use_hyperthreading)
+    return _get_cpu_cores_per_run0(coreLimit, num_of_threads, use_hyperthreading, allCpus, cores_of_package, siblings_of_core)
 
-def _get_cpu_cores_per_run0(coreLimit, num_of_threads, allCpus, cores_of_package, siblings_of_core, use_hyperthreading):
+def _get_cpu_cores_per_run0(coreLimit, num_of_threads, use_hyperthreading, allCpus, cores_of_package, siblings_of_core):
     """This method does the actual work of _get_cpu_cores_per_run
     without reading the machine architecture from the file system
     in order to be testable. For description, c.f. above.
     Note that this method might change the input parameters!
     Do not call it directly, call getCpuCoresPerRun()!
+    @param use_hyperthreading: A boolean to check if no-hyperthreading method is being used
     @param allCpus: the list of all available cores
     @param cores_of_package: a mapping from package (CPU) ids to lists of cores that belong to this CPU
     @param siblings_of_core: a mapping from each core to a list of sibling cores including the core itself (a sibling is a core sharing the same physical core)
-    @param use_hyperthreading: A boolean to check if no-hyperthreading method is being used
     """
     # First, do some checks whether this algorithm has a chance to work.
     if coreLimit > len(allCpus):

--- a/benchexec/resources.py
+++ b/benchexec/resources.py
@@ -119,7 +119,6 @@ def _get_cpu_cores_per_run0(coreLimit, num_of_threads, use_hyperthreading, allCp
         sys.exit("Cannot run {0} benchmarks in parallel with {1} CPU cores each, only {2} CPU cores available. Please reduce the number of threads to {3}.".format(num_of_threads, coreLimit, len(allCpus), len(allCpus) // coreLimit))
 
     if not use_hyperthreading:
-        logging.debug("Running in no-hyperthreading mode")
         package_of_core = {}
         unused_cores = []
         for package, cores in cores_of_package.items():
@@ -135,6 +134,7 @@ def _get_cpu_cores_per_run0(coreLimit, num_of_threads, use_hyperthreading, allCp
                 unused_cores.append(core)
         for core in unused_cores:
             siblings_of_core.pop(core)
+        logging.debug("Running in no-hyperthreading mode, avoiding the use of CPU cores {}".format(unused_cores))
 
     package_size = None # Number of cores per package
     for package, cores in cores_of_package.items():

--- a/benchexec/resources.py
+++ b/benchexec/resources.py
@@ -40,7 +40,7 @@ __all__ = [
            'get_cpu_package_for_core',
            ]
 
-def get_cpu_cores_per_run(coreLimit, num_of_threads, my_cgroups, nohyperthreading, coreSet=None):
+def get_cpu_cores_per_run(coreLimit, num_of_threads, my_cgroups, use_hyperthreading, coreSet=None):
     """
     Calculate an assignment of the available CPU cores to a number
     of parallel benchmark executions such that each run gets its own cores
@@ -99,84 +99,9 @@ def get_cpu_cores_per_run(coreLimit, num_of_threads, my_cgroups, nohyperthreadin
         logging.debug("Siblings of cores are %s.", siblings_of_core)
     except ValueError as e:
         sys.exit("Could not read CPU information from kernel: {0}".format(e))
-    if nohyperthreading:
-        return _get_cpu_cores_per_run_no_hyperthreading(coreLimit, num_of_threads, allCpus, cores_of_package, siblings_of_core)
-    return _get_cpu_cores_per_run0(coreLimit, num_of_threads, allCpus, cores_of_package, siblings_of_core)
+    return _get_cpu_cores_per_run0(coreLimit, num_of_threads, allCpus, cores_of_package, siblings_of_core, use_hyperthreading)
 
-def _get_cpu_cores_per_run_no_hyperthreading(coreLimit, num_of_threads, allCpus, cores_of_package, siblings_of_core):
-    """
-        This method does the actual work of _get_cpu_cores_per_run when
-        non hyperthreading mode is selected without reading the machine architecture
-        from the file system in order to be testable. For description, c.f. above.
-        Note that this method might change the input parameters!
-        Do not call it directly, call getCpuCoresPerRun()!
-        @param allCpus: the list of all available cores
-        @param cores_of_package: a mapping from package (CPU) ids to lists of cores that belong to this CPU
-        @param siblings_of_core: a mapping from each core to a list of sibling cores including the core itself (a sibling is a core sharing the same physical core)
-    """
-    logging.debug("Running in no-hyperthreading mode")
-    if coreLimit * num_of_threads > len(allCpus):
-        sys.exit("Cannot run {0} benchmarks in parallel with {1} CPU cores each, only {2} CPU cores available. Please reduce the number of threads to {3}.".format(num_of_threads, coreLimit, len(allCpus), len(allCpus) // coreLimit))
-    # List of non-siblings usable cores (i.e physical cores) for each package
-    disjoint_cores_of_package = []
-    all_cpus_set = set(allCpus) 
-    all_disjoint_cores = 0
-    # seperate physical cores for each package
-    for package, cores in cores_of_package.items():
-        disjoint_cores_package = []
-        siblings_cores_package = set()
-        for core in cores:
-            if core in all_cpus_set and core not in siblings_cores_package:
-                disjoint_cores_package.append(core)
-                siblings_cores_package.update(siblings_of_core[core])
-        disjoint_cores_of_package.append(disjoint_cores_package)
-        all_disjoint_cores += len(disjoint_cores_package)
-    if coreLimit*num_of_threads > all_disjoint_cores:
-        sys.exit("Cannot run {0} benchmarks in parallel with {1} physical CPU cores each, only {2} physical CPU cores available. Please reduce the number of threads to {3}.".format(num_of_threads, coreLimit, all_disjoint_cores, math.floor(all_disjoint_cores / coreLimit)))
-    
-    package_size = None # Number of cores per package
-    for cores in disjoint_cores_of_package:
-        if package_size is None:
-            package_size = len(cores)
-        elif package_size != len(cores):
-            sys.exit("Asymmetric machine architecture not supported: A CPU package has {0} cores, but other package has {1} cores.".format(len(cores), package_size))    
-    
-    package_count = len(disjoint_cores_of_package)
-    packages_per_run = int(math.ceil(coreLimit / package_size))
-    if packages_per_run > 1 and packages_per_run * num_of_threads > package_count:
-        sys.exit("Cannot split runs over multiple CPUs and at the same time assign multiple runs to the same CPU. Please reduce the number of threads to {0}.".format(package_count // packages_per_run))
-    
-    max_runs_per_package = int(math.floor(package_size / coreLimit))
-    optimal_runs_per_package = int(math.floor(num_of_threads / package_count))
-    modulo_runs = num_of_threads % package_count
-    if packages_per_run == 1 and max_runs_per_package*package_count < num_of_threads:
-        sys.exit("Cannot run {} benchmarks with {} cores on {} CPUs with {} physical cores, because runs would need to be split across multiple CPUs. Please reduce the number of threads.".format(num_of_threads, coreLimit, package_count, package_size))    
-    start = 0
-    result = []
-    run_count = 0
-    # Actual core assignment
-    for run in range(num_of_threads):
-        cores = []
-        if packages_per_run > 1:
-            #Assign cores when multiple packages are used for a single run
-            for i in range(packages_per_run):
-                cores.extend(disjoint_cores_of_package[start+i])
-            cores = cores[:coreLimit]
-            start += packages_per_run
-        else:
-            # Assign cores evenly when single package is used for multiple runs
-            cores = disjoint_cores_of_package[start][:coreLimit]
-            disjoint_cores_of_package[start] = disjoint_cores_of_package[start][coreLimit:]
-            # this calculation ensures runs are split even across packages
-            run_count += 1
-            if run_count == optimal_runs_per_package + min(modulo_runs, 1):
-                start += 1
-                modulo_runs = max(0, modulo_runs - 1)
-                run_count = 0
-        result.append(cores)
-    return result
-
-def _get_cpu_cores_per_run0(coreLimit, num_of_threads, allCpus, cores_of_package, siblings_of_core):
+def _get_cpu_cores_per_run0(coreLimit, num_of_threads, allCpus, cores_of_package, siblings_of_core, use_hyperthreading):
     """This method does the actual work of _get_cpu_cores_per_run
     without reading the machine architecture from the file system
     in order to be testable. For description, c.f. above.
@@ -185,12 +110,31 @@ def _get_cpu_cores_per_run0(coreLimit, num_of_threads, allCpus, cores_of_package
     @param allCpus: the list of all available cores
     @param cores_of_package: a mapping from package (CPU) ids to lists of cores that belong to this CPU
     @param siblings_of_core: a mapping from each core to a list of sibling cores including the core itself (a sibling is a core sharing the same physical core)
+    @param use_hyperthreading: A boolean to check if no-hyperthreading method is being used
     """
     # First, do some checks whether this algorithm has a chance to work.
     if coreLimit > len(allCpus):
         sys.exit("Cannot run benchmarks with {0} CPU cores, only {1} CPU cores available.".format(coreLimit, len(allCpus)))
     if coreLimit * num_of_threads > len(allCpus):
         sys.exit("Cannot run {0} benchmarks in parallel with {1} CPU cores each, only {2} CPU cores available. Please reduce the number of threads to {3}.".format(num_of_threads, coreLimit, len(allCpus), len(allCpus) // coreLimit))
+
+    if not use_hyperthreading:
+        logging.debug("Running in no-hyperthreading mode")
+        package_of_core = {}
+        unused_cores = []
+        for package, cores in cores_of_package.items():
+            for core in cores:
+                package_of_core[core] = package
+        for core, siblings in siblings_of_core.items():
+            if core in allCpus:
+                siblings.remove(core)
+                cores_of_package[package_of_core[core]] = [c for c in cores_of_package[package_of_core[core]] if c not in siblings]
+                siblings_of_core[core] = [core]
+                allCpus = [c for c in allCpus if c not in siblings]
+            else:
+                unused_cores.append(core)
+        for core in unused_cores:
+            siblings_of_core.pop(core)
 
     package_size = None # Number of cores per package
     for package, cores in cores_of_package.items():

--- a/benchexec/test_core_assignment.py
+++ b/benchexec/test_core_assignment.py
@@ -376,8 +376,8 @@ class TestCpuCoresPerRun_dualCPU_no_ht(TestCpuCoresPerRun):
     
     def test_dualCPU_noncontiguousID(self):
         results = _get_cpu_cores_per_run0(2, 3, False, [0, 4, 9, 15, 21, 19, 31, 12, 10, 11, 8, 23, 27, 14, 1, 20],
-        {0 : [0, 4, 9, 15, 21, 19, 31, 12], 2: [10, 11, 8, 23, 27, 14, 1, 20]}, {0:[0,4], 4:[0,4], 9:[9,15], 15:[9,15], 21:[21,19], 19:[19,21], 31:[31,12], 12:[12,31], 10:[10,11], 11:[10,11], 8:[8,23], 23:[8,23], 27:[27,14], 14:[27, 14], 1:[1, 20], 20:[1,20]})
-        self.assertEqual(results, [[0, 9], [8, 10], [21, 31]], "Incorrect result for {} cores and {} threads.".format(2, 3))
+        {0 : [0, 4, 9, 12, 15, 19, 21, 31], 2: [10, 11, 8, 23, 27, 14, 1, 20]}, {0:[0,4], 4:[0,4], 9:[9,12], 12:[9,12], 15:[15,19], 19:[15,19], 21:[21,31], 31:[21,31], 10:[10,11], 11:[10,11], 8:[8,23], 23:[8,23], 27:[27,14], 14:[27, 14], 1:[1, 20], 20:[1,20]})
+        self.assertEqual(results, [[0, 9], [8, 10], [15, 21]], "Incorrect result for {} cores and {} threads.".format(2, 3))
 
 class TestCpuCoresPerRun_threeCPU_no_ht(TestCpuCoresPerRun):
     cpus = 3

--- a/benchexec/test_core_assignment.py
+++ b/benchexec/test_core_assignment.py
@@ -38,12 +38,12 @@ class TestCpuCoresPerRun(unittest.TestCase):
         logging.disable(logging.CRITICAL)
 
     def assertValid(self, coreLimit, num_of_threads, expectedResult=None):
-        result = _get_cpu_cores_per_run0(coreLimit, num_of_threads, *self.machine())
+        result = _get_cpu_cores_per_run0(coreLimit, num_of_threads, True, *self.machine())
         if expectedResult:
             self.assertEqual(expectedResult, result, "Incorrect result for {} cores and {} threads.".format(coreLimit, num_of_threads))
 
     def assertInvalid(self, coreLimit, num_of_threads):
-        self.assertRaises(SystemExit, _get_cpu_cores_per_run0, coreLimit, num_of_threads, *self.machine())
+        self.assertRaises(SystemExit, _get_cpu_cores_per_run0, coreLimit, num_of_threads, True, *self.machine())
 
     def machine(self):
         """Create the necessary parameters of _get_cpu_cores_per_run0 for a specific machine."""
@@ -162,7 +162,7 @@ class TestCpuCoresPerRun_singleCPU_HT(TestCpuCoresPerRun_singleCPU):
 
     def test_halfPhysicalCore(self):
         # Cannot run if we have only half of one physical core
-        self.assertRaises(SystemExit, _get_cpu_cores_per_run0, 1, 1, [0], {0: [0,1]}, {0: [0,1]})
+        self.assertRaises(SystemExit, _get_cpu_cores_per_run0, 1, 1, True, [0], {0: [0,1]}, {0: [0,1]})
 
 class TestCpuCoresPerRun_dualCPU_HT(TestCpuCoresPerRun):
     cpus = 2
@@ -226,7 +226,7 @@ class TestCpuCoresPerRun_threeCPU_HT(TestCpuCoresPerRun):
         """3 CPUs with one core (plus HT) and non-contiguous core and package numbers.
         This may happen on systems with administrative core restrictions,
         because the ordering of core and package numbers is not always consistent."""
-        result = _get_cpu_cores_per_run0(2, 3,
+        result = _get_cpu_cores_per_run0(2, 3, True,
             [0, 1, 2, 3, 6, 7], {0: [0, 1], 2: [2, 3], 3: [6, 7]},
             {0: [0, 1], 1: [0, 1], 2: [2, 3], 3: [2, 3], 6: [6, 7], 7: [6,7]})
         self.assertEqual([[0, 1], [2, 3], [6, 7]], result, "Incorrect result for {} cores and {} threads.".format(2, 3))
@@ -244,7 +244,7 @@ class TestCpuCoresPerRun_quadCPU_HT(TestCpuCoresPerRun):
         Furthermore, sibling cores have numbers next to each other (occurs on AMD Opteron machines with shared L1/L2 caches)
         and are not split as far as possible from each other (as it occurs on hyper-threading machines).
         """
-        result = _get_cpu_cores_per_run0(1, 8,
+        result = _get_cpu_cores_per_run0(1, 8, True,
             [0, 1, 8, 9, 16, 17, 24, 25, 32, 33, 40, 41, 48, 49, 56, 57],
             {0: [0, 1, 8, 9], 1: [32, 33, 40, 41], 2: [48, 49, 56, 57], 3: [16, 17, 24, 25]},
             {0: [0, 1], 1: [0, 1], 48: [48, 49], 33: [32, 33], 32: [32, 33], 40: [40, 41], 9: [8, 9], 16: [16, 17], 17: [16, 17], 56: [56, 57], 57: [56, 57], 8: [8, 9], 41: [40, 41], 24: [24, 25], 25: [24, 25], 49: [48, 49]})


### PR DESCRIPTION
This pull request implements the feature requested in #122. 
The pull request implements no-hyperthreading feature while doing parallel benchmarking to ensure deterministic results.
I have added a command-line argument `--no-hyperthreading` and the feature can be used just by using the following command:
`benchexec "file_name.xml" --no-hyperthreading`