### PR TITLE
Fix "list index out of range" error in metaval

### DIFF
--- a/benchexec/tools/metaval.py
+++ b/benchexec/tools/metaval.py
@@ -79,8 +79,8 @@ class Tool(benchexec.tools.template.BaseTool):
     def determine_result(self, returncode, returnsignal, output, isTimeout):
         verifierDir = None
         regex = re.compile("verifier used in MetaVal is (.*)")
-        for i in range(20):
-            match = regex.match(output[i])
+        for line in output[:20]:
+            match = regex.match(line)
             if match != None:
                 verifierDir = match.group(1)
                 break


### PR DESCRIPTION
Before it was able that the changed piece of code could lead to  an `IndexError` in case MetaVal is aborted before it can output the first few lines (or in case this output is not present for any other reason).