### PR TITLE
Add documentation for task-definitions in format 2.0; adjust version id

### DIFF
--- a/benchexec/model.py
+++ b/benchexec/model.py
@@ -44,7 +44,7 @@ _ERROR_RESULTS_FOR_TERMINATION_REASON = {
 _EXPECTED_RESULT_FILTER_VALUES = {True: "true", False: "false", None: "unknown"}
 _WARNED_ABOUT_UNSUPPORTED_EXPECTED_RESULT_FILTER = False
 
-_TASK_DEF_VERSIONS = frozenset(["0.1", "1.0", "1.1"])
+_TASK_DEF_VERSIONS = frozenset(["0.1", "1.0", "2.0"])
 
 
 def substitute_vars(oldList, runSet=None, task_file=None):
@@ -108,10 +108,10 @@ def load_task_definition_file(task_def_file):
             )
         )
 
-    if format_version != "1.1" and "options" in task_def:
+    if format_version != "2.0" and "options" in task_def:
         raise BenchExecException(
             "Task-definition file {} specifies invalid key 'options', "
-            "format_version needs to be at least 1.1 for this.".format(task_def_file)
+            "format_version needs to be at least 2.0 for this.".format(task_def_file)
         )
 
     return task_def

--- a/doc/benchexec.md
+++ b/doc/benchexec.md
@@ -83,7 +83,7 @@ The tag `<resultfiles>` inside the `<benchmark>` tag specifies
 (only supported if [container mode](container.md) is not turned off).
 
 ### Defining Tasks for BenchExec
-Typically tasks for `benchexec` correspond to an input file of the benchmarked tool.
+Typically, tasks for `benchexec` correspond to an input file of the benchmarked tool.
 The easiest way to specify tasks inside a `<tasks>` tag is with the `<include>` tag,
 which contains a file-name pattern.
 If the file-name patterns point to `.yml` files in the task-definition format of BenchExec,
@@ -114,7 +114,10 @@ Such files can be used to specify more complex tasks,
 such as tasks with several input files
 or tasks where BenchExec should compare the produced tool output against an expected result.
 The files need to be in [YAML format](http://yaml.org/) (which is a superset of JSON)
-and their structure is explained in our [example file doc/task-definition-example.yml](task-definition-example.yml).
+and their structure needs to adhere to the
+[task-definition format](https://gitlab.com/sosy-lab/software/task-definition-format)
+(cf. also our [example file doc/task-definition-example.yml](task-definition-example.yml)).
+BenchExec supports versions 1.0 and 2.0 of the format.
 For creating task-definition files for existing tasks
 that use the legacy way of encoding expected verdicts in the file name
 we provide a [helper script](../contrib/create_yaml_files.py).
@@ -135,6 +138,10 @@ with one of the values `true`, `false`, `unknown`,
 or `false(subproperty)` for some `subproperty`,
 `benchexec` will ignore tasks where the expected verdict
 that is declared in the task-definition file does not match.
+
+The `options` dictionary can optionally contain parameters or information about the task
+in an application-specified format.
+BenchExec passes the dictionary to tool-info modules as is, without further checks.
 
 ### Starting benchexec
 To use `benchexec`, simply call it with an XML file with a benchmark definition:

--- a/doc/task-definition-example.yml
+++ b/doc/task-definition-example.yml
@@ -5,6 +5,9 @@
 #
 # SPDX-License-Identifier: Apache-2.0
 
+# The official definition of this format is at
+# https://gitlab.com/sosy-lab/software/task-definition-format
+
 # Required, string with format version of this file
 format_version: "2.0"
 

--- a/doc/task-definition-example.yml
+++ b/doc/task-definition-example.yml
@@ -6,7 +6,7 @@
 # SPDX-License-Identifier: Apache-2.0
 
 # Required, string with format version of this file
-format_version: "1.1"
+format_version: "2.0"
 
 # Required, either a string or a list of strings with file-name patterns.
 # Relative paths interpreted as relative to this file.


### PR DESCRIPTION
This PR tries to help with upgrading to the [new task-definition format, version 2.0](https://gitlab.com/sosy-lab/software/task-definition-format).

- It was proposed to use version id 2.0 because the new format has major consequences in terms of compatibility considerations.
- Update documentation with a link to the task-definition project, and text explaining the new `options` dictionary.