### PR TITLE
Update the jdart tool integration module to include all shell scripts

### DIFF
--- a/benchexec/tools/jdart.py
+++ b/benchexec/tools/jdart.py
@@ -42,6 +42,8 @@ class Tool(benchexec.tools.template.BaseTool):
         "jpf-jdart.jar",
         "RunJPF.jar",
         "version.txt",
+        "jdart.sh",
+        "run-jdart.sh",
     ]
 
     def executable(self):


### PR DESCRIPTION
After checking the preliminary results, it is visible that the executable shell script is picked from the main directory without being in the REQUIRED_PATHS list but other shell scripts are ignored.