### PR TITLE
Add tool-info module for new validator: metaval

### DIFF
--- a/benchexec/tools/metaval.py
+++ b/benchexec/tools/metaval.py
@@ -1,0 +1,85 @@
+"""
+BenchExec is a framework for reliable benchmarking.
+This file is part of BenchExec.
+
+Copyright (C) 2007-2019  Dirk Beyer
+All rights reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+"""
+
+import benchexec.util as util
+import benchexec.tools.template
+import benchexec.result as result
+import os
+
+
+class Tool(benchexec.tools.template.BaseTool):
+
+    REQUIRED_PATHS = ["CPAchecker", "esbmc"]
+    TOOL_TO_PATH_MAP = {"cpachecker": ["CPAchecker"], "esbmc": ["esbmc"]}
+
+    def executable(self):
+        return util.find_executable("metaval.sh")
+
+    def name(self):
+        return "metaval"
+
+    def determine_result(self, returncode, returnsignal, output, isTimeout):
+        if not hasattr(self, "wrappedTool"):
+            return "METAVAL ERROR"
+        return self.wrappedTool.determine_result(
+            returncode, returnsignal, output, isTimeout
+        )
+
+    def cmdline(self, executable, options, tasks, propertyfile=None, rlimits={}):
+        verifierOption = options.index("--metaval")
+        self.verifierName = options[verifierOption + 1].lower()
+        del options[verifierOption : verifierOption + 2]
+        witnessOption = options.index("--witness")
+        self.witnessName = options[witnessOption + 1]
+        del options[witnessOption : witnessOption + 2]
+        if self.verifierName == "cpachecker":
+            import benchexec.tools.cpachecker as cpachecker
+
+            self.wrappedTool = cpachecker.Tool()
+        elif self.verifierName == "esbmc":
+            import benchexec.tools.esbmc as esbmc
+
+            self.wrappedTool = esbmc.Tool()
+
+        if hasattr(self, "wrappedTool"):
+            os.environ["PATH"] += os.pathsep + os.path.join(
+                os.curdir, *self.TOOL_TO_PATH_MAP[self.verifierName]
+            )
+            return (
+                [executable]
+                + ["--witness"]
+                + [self.witnessName]
+                + tasks
+                + ["--"]
+                + self.wrappedTool.cmdline(
+                    self.wrappedTool.executable(),
+                    options,
+                    ["output/ARG.c",],
+                    propertyfile,
+                    rlimits,
+                )
+            )
+        else:
+            sys.exit("ERROR: Could not find wrapped tool")
+
+    def version(self, executable):
+        stdout = self._version_from_tool(executable, "--version")
+        metavalVersion = next((l.strip() for l in stdout.splitlines())).split()[2]
+        return metavalVersion

--- a/benchexec/tools/metaval.py
+++ b/benchexec/tools/metaval.py
@@ -54,6 +54,7 @@ class Tool(benchexec.tools.template.BaseTool):
         (knownargs, options) = parser.parse_known_args(options)
         verifierName = knownargs.metaval.lower()
         witnessName = knownargs.witness
+        self.lock.acquire()
         if not hasattr(self, "wrappedTool"):
             self.wrappedTool = __import__(
                 "benchexec.tools." + verifierName, fromlist=["Tool"]
@@ -61,6 +62,7 @@ class Tool(benchexec.tools.template.BaseTool):
         else:
             if not verifierName == self.wrappedTool.name().tolower():
                 exit("metaval is called with mixed wrapped tools")
+        self.lock.release()
 
         if hasattr(self, "wrappedTool"):
             self.lock.acquire()

--- a/benchexec/tools/metaval.py
+++ b/benchexec/tools/metaval.py
@@ -44,9 +44,9 @@ class Tool(benchexec.tools.template.BaseTool):
         )
 
     def cmdline(self, executable, options, tasks, propertyfile=None, rlimits={}):
-        parser = argparse.ArgumentParser(add_help=False)
-        parser.add_argument("--witness")
-        parser.add_argument("--metaval")
+        parser = argparse.ArgumentParser(add_help = False, usage = argparse.SUPPRESS)
+        parser.add_argument("--witness", required = True)
+        parser.add_argument("--metaval", required = True)
         (knownargs, options) = parser.parse_known_args(options)
         self.verifierName = knownargs.metaval.lower()
         self.witnessName = knownargs.witness

--- a/benchexec/tools/metaval.py
+++ b/benchexec/tools/metaval.py
@@ -18,6 +18,7 @@ See the License for the specific language governing permissions and
 limitations under the License.
 """
 
+import argparse
 import benchexec.util as util
 import benchexec.tools.template
 import benchexec.result as result
@@ -43,20 +44,13 @@ class Tool(benchexec.tools.template.BaseTool):
         )
 
     def cmdline(self, executable, options, tasks, propertyfile=None, rlimits={}):
-        verifierOption = options.index("--metaval")
-        self.verifierName = options[verifierOption + 1].lower()
-        del options[verifierOption : verifierOption + 2]
-        witnessOption = options.index("--witness")
-        self.witnessName = options[witnessOption + 1]
-        del options[witnessOption : witnessOption + 2]
-        if self.verifierName == "cpachecker":
-            import benchexec.tools.cpachecker as cpachecker
-
-            self.wrappedTool = cpachecker.Tool()
-        elif self.verifierName == "esbmc":
-            import benchexec.tools.esbmc as esbmc
-
-            self.wrappedTool = esbmc.Tool()
+        parser = argparse.ArgumentParser(add_help=False)
+        parser.add_argument("--witness")
+        parser.add_argument("--metaval")
+        (knownargs, options) = parser.parse_known_args(options)
+        self.verifierName = knownargs.metaval.lower()
+        self.witnessName = knownargs.witness
+        self.wrappedTool = __import__("benchexec.tools." + self.verifierName, fromlist=["Tool"]).Tool()
 
         if hasattr(self, "wrappedTool"):
             oldcwd = os.getcwd()

--- a/benchexec/tools/metaval.py
+++ b/benchexec/tools/metaval.py
@@ -66,16 +66,18 @@ class Tool(benchexec.tools.template.BaseTool):
 
         if hasattr(self, "wrappedTool"):
             with self.lock:
-                oldcwd = os.getcwd()
-                os.chdir(os.path.join(oldcwd, self.TOOL_TO_PATH_MAP[verifierName]))
-                wrappedOptions = self.wrappedTool.cmdline(
-                    self.wrappedTool.executable(),
-                    options,
-                    [os.path.relpath(os.path.join(oldcwd, "output/ARG.c"))],
-                    os.path.relpath(os.path.join(oldcwd, propertyfile)),
-                    rlimits,
-                )
-                os.chdir(oldcwd)
+                try:
+                    oldcwd = os.getcwd()
+                    os.chdir(os.path.join(oldcwd, self.TOOL_TO_PATH_MAP[verifierName]))
+                    wrappedOptions = self.wrappedTool.cmdline(
+                        self.wrappedTool.executable(),
+                        options,
+                        [os.path.relpath(os.path.join(oldcwd, "output/ARG.c"))],
+                        os.path.relpath(os.path.join(oldcwd, propertyfile)),
+                        rlimits,
+                    )
+                finally:
+                    os.chdir(oldcwd)
             return [
                 executable,
                 "--verifier",

--- a/benchexec/tools/metaval.py
+++ b/benchexec/tools/metaval.py
@@ -56,11 +56,12 @@ class Tool(benchexec.tools.template.BaseTool):
         witnessName = knownargs.witness
         with self.lock:
             if not hasattr(self, "wrappedTool"):
+                self.verifierName = verifierName
                 self.wrappedTool = __import__(
                     "benchexec.tools." + verifierName, fromlist=["Tool"]
                 ).Tool()
             else:
-                if not verifierName == self.wrappedTool.name().tolower():
+                if not verifierName == self.verifierName:
                     exit("metaval is called with mixed wrapped tools")
 
         if hasattr(self, "wrappedTool"):

--- a/benchexec/tools/metaval.py
+++ b/benchexec/tools/metaval.py
@@ -78,16 +78,18 @@ class Tool(benchexec.tools.template.BaseTool):
                     )
                 finally:
                     os.chdir(oldcwd)
-            return [
-                executable,
-                "--verifier",
-                self.TOOL_TO_PATH_MAP[verifierName],
-                "--witness",
-                witnessName,
-                *tasks,
-                "--",
-                *wrappedOptions,
-            ]
+            return (
+                [
+                    executable,
+                    "--verifier",
+                    self.TOOL_TO_PATH_MAP[verifierName],
+                    "--witness",
+                    witnessName,
+                ]
+                + tasks
+                + ["--"]
+                + wrappedOptions
+            )
         else:
             sys.exit("ERROR: Could not find wrapped tool")
 


### PR DESCRIPTION
metaval works by transforming the validation problem into a
reachability problem and then transparently delegates it to
a classical verifier. For now, there is support for validating
correctness witnesses with ESBMC and CPAchecker, but this will
later be extended to other verifiers with compatible license.