### PR TITLE
Fix REQUIRED_PATHS for LibKluzzer

### DIFF
--- a/benchexec/tools/libkluzzer.py
+++ b/benchexec/tools/libkluzzer.py
@@ -26,7 +26,7 @@ class Tool(benchexec.tools.template.BaseTool):
     Tool info for LibKluzzer (http://unihb.eu/kluzzer).
     """
 
-    REQUIRED_PATHS = ["bin", "lib"]
+    REQUIRED_PATHS = ["bin", "lib", "kluzzer"]
 
     def program_files(self, executable):
         return self._program_files_from_executable(


### PR DESCRIPTION
@dbeyer I had a problem with the last two pre-runs that a directory from the zip archive was missing. Now I realize that possibly only paths specified in REQUIRED_PATHS will be copied for each single run. Can you please merge this and schedule a new pre-run for LibKluzzer using the current zip archive? Thanks!