### PR TITLE
Improve signature of determine_result and provide run options

### DIFF
--- a/benchexec/model.py
+++ b/benchexec/model.py
@@ -1072,7 +1072,7 @@ class Run(object):
         assert (
             self.runSet.benchmark.executable is not None
         ), "executor needs to set tool executable"
-        return cmdline_for_run(
+        self._cmdline = cmdline_for_run(
             self.runSet.benchmark.tool,
             self.runSet.benchmark.executable,
             self.options,
@@ -1082,6 +1082,7 @@ class Run(object):
             self.task_options,
             self.runSet.benchmark.rlimits,
         )
+        return self._cmdline
 
     def set_result(self, values, visible_columns={}):
         """Set the result of this run.
@@ -1145,7 +1146,9 @@ class Run(object):
         if exitcode is not None:
             logging.debug("My subprocess returned %s.", exitcode)
             tool_status = self.runSet.benchmark.tool.determine_result(
-                tooladapter.CURRENT_BASETOOL.Run(exitcode, output, termination_reason)
+                tooladapter.CURRENT_BASETOOL.Run(
+                    self._cmdline, exitcode, output, termination_reason
+                )
             )
 
             if tool_status in result.RESULT_LIST_OTHER:

--- a/benchexec/model.py
+++ b/benchexec/model.py
@@ -1144,9 +1144,8 @@ class Run(object):
         tool_status = None
         if exitcode is not None:
             logging.debug("My subprocess returned %s.", exitcode)
-            isTimeout = termination_reason in ["cputime", "cputime-soft", "walltime"]
             tool_status = self.runSet.benchmark.tool.determine_result(
-                exitcode, output, isTimeout
+                tooladapter.CURRENT_BASETOOL.Run(exitcode, output, termination_reason)
             )
 
             if tool_status in result.RESULT_LIST_OTHER:

--- a/benchexec/model.py
+++ b/benchexec/model.py
@@ -1151,7 +1151,7 @@ class Run(object):
         if exitcode is not None:
             logging.debug("My subprocess returned %s.", exitcode)
             tool_status = self.runSet.benchmark.tool.determine_result(
-                exitcode.value or 0, exitcode.signal or 0, output, isTimeout
+                exitcode, output, isTimeout
             )
 
             if tool_status in result.RESULT_LIST_OTHER:

--- a/benchexec/model.py
+++ b/benchexec/model.py
@@ -1122,6 +1122,7 @@ class Run(object):
         except OSError as e:
             logging.warning("Cannot read log file: %s", e.strerror)
             output = []
+        output = tooladapter.CURRENT_BASETOOL.RunOutput(output)
 
         self.status = self._analyze_result(exitcode, output, termination_reason)
         self.category = result.get_result_category(

--- a/benchexec/model.py
+++ b/benchexec/model.py
@@ -1143,10 +1143,7 @@ class Run(object):
         tool_status = None
         if exitcode is not None:
             logging.debug("My subprocess returned %s.", exitcode)
-            isTimeout = (
-                termination_reason in ["cputime", "cputime-soft", "walltime"]
-                or self._is_timeout()
-            )
+            isTimeout = termination_reason in ["cputime", "cputime-soft", "walltime"]
             tool_status = self.runSet.benchmark.tool.determine_result(
                 exitcode, output, isTimeout
             )

--- a/benchexec/test_analyze_run_result.py
+++ b/benchexec/test_analyze_run_result.py
@@ -47,7 +47,7 @@ class TestResult(unittest.TestCase):
         runSet.benchmark.rlimits = {}
         runSet.benchmark.tool = BaseTool()
 
-        def determine_result(self, returncode, returnsignal, output, isTimeout=False):
+        def determine_result(self, exit_code, output, isTimeout=False):
             return info_result
 
         runSet.benchmark.tool.determine_result = determine_result

--- a/benchexec/test_analyze_run_result.py
+++ b/benchexec/test_analyze_run_result.py
@@ -52,13 +52,15 @@ class TestResult(unittest.TestCase):
 
         runSet.benchmark.tool.determine_result = determine_result
 
-        return Run(
+        run = Run(
             identifier="test.c",
             sourcefiles=["test.c"],
             task_options=None,
             fileOptions=[],
             runSet=runSet,
         )
+        run._cmdline = ["dummy.bin", "test.c"]
+        return run
 
     def test_simple(self):
         run = self.create_run(info_result=RESULT_UNKNOWN)

--- a/benchexec/test_analyze_run_result.py
+++ b/benchexec/test_analyze_run_result.py
@@ -47,7 +47,7 @@ class TestResult(unittest.TestCase):
         runSet.benchmark.rlimits = {}
         runSet.benchmark.tool = BaseTool()
 
-        def determine_result(self, exit_code, output, isTimeout=False):
+        def determine_result(run):
             return info_result
 
         runSet.benchmark.tool.determine_result = determine_result

--- a/benchexec/test_tool_info.py
+++ b/benchexec/test_tool_info.py
@@ -298,8 +298,9 @@ def analyze_tool_output(tool, file):
         return
 
     try:
+        exit_code = util.ProcessExitCode.create(value=0)
         result = tool.determine_result(
-            returncode=0, returnsignal=0, output=output, isTimeout=False
+            exit_code=exit_code, output=output, isTimeout=False
         )
         print_value(
             "Result of analyzing tool output in “" + file.name + "”",

--- a/benchexec/test_tool_info.py
+++ b/benchexec/test_tool_info.py
@@ -260,6 +260,9 @@ def print_standard_task_cmdlines(tool, executable):
         )
         print_list("Command line CPU-time limit", cmdline)
 
+    # This will return the last command line that did not trigger an exception
+    return cmdline
+
 
 def print_task_cmdline(tool, executable, task_def_file):
     """Print command lines resulting for tasks from the given task-definition file."""
@@ -296,7 +299,7 @@ def print_task_cmdline(tool, executable, task_def_file):
             print_cmdline("with property " + property_file, property_file)
 
 
-def analyze_tool_output(tool, file):
+def analyze_tool_output(tool, file, dummy_cmdline):
     try:
         output = file.readlines()
     except (OSError, UnicodeDecodeError) as e:
@@ -306,7 +309,7 @@ def analyze_tool_output(tool, file):
     try:
         exit_code = util.ProcessExitCode.create(value=0)
         output = CURRENT_BASETOOL.RunOutput(output)
-        run = CURRENT_BASETOOL.Run(exit_code, output, None)
+        run = CURRENT_BASETOOL.Run(dummy_cmdline, exit_code, output, None)
         result = tool.determine_result(run)
         print_value(
             "Result of analyzing tool output in “" + file.name + "”",
@@ -369,13 +372,13 @@ def main(argv=None):
         try:
             print_value("Full name of tool module", tool_module)
             executable = print_tool_info(tool, tool_locator)
-            print_standard_task_cmdlines(tool, executable)
+            dummy_cmdline = print_standard_task_cmdlines(tool, executable)
             for task_def_file in options.task_definition:
                 print_task_cmdline(tool, executable, task_def_file)
 
             if options.tool_output:
                 for file in options.tool_output:
-                    analyze_tool_output(tool, file)
+                    analyze_tool_output(tool, file, dummy_cmdline)
         finally:
             tool.close()
 

--- a/benchexec/test_tool_info.py
+++ b/benchexec/test_tool_info.py
@@ -299,6 +299,7 @@ def analyze_tool_output(tool, file):
 
     try:
         exit_code = util.ProcessExitCode.create(value=0)
+        output = CURRENT_BASETOOL.RunOutput(output)
         result = tool.determine_result(
             exit_code=exit_code, output=output, isTimeout=False
         )

--- a/benchexec/test_tool_info.py
+++ b/benchexec/test_tool_info.py
@@ -300,9 +300,8 @@ def analyze_tool_output(tool, file):
     try:
         exit_code = util.ProcessExitCode.create(value=0)
         output = CURRENT_BASETOOL.RunOutput(output)
-        result = tool.determine_result(
-            exit_code=exit_code, output=output, isTimeout=False
-        )
+        run = CURRENT_BASETOOL.Run(exit_code, output, None)
+        result = tool.determine_result(run)
         print_value(
             "Result of analyzing tool output in “" + file.name + "”",
             result,

--- a/benchexec/tooladapter.py
+++ b/benchexec/tooladapter.py
@@ -73,9 +73,12 @@ class Tool1To2:
             rlimits_dict,
         )
 
-    def determine_result(self, exit_code, output, isTimeout):
+    def determine_result(self, run):
         return self._wrapped.determine_result(
-            exit_code.value or 0, exit_code.signal or 0, output._lines, isTimeout
+            run.exit_code.value or 0,
+            run.exit_code.signal or 0,
+            run.output._lines,
+            run.was_timeout,
         )
 
     def get_value_from_output(self, output, identifier):

--- a/benchexec/tooladapter.py
+++ b/benchexec/tooladapter.py
@@ -35,7 +35,6 @@ class Tool1To2:
         "program_files",
         "version",
         "name",
-        "get_value_from_output",
         "working_directory",
         "environment",
     ]
@@ -76,8 +75,11 @@ class Tool1To2:
 
     def determine_result(self, exit_code, output, isTimeout):
         return self._wrapped.determine_result(
-            exit_code.value or 0, exit_code.signal or 0, output, isTimeout
+            exit_code.value or 0, exit_code.signal or 0, output._lines, isTimeout
         )
+
+    def get_value_from_output(self, output, identifier):
+        return self._wrapped.get_value_from_output(output._lines, identifier)
 
 
 def adapt_to_current_version(tool):

--- a/benchexec/tooladapter.py
+++ b/benchexec/tooladapter.py
@@ -35,7 +35,6 @@ class Tool1To2:
         "program_files",
         "version",
         "name",
-        "determine_result",
         "get_value_from_output",
         "working_directory",
         "environment",
@@ -73,6 +72,11 @@ class Tool1To2:
             list(task.input_files_or_identifier),
             task.property_file,
             rlimits_dict,
+        )
+
+    def determine_result(self, exit_code, output, isTimeout):
+        return self._wrapped.determine_result(
+            exit_code.value or 0, exit_code.signal or 0, output, isTimeout
         )
 
 

--- a/benchexec/tools/template.py
+++ b/benchexec/tools/template.py
@@ -457,7 +457,9 @@ class BaseTool2(object, metaclass=ABCMeta):
                 cls, cputime, cputime_hard, walltime, memory, cpu_cores
             )
 
-    class Run(namedtuple("Run", ["exit_code", "output", "termination_reason"])):
+    class Run(
+        namedtuple("Run", ["cmdline", "exit_code", "output", "termination_reason"])
+    ):
         """
         Represent a run (one tool execution) and its result. While this class is
         technically a tuple, this should be seen as an implementation detail
@@ -472,6 +474,10 @@ class BaseTool2(object, metaclass=ABCMeta):
             (cf. https://github.com/sosy-lab/benchexec/blob/master/doc/run-results.md,
             useful to distinguish between program killed because of error and timeout)
         """
+
+        def __new__(cls, cmdline, exit_code, output, termination_reason):
+            cmdline = tuple(cmdline)  # make cmdline immutable
+            return super().__new__(cls, cmdline, exit_code, output, termination_reason)
 
         @property
         def was_terminated(self):

--- a/benchexec/tools/template.py
+++ b/benchexec/tools/template.py
@@ -501,13 +501,14 @@ class BaseTool2(object, metaclass=ABCMeta):
         This class is basically an immutable list of strings
         and supports all the usual list operations (indexing, iterating, etc.)
         as well as a few other utility methods.
+        Each list entry is one line of the tool's output without line separator.
         """
 
         @property
         def text(self):
             """Return the full output as a single string (with line separators)."""
             if self._text is None:
-                self._text = os.linesep.join(self._lines)
+                self._text = "".join(self._lines)
             return self._text
 
         def any_line_contains(self, substr):
@@ -516,11 +517,13 @@ class BaseTool2(object, metaclass=ABCMeta):
             return any(substr in line for line in self._lines)
 
         def __init__(self, lines):
+            # We keep the original line separators in _lines because then we can
+            # recreate _text exactly and it makes tooladapter.Tool1To2's job easier.
             self._lines = lines
             self._text = None
 
         def __getitem__(self, index):
-            return self._lines[index]
+            return self._lines[index].rstrip(os.linesep)
 
         def __len__(self):
             return len(self._lines)

--- a/benchexec/tools/template.py
+++ b/benchexec/tools/template.py
@@ -467,6 +467,7 @@ class BaseTool2(object, metaclass=ABCMeta):
         New fields may be added in the future.
 
         Explanation of files:
+        @param cmdline: command line as executed (as sequence of strings)
         @param exit_code: an instance of class benchexec.util.ProcessExitCode
             (contains return code or the signal that led to termination)
         @param output: the output of the tool as instance of class RunOutput

--- a/benchexec/tools/template.py
+++ b/benchexec/tools/template.py
@@ -403,14 +403,35 @@ class BaseTool2(object, metaclass=ABCMeta):
             )
 
     class Run(namedtuple("Run", ["exit_code", "output", "termination_reason"])):
+        """
+        Represent a run (one tool execution) and its result. While this class is
+        technically a tuple, this should be seen as an implementation detail
+        and the order of elements in the tuple should not be considered.
+        New fields may be added in the future.
+
+        Explanation of files:
+        @param exit_code: an instance of class benchexec.util.ProcessExitCode
+            (contains return code or the signal that led to termination)
+        @param output: the output of the tool as instance of class RunOutput
+        @param termination_reason: reason why BenchExec terminated the run, if any
+            (cf. https://github.com/sosy-lab/benchexec/blob/master/doc/run-results.md,
+            useful to distinguish between program killed because of error and timeout)
+        """
+
         @property
         def was_terminated(self):
-            """Returns whether the tool was terminated by BenchExec due to limits."""
+            """
+            Returns whether the tool was terminated by BenchExec due to a violation
+            of a resource limit or some other reason.
+            """
             return bool(self.termination_reason)
 
         @property
         def was_timeout(self):
-            """Returns whether the tool was terminated by BenchExec due to limits."""
+            """
+            Returns whether the tool was terminated by BenchExec due to a violation
+            of some time limit.
+            """
             return self.termination_reason in ["cputime", "cputime-soft", "walltime"]
 
     class RunOutput(collections.abc.Sequence):

--- a/benchexec/tools/template.py
+++ b/benchexec/tools/template.py
@@ -261,7 +261,7 @@ class BaseTool2(object, metaclass=ABCMeta):
         """
         return [executable, *options, *task.input_files_or_identifier]
 
-    def determine_result(self, returncode, returnsignal, output, isTimeout):
+    def determine_result(self, exit_code, output, isTimeout):
         """
         Parse the output of the tool and extract the verification result.
         If the tool gave a result, this method needs to return one of the
@@ -273,8 +273,7 @@ class BaseTool2(object, metaclass=ABCMeta):
         can be returned (this is also the default implementation).
         BenchExec will then automatically add some more information
         if the tool was killed due to a timeout, segmentation fault, etc.
-        @param returncode: the exit code of the program, 0 if the program was killed
-        @param returnsignal: the signal that killed the program, 0 if program exited itself
+        @param exit_code: an instance of class benchexec.util.ProcessExitCode
         @param output: a list of strings of output lines of the tool (both stdout and stderr)
         @param isTimeout: whether the result is a timeout
         (useful to distinguish between program killed because of error and timeout)


### PR DESCRIPTION
As requested in #166, some tool-info modules need the run command line in order to be able to properly parse the tool's output. This adds it together with a general improvement of what info is available to `determine_result`, like exit code and termination reason.

Differently from the discussion in #166 we provide not the `options` list that the `cmdline` method receives, but the full command line, similar to what is returned from `cmdline`. I think this is more helpful, and it should work equally well for the use cases mentioned in #166.

So far no other results like measurements are added because I see no need for that and it will be easy to add in the future (no breaking change due to parameter object).

The method `get_value_from_output` still does not get this information because it was never requested. But we pass the more convenient `RunOutput` object to it instead of a dumb list of strings for the output because we have it anyway.

@MartinSpiessl You requested this feature for MetaVal, is this implementation sufficient for you?