### PR TITLE
Improve and extend metaval tool-info module

### DIFF
--- a/benchexec/tools/metaval.py
+++ b/benchexec/tools/metaval.py
@@ -24,10 +24,21 @@ import benchexec.tools.template
 import benchexec.result as result
 import contextlib
 import os
+import sys
 import threading
 
 
 class Tool(benchexec.tools.template.BaseTool):
+    """
+    This is the tool info module for MetaVal.
+
+    The official repository is:
+    https://gitlab.com/sosy-lab/software/metaval
+
+    Please report any issues to our issue tracker at:
+    https://gitlab.com/sosy-lab/software/metaval/issues
+
+    """
 
     TOOL_TO_PATH_MAP = {
         "cpachecker-metaval": "CPAchecker",
@@ -98,7 +109,7 @@ class Tool(benchexec.tools.template.BaseTool):
                 ).Tool()
             else:
                 if not verifierName == self.verifierName:
-                    exit("metaval is called with mixed wrapped tools")
+                    sys.exit("metaval is called with mixed wrapped tools")
 
         if hasattr(self, "wrappedTool"):
             with self._in_tool_directory() as oldcwd:


### PR DESCRIPTION
There was a bug in the delegation of `determine_result`
to the wrapped tool. Some tools like Symbiotic determine the version
again in this step and need access to the binary again. If we do not
chdir into the wrapped tool's folder, the binary will not be found.

This PR also adds some configuration options. The first one is
needed for running older versions of wrapped tools which need Java 8
and therefore a custom entry in the PATH variable. The second one
will enable the tool user to ensure that only a certain type of
witness is checked.