### PR TITLE
Fix UnboundLocalError in table generator when using "href" in column definitions

### DIFF
--- a/benchexec/tablegenerator/util.py
+++ b/benchexec/tablegenerator/util.py
@@ -293,11 +293,11 @@ def prepare_rows_for_js(rows, tools, base_dir, href_base):
         # but for text columns format_value returns the same for csv and html_cell,
         # and for number columns the HTML result is safe.
         formatted_value = column.format_value(value, True, "html_cell")
+        result = {"raw": raw_value}
         if column.href:
             result["href"] = create_link(column.href, base_dir, run_result, href_base)
             if not raw_value and not formatted_value:
                 raw_value = column.pattern
-        result = {"raw": raw_value}
         if formatted_value and formatted_value != raw_value:
             result["html"] = formatted_value
         return result


### PR DESCRIPTION
This fixes the following error:
```
  File "/home/leostrakosch/Documents/SV/test-comp/benchexec/bin/../benchexec/tablegenerator/util.py", line 324, in <listcomp>
    clean_up_results(res, i) for i, res in enumerate(row["results"])
  File "/home/leostrakosch/Documents/SV/test-comp/benchexec/bin/../benchexec/tablegenerator/util.py", line 308, in clean_up_results
    for i, column in enumerate(res.columns)
  File "/home/leostrakosch/Documents/SV/test-comp/benchexec/bin/../benchexec/tablegenerator/util.py", line 308, in <listcomp>
    for i, column in enumerate(res.columns)
  File "/home/leostrakosch/Documents/SV/test-comp/benchexec/bin/../benchexec/tablegenerator/util.py", line 297, in prepare_values
    result["href"] = create_link(column.href, base_dir, run_result, href_base)
UnboundLocalError: local variable 'result' referenced before assignment
```