### PR TITLE
Add parameter --tool-directory to benchexec

### DIFF
--- a/benchexec/benchexec.py
+++ b/benchexec/benchexec.py
@@ -126,6 +126,14 @@ class BenchExec(object):
         )
 
         parser.add_argument(
+            "--tool-directory",
+            help="Use benchmarked tool from given directory "
+            "instead of looking in PATH and the current directory",
+            metavar="DIR",
+            type=util.non_empty_str,
+        )
+
+        parser.add_argument(
             "-n",
             "--name",
             dest="name",

--- a/benchexec/localexecution.py
+++ b/benchexec/localexecution.py
@@ -20,6 +20,7 @@ from benchexec import resources
 from benchexec.runexecutor import RunExecutor
 from benchexec.pqos import Pqos
 from benchexec import systeminfo
+from benchexec import tooladapter
 from benchexec import util
 from benchexec.intel_cpu_energy import EnergyMeasurement
 
@@ -43,7 +44,8 @@ def init(config, benchmark):
             )
     config.containerargs["use_namespaces"] = config.container
 
-    benchmark.executable = benchmark.tool.executable()
+    tool_locator = tooladapter.create_tool_locator(config)
+    benchmark.executable = benchmark.tool.executable(tool_locator)
     benchmark.tool_version = benchmark.tool.version(benchmark.executable)
 
 

--- a/benchexec/test_tool_info.py
+++ b/benchexec/test_tool_info.py
@@ -17,6 +17,7 @@ import yaml
 import benchexec
 import benchexec.benchexec
 from benchexec import model
+from benchexec import tooladapter
 from benchexec import util
 from benchexec.tooladapter import CURRENT_BASETOOL
 import benchexec.tools.template
@@ -116,13 +117,13 @@ def log_if_unsupported(msg):
         )
 
 
-def print_tool_info(tool):
+def print_tool_info(tool, tool_locator):
     """Print standard info from tool-info module"""
     print_multiline_text("Documentation of tool module", inspect.getdoc(tool))
 
     print_value("Name of tool", tool.name())
 
-    executable = tool.executable()
+    executable = tool.executable(tool_locator)
     print_value("Executable", executable)
     if not os.path.isabs(executable):
         print_value("Executable (absolute path)", os.path.abspath(executable))
@@ -137,6 +138,11 @@ def print_tool_info(tool):
         logging.warning("Designated executable does not exist.")
     elif not os.access(executable, os.X_OK):
         logging.warning("Designated executable is not marked as executable.")
+    if tool_locator.tool_directory:
+        abs_directory = os.path.abspath(tool_locator.tool_directory)
+        abs_executable = os.path.abspath(executable)
+        if not os.path.commonpath((abs_directory, abs_executable)) == abs_directory:
+            logging.warning("Executable is not within specified tool directory.")
 
     try:
         print_value("Version", tool.version(executable))
@@ -328,6 +334,12 @@ def main(argv=None):
     )
     parser.add_argument("tool", metavar="TOOL", help="name of tool info to test")
     parser.add_argument(
+        "--tool-directory",
+        help="look for tool in given directory",
+        metavar="DIR",
+        type=benchexec.util.non_empty_str,
+    )
+    parser.add_argument(
         "--tool-output",
         metavar="OUTPUT_FILE",
         nargs="+",
@@ -348,13 +360,14 @@ def main(argv=None):
     logging.basicConfig(
         format=COLOR_WARNING + "%(levelname)s: %(message)s" + COLOR_DEFAULT
     )
+    tool_locator = tooladapter.create_tool_locator(options)
 
     print_value("Name of tool module", options.tool)
     try:
         tool_module, tool = model.load_tool_info(options.tool, options)
         try:
             print_value("Full name of tool module", tool_module)
-            executable = print_tool_info(tool)
+            executable = print_tool_info(tool, tool_locator)
             print_standard_task_cmdlines(tool, executable)
             for task_def_file in options.task_definition:
                 print_task_cmdline(tool, executable, task_def_file)
@@ -366,7 +379,7 @@ def main(argv=None):
             tool.close()
 
     except benchexec.BenchExecException as e:
-        sys.exit(str(e))
+        sys.exit("Error: " + str(e))
 
 
 if __name__ == "__main__":

--- a/benchexec/tooladapter.py
+++ b/benchexec/tooladapter.py
@@ -13,7 +13,7 @@ This is an internal module for BenchExec and not to be used by tool-info modules
 
 import inspect
 
-from benchexec.tools.template import BaseTool, BaseTool2
+from benchexec.tools.template import BaseTool, BaseTool2, ToolNotFoundException
 
 import benchexec.model
 
@@ -31,7 +31,6 @@ class Tool1To2:
     """
 
     _FORWARDED_METHODS = [
-        "executable",
         "program_files",
         "version",
         "name",
@@ -50,6 +49,22 @@ class Tool1To2:
             setattr(self, method, getattr(wrapped, method))
 
         self.__doc__ = inspect.getdoc(wrapped)
+
+    def executable(self, tool_locator):
+        if tool_locator.tool_directory:
+            raise ToolNotFoundException(
+                "Tool-info module for {} does not support parameter --tool-directory. "
+                "Instead, you can add the tool to PATH, "
+                "execute benchexec from the tool directory, "
+                "or upgrade the tool-info module.".format(self.name())
+            )
+
+        assert tool_locator.use_path and tool_locator.use_current
+        # This is the behavior that old tool-info modules are expected to have.
+        try:
+            return self._wrapped.executable()
+        except SystemExit as e:
+            raise ToolNotFoundException(str(e)) from e
 
     def cmdline(self, executable, options, task, rlimits):
         rlimits_dict = {}
@@ -90,3 +105,14 @@ def adapt_to_current_version(tool):
             "{} is not a subclass of one of the expected base classes "
             "in benchexec.tools.template".format(tool.__class__)
         )
+
+
+def create_tool_locator(config):
+    """
+    Create an instance of ToolLocator with the standard behavior based on the given
+    command-line options.
+    """
+    if config.tool_directory:
+        return CURRENT_BASETOOL.ToolLocator(tool_directory=config.tool_directory)
+    else:
+        return CURRENT_BASETOOL.ToolLocator(use_path=True, use_current=True)

--- a/benchexec/tools/template.py
+++ b/benchexec/tools/template.py
@@ -27,6 +27,14 @@ import benchexec.result as result
 import benchexec.util as util
 
 
+class ToolNotFoundException(benchexec.BenchExecException):
+    """
+    Raised when a tool's executable cannot be found.
+    """
+
+    pass
+
+
 class UnsupportedFeatureException(benchexec.BenchExecException):
     """
     Raised when a tool or its tool-info module does not support a requested feature.
@@ -75,15 +83,16 @@ class BaseTool2(object, metaclass=ABCMeta):
         raise NotImplementedError()
 
     @abstractmethod
-    def executable(self):
+    def executable(self, tool_locator):
         """
         Find the path to the executable file that will get executed.
         This method always needs to be overridden,
         and should typically delegate to our utility method find_executable. Example:
 
-        return benchexec.util.find_executable("mytool")
+        return tool_locator.find_executable("mytool")
 
         The path returned should be relative to the current directory.
+        @param tool_locator: an instance of class ToolLocator
         @return a string pointing to an executable file
         """
         raise NotImplementedError()
@@ -293,6 +302,52 @@ class BaseTool2(object, metaclass=ABCMeta):
         """
 
     # Classes that are used in parameters above
+
+    class ToolLocator(
+        namedtuple("ToolLocator", ["tool_directory", "use_path", "use_current"])
+    ):
+        def find_executable(self, executable_name, subdir=""):
+            assert (
+                os.path.basename(executable_name) == executable_name
+            ), "Executable needs to be a simple file name"
+            dirs = []
+            if self.tool_directory:
+                # join automatically handles the case where subdir is the empty string
+                dirs.append(os.path.join(self.tool_directory, subdir))
+            if self.use_path:
+                dirs.extend(benchexec.util.get_path())
+            if self.use_current:
+                dirs.append(os.curdir)
+                if subdir:
+                    dirs.append(subdir)
+
+            executable = benchexec.util.find_executable2(executable_name, dirs)
+            if executable:
+                return executable
+
+            other_file = benchexec.util.find_executable2(executable_name, dirs, os.F_OK)
+            if other_file:
+                raise ToolNotFoundException(
+                    "Could not find executable '{}', but found file '{}' "
+                    "that is not executable.".format(executable_name, other_file)
+                )
+
+            msg = "Could not find executable '{}'. The searched directories were: {}".format(
+                executable_name, "".join("\n  " + d for d in dirs)
+            )
+            if not self.tool_directory:
+                msg += "\nYou can specify the tool's directory with --tool-directory."
+
+            raise ToolNotFoundException(msg)
+
+        def __new__(cls, tool_directory=None, use_path=False, use_current=False):
+            """
+            Create instance. All parameters have default values that do nothing and
+            at least one parameter needs to be given, otherwise the instance could not
+            do anything.
+            """
+            assert tool_directory or use_path or use_current
+            return super().__new__(cls, tool_directory, use_path, use_current)
 
     class Task(
         namedtuple(

--- a/benchexec/util.py
+++ b/benchexec/util.py
@@ -9,6 +9,7 @@
 This module contains some useful functions for Strings, XML or Lists.
 """
 
+import argparse
 import collections
 import datetime
 import errno
@@ -221,6 +222,14 @@ def parse_timespan_value(s):
         raise ValueError("unknown unit: {} (allowed are s, min, h, and d)".format(unit))
 
 
+def non_empty_str(s):
+    """Utility for requiring a non-empty string value as command-line parameter."""
+    s = str(s)
+    if not s:
+        raise argparse.ArgumentTypeError("empty string not allowed")
+    return s
+
+
 def expand_filename_pattern(pattern, base_dir):
     """
     Expand a file name pattern containing wildcards, environment variables etc.
@@ -295,14 +304,14 @@ def find_executable(program, fallback=None, exitOnError=True, use_current_dir=Tr
     if exitOnError:
         if found_non_executable:
             sys.exit(  # noqa: R503 always raises
-                "ERROR: Could not find '{0}' executable, "
+                "Could not find '{0}' executable, "
                 "but found file '{1}' that is not executable.".format(
                     program, found_non_executable[0]
                 )
             )
         else:
             sys.exit(  # noqa: R503 always raises
-                "ERROR: Could not find '{0}' executable.".format(program)
+                "Could not find '{0}' executable.".format(program)
             )
     else:
         return fallback

--- a/doc/tool-integration.md
+++ b/doc/tool-integration.md
@@ -20,9 +20,13 @@ Simply use the name of the tool-info module (without `.py` suffix)
 as the value of the `tool` attribute of the `<benchmark>` tag.
 
 Note that BenchExec needs to be able to find the executable of the tool, of course.
-By default, it searches in the directories of the `PATH` environment variable and in the current directory.
-Thus the easiest way is to run BenchExec directly inside the directory of the tool,
-or to adjust `PATH` accordingly:
+The easiest way to achieve this is to specify the directory of the tool
+with the parameter `--tool-directory` on the command line.
+If this parameter is not given,
+BenchExec searches in the directories of the `PATH` environment variable
+and in the current directory.
+Thus one can also execute BenchExec directly inside the directory of the tool,
+or adjust `PATH` accordingly:
 
     PATH=/path/to/tool/directory:$PATH benchexec ...
 


### PR DESCRIPTION
This allows to specify the directory of the benchmarked tool easily without having to resort to workarounds like changing PATH.

It needs changes to the tool-info API, so it can only be done on top of #592 and will work only with new or upgraded tool-info modules.