### PR TITLE
Add Tool Info for JDart

### DIFF
--- a/benchexec/tools/jdart.py
+++ b/benchexec/tools/jdart.py
@@ -1,0 +1,71 @@
+"""
+BenchExec is a framework for reliable benchmarking.
+This file is part of BenchExec.
+Copyright (C) 2007-2018  Dirk Beyer
+All rights reserved.
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+    http://www.apache.org/licenses/LICENSE-2.0
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+"""
+
+import os
+
+import benchexec.util as util
+import benchexec.tools.template
+import benchexec.result as result
+
+
+class Tool(benchexec.tools.template.BaseTool):
+    """
+    Tool info for JDart modified by TU Dortmund
+    (https://github.com/tudo-aqua/jdart).
+    """
+
+    REQUIRED_PATHS = ["jconstraints-extensions",
+                      "lib",
+                      "z3",
+                      "basic.jpf",
+                      "jdk8u222-b10",
+                      "jconstraints-0.9.2-SNAPSHOT.jar",
+                      "jpf-annotations.jar",
+                      "jpf-classes.jar",
+                      "jpf.jar",
+                      "jpf-jdart-annotations.jar",
+                      "jpf-jdart-classes.jar",
+                      "jpf-jdart.jar",
+                      "RunJPF.jar",
+                      "version.txt"]
+
+    def executable(self):
+        return util.find_executable("run-jdart.sh")
+
+    def version(self, executable):
+        return self._version_from_tool(executable, arg="-v")
+
+    def name(self):
+        return "JDart"
+
+    def cmdline(self, executable, options, tasks, propertyfile, rlimits):
+        cmd = [executable]
+        if options:
+            cmd = cmd + options
+        if propertyfile:
+            cmd.append(propertyfile)
+        return cmd + tasks
+
+    def determine_result(self, returncode, returnsignal, output, isTimeout):
+        # parse output
+        status = result.RESULT_UNKNOWN
+        for line in output:
+            if "== ERROR" in line:
+                status = result.RESULT_FALSE_PROP
+            elif "== OK" in line:
+                status = result.RESULT_TRUE_PROP
+
+        return status


### PR DESCRIPTION
We want to integrate JDart into the BenchExec framework.
Currently, JDart doesn't support a fixed Version system that is extractable from the binary.  Therefore, I left the Version String empty.