### PR TITLE
Support provenance information to the benchmarking results; fixes #524

### DIFF
--- a/doc/result.dtd
+++ b/doc/result.dtd
@@ -1,4 +1,4 @@
-<!ELEMENT result (columns, systeminfo+, run*, column*)>
+<!ELEMENT result (provenance?, columns, systeminfo+, run*, column*)>
 <!ATTLIST result name CDATA #IMPLIED
                benchmarkname CDATA #REQUIRED
                displayName CDATA #IMPLIED
@@ -14,6 +14,7 @@
                generator CDATA #REQUIRED
                error CDATA #IMPLIED>
 
+<!ELEMENT provenance (#PCDATA)>
 <!ELEMENT systeminfo (os, cpu, ram, environment)>
 <!ATTLIST systeminfo hostname CDATA #IMPLIED>
 <!ELEMENT os EMPTY>


### PR DESCRIPTION
It is extremely important for replicability and credibility of results to log
- where the benchmarking results are coming from,
- how they were produced, and
- what other information is necessary to replicate the benchmark experiment.

This PR allows a field in the exchange format for benchmark results
that tells the reader more about the provenance.
Like a lab log-book entry.