### PR TITLE
Add element to task-def that defines contextual information

### DIFF
--- a/doc/task-definition-example.yml
+++ b/doc/task-definition-example.yml
@@ -45,12 +45,12 @@ properties:
 context:
   # Example namespace
   com.github.sosy-lab.sv-benchmarks:
-      # Example field for this dict.
+      # Example context attribute in the above namespace:
       # Machine model the task definition is defined for.
       # Properties of this task definition are only guaranteed to be
       # valid on the input_files for the machine model specified here.
       #
-      # Values tools are expected to support: linux32, linux64
-      machine_model: linux32
+      # Values tools are expected to support: x86_32-unknown-linux, x86_64-unknown-linux
+      target_architecture: x86_32-unknown-linux
 
 # All other keys in the global dict and in the properties dict are reserved for future use.

--- a/doc/task-definition-example.yml
+++ b/doc/task-definition-example.yml
@@ -35,12 +35,17 @@ properties:
 # Optional, contains dict with key-value pairs that
 # provide additional information about the context of the task definition.
 # If given, benchexec will pass this information to the tool-info module.
+#
+# Keys and their values are not interpreted by benchexec and may differ between application areas.
+# Because of this, they should be namespaced to avoid naming conflicts
+# and put their intended meaning in context (no pun intended; see below for an example).
 context:
+  # Example field for this dict.
   # Machine model the task definition is defined for.
   # Properties of this task definition are only guaranteed to be
   # valid on the input_files for the machine model specified here.
   #
   # Values tools are expected to support: linux32 and linux64
-  - machine_model: linux32
+  - com.github.sosy-lab.sv-benchmarks.machine_model: linux32
 
 # All other keys in the global dict and in the properties dict are reserved for future use.

--- a/doc/task-definition-example.yml
+++ b/doc/task-definition-example.yml
@@ -5,8 +5,8 @@
 #
 # SPDX-License-Identifier: Apache-2.0
 
-# Required, string with format version of this file (currently only "1.0")
-format_version: "1.0"
+# Required, string with format version of this file
+format_version: "1.1"
 
 # Required, either a string or a list of strings with file-name patterns.
 # Relative paths interpreted as relative to this file.
@@ -31,5 +31,16 @@ properties:
     subproperty: valid-deref                     # optional string, contains violated subproperty
   - property_file: ../test/tasks/other.prp
     expected_verdict: true
+
+# Optional, contains dict with key-value pairs that
+# provide additional information about the context of the task definition.
+# If given, benchexec will pass this information to the tool.
+context:
+  # Machine model the task definition is defined for.
+  # Properties of this task definition are only guaranteed to be
+  # valid on the input_files for the machine model specified here.
+  #
+  # Values tools are expected to support: intel32 and intel64
+  - machine_model: intel32
 
 # All other keys in the global dict and in the properties dict are reserved for future use.

--- a/doc/task-definition-example.yml
+++ b/doc/task-definition-example.yml
@@ -32,20 +32,25 @@ properties:
   - property_file: ../test/tasks/other.prp
     expected_verdict: true
 
-# Optional, contains dict with key-value pairs that
-# provide additional information about the context of the task definition.
+# Optional, contains dict that provides additional information
+# about the context of the task definition.
 # If given, benchexec will pass this information to the tool-info module.
 #
-# Keys and their values are not interpreted by benchexec and may differ between application areas.
-# Because of this, they should be namespaced to avoid naming conflicts
-# and put their intended meaning in context (no pun intended; see below for an example).
+# Each key in the dict defines a namespace for context attributes.
+# Each namespace contains another dict with key-value pairs in that namespace.
+# These key-value pairs describe the concrete context.
+#
+# Namespaces, context attributes and their values are not interpreted by benchexec
+# and may differ between application areas.
 context:
-  # Example field for this dict.
-  # Machine model the task definition is defined for.
-  # Properties of this task definition are only guaranteed to be
-  # valid on the input_files for the machine model specified here.
-  #
-  # Values tools are expected to support: linux32 and linux64
-  com.github.sosy-lab.sv-benchmarks.machine_model: linux32
+  # Example namespace
+  com.github.sosy-lab.sv-benchmarks:
+      # Example field for this dict.
+      # Machine model the task definition is defined for.
+      # Properties of this task definition are only guaranteed to be
+      # valid on the input_files for the machine model specified here.
+      #
+      # Values tools are expected to support: linux32, linux64
+      machine_model: linux32
 
 # All other keys in the global dict and in the properties dict are reserved for future use.

--- a/doc/task-definition-example.yml
+++ b/doc/task-definition-example.yml
@@ -40,7 +40,7 @@ context:
   # Properties of this task definition are only guaranteed to be
   # valid on the input_files for the machine model specified here.
   #
-  # Values tools are expected to support: intel32 and intel64
-  - machine_model: intel32
+  # Values tools are expected to support: linux32 and linux64
+  - machine_model: linux32
 
 # All other keys in the global dict and in the properties dict are reserved for future use.

--- a/doc/task-definition-example.yml
+++ b/doc/task-definition-example.yml
@@ -32,25 +32,24 @@ properties:
   - property_file: ../test/tasks/other.prp
     expected_verdict: true
 
-# Optional, contains dict that provides additional information
-# that is not interpreted by benchexec.
-# If given, benchexec will pass this information to the tool-info module.
+# Optional data structure with arbitrary additional information or context
+# about the task that is not interpreted by benchexec itself.
+# However, benchexec will pass any content of this key to the tool-info module.
+# This can be used for example to define options that the tool needs to know
+# in order to correctly interpret the task, for example the format or language
+# of the input files.
 #
-# Each key in the dict defines a namespace for additional information.
-# Each namespace contains another dict with key-value pairs in that namespace.
-# These key-value pairs describe the concrete, additional information.
-#
-# Namespaces, additional information and their values are not interpreted by benchexec
-# and may differ between application areas.
-additional_information:
+# Apart from being valid YAML, benchexec does not impose any restrictions
+# on the content of this key. However, it is recommended to use a dict of dicts
+# as content in order to avoid confusion and conflicts between the data used by
+# different communities and application areas. The outer dict would contain keys
+# whose names form globally unique namespaces, and each inner dict would contain
+# the data for one use case, defined by some user community
+# (similar to how XML namespaces are used).
+options:
   # Example namespace
-  com.github.sosy-lab.sv-benchmarks:
-      # Example information in the above namespace:
-      # Machine model the task definition is defined for.
-      # Properties of this task definition are only guaranteed to be
-      # valid on the input_files for the machine model specified here.
-      #
-      # Values tools are expected to support: x86_32-unknown-linux, x86_64-unknown-linux
-      target_architecture: x86_32-unknown-linux
+  com.example:
+    # Definition of data here should be available on https://example.com
+    some_key: some_data
 
 # All other keys in the global dict and in the properties dict are reserved for future use.

--- a/doc/task-definition-example.yml
+++ b/doc/task-definition-example.yml
@@ -46,6 +46,6 @@ context:
   # valid on the input_files for the machine model specified here.
   #
   # Values tools are expected to support: linux32 and linux64
-  - com.github.sosy-lab.sv-benchmarks.machine_model: linux32
+  com.github.sosy-lab.sv-benchmarks.machine_model: linux32
 
 # All other keys in the global dict and in the properties dict are reserved for future use.

--- a/doc/task-definition-example.yml
+++ b/doc/task-definition-example.yml
@@ -33,19 +33,19 @@ properties:
     expected_verdict: true
 
 # Optional, contains dict that provides additional information
-# about the context of the task definition.
+# that is not interpreted by benchexec.
 # If given, benchexec will pass this information to the tool-info module.
 #
-# Each key in the dict defines a namespace for context attributes.
+# Each key in the dict defines a namespace for additional information.
 # Each namespace contains another dict with key-value pairs in that namespace.
-# These key-value pairs describe the concrete context.
+# These key-value pairs describe the concrete, additional information.
 #
-# Namespaces, context attributes and their values are not interpreted by benchexec
+# Namespaces, additional information and their values are not interpreted by benchexec
 # and may differ between application areas.
-context:
+additional_information:
   # Example namespace
   com.github.sosy-lab.sv-benchmarks:
-      # Example context attribute in the above namespace:
+      # Example information in the above namespace:
       # Machine model the task definition is defined for.
       # Properties of this task definition are only guaranteed to be
       # valid on the input_files for the machine model specified here.

--- a/doc/task-definition-example.yml
+++ b/doc/task-definition-example.yml
@@ -34,7 +34,7 @@ properties:
 
 # Optional, contains dict with key-value pairs that
 # provide additional information about the context of the task definition.
-# If given, benchexec will pass this information to the tool.
+# If given, benchexec will pass this information to the tool-info module.
 context:
   # Machine model the task definition is defined for.
   # Properties of this task definition are only guaranteed to be


### PR DESCRIPTION
*This PR is marked as WIP to get initial feedback on the proposed naming and structuring.*

This PR adds a new entry 'additional_information' to the task definition.

'additional_information' contains a dict of dicts that can contain further
information about the task definition.

**Example:**
The following entry may tell users about the target architecture of the task:

```json
additional_information:
    com.github.sosy-lab.sv-benchmarks:
        target_architecture: x86_32-unknown-linux
```

Comments and feedback are welcome!

## To-Dos

- [ ] Decide on name for target architecture/machine model
- [ ] Decide on names for target architecture values
- [ ] Move discussion whether tasks should also get an entry for the compiler version expected to sv-benchmarks