### PR TITLE
fix import of "util" for contrib-script.

### DIFF
--- a/contrib/plots/quantile-generator.py
+++ b/contrib/plots/quantile-generator.py
@@ -31,7 +31,7 @@ import benchexec.tablegenerator as tablegenerator
 
 sys.dont_write_bytecode = True  # prevent creation of .pyc files
 
-Util = tablegenerator.Util
+util = tablegenerator.util
 
 
 def get_extract_value_function(column_identifier):
@@ -47,7 +47,7 @@ def get_extract_value_function(column_identifier):
                 break
         if pos is None:
             sys.exit("CPU time missing for task {0}.".format(run_result.task_id[0]))
-        return Util.to_decimal(run_result.values[pos])
+        return util.to_decimal(run_result.values[pos])
 
     return extract_value
 
@@ -164,7 +164,7 @@ def main(args=None):
         columns = itertools.chain(
             [index],
             (id for id, show in zip(run_result.id, relevant_id_columns) if show),
-            map(Util.remove_unit, (value or "" for value in run_result.values)),
+            map(util.remove_unit, (value or "" for value in run_result.values)),
         )
         print(*columns, sep="\t")
 


### PR DESCRIPTION
Without this fix, we get an exception:
<pre>
$> contrib/plots/quantile-generator.py
Traceback (most recent call last):
  File "benchexec/contrib/plots/quantile-generator.py", line 34, in <module>
    Util = tablegenerator.Util
AttributeError: module 'benchexec.tablegenerator' has no attribute 'Util'
</pre>