### PR TITLE
Fix behavior of method Task.input_files_or_identifier

### DIFF
--- a/benchexec/tools/template.py
+++ b/benchexec/tools/template.py
@@ -425,7 +425,8 @@ class BaseTool2(object, metaclass=ABCMeta):
             Return either the sequence of input files or a one-element sequence with the
             identifier. Useful for adding either to the command line arguments.
             """
-            return self.input_files_or_empty or tuple(self.identifier)
+            # self.identifier can be a list or a String. We should avoid unpacking here.
+            return self.input_files_or_empty or (self.identifier,)
 
         def require_input_files(self):
             """

--- a/benchexec/tools/template.py
+++ b/benchexec/tools/template.py
@@ -425,7 +425,6 @@ class BaseTool2(object, metaclass=ABCMeta):
             Return either the sequence of input files or a one-element sequence with the
             identifier. Useful for adding either to the command line arguments.
             """
-            # self.identifier can be a list or a String. We should avoid unpacking here.
             return self.input_files_or_empty or (self.identifier,)
 
         def require_input_files(self):


### PR DESCRIPTION
I did not yet further test this fix. :-) Seems to work so far.