### PR TITLE
Increase width of status column in stdout of benchexec.

### DIFF
--- a/benchexec/outputhandler.py
+++ b/benchexec/outputhandler.py
@@ -68,7 +68,7 @@ if sys.stdout.isatty():
     elif _term.startswith("screen"):
         TERMINAL_TITLE = "\033kTask {0}\033\\"
 
-LEN_OF_STATUS = 22
+LEN_OF_STATUS = 25
 
 # the number of digits after the decimal separator for text output of time columns with times
 TIME_PRECISION = 2


### PR DESCRIPTION
Our status texts got longer in the last years, so it is time to increase the column width.
The text `false(valid-memcleanup)` has `23` chars, which is already larger than the existing limit of `22`.
For an example table, you can take a look at https://buildbot.sosy-lab.org/cpachecker/#/builders/18/builds/210/steps/4/logs/stdio ,
where the columns are slightly misaligned.