### PR TITLE
Fix missing folder while writing header to log

### DIFF
--- a/benchexec/filewriter.py
+++ b/benchexec/filewriter.py
@@ -4,6 +4,7 @@
 # SPDX-FileCopyrightText: 2007-2020 Dirk Beyer <https://www.sosy-lab.org>
 #
 # SPDX-License-Identifier: Apache-2.0
+from pathlib import Path
 
 
 class FileWriter(object):
@@ -16,7 +17,7 @@ class FileWriter(object):
         The constructor of FileWriter creates the file.
         If the file exist, it will be OVERWRITTEN without a message!
         """
-
+        Path(filename).parents[0].mkdir(parents=True, exist_ok=True)
         self._file = open(filename, "w")
         self._pos = None
         self.append(content)


### PR DESCRIPTION
I tried to use BenchExec for running some experiments, when I encountered the following error trace:
```
Traceback (most recent call last):
  File "../benchexec/bin/benchexec", line 27, in <module>
    sys.exit(benchexec.benchexec.main())
  File "../benchexec/bin/../benchexec/benchexec.py", line 478, in main
    sys.exit(benchexec.start(argv or sys.argv))
  File "../benchexec/bin/../benchexec/benchexec.py", line 73, in start
    rc = self.execute_benchmark(arg)
  File "../benchexec/bin/../benchexec/benchexec.py", line 343, in execute_benchmark
    output_handler = OutputHandler(
  File "../benchexec/bin/../benchexec/outputhandler.py", line 98, in __init__
    self.write_header_to_log(sysinfo)
  File "../benchexec/bin/../benchexec/outputhandler.py", line 307, in write_header_to_log
    self.txt_file = filewriter.FileWriter(txt_file_name, self.description)
  File "../benchexec/bin/../benchexec/filewriter.py", line 20, in __init__
    self._file = open(filename, "w")
FileNotFoundError: [Errno 2] No such file or directory:
```

It seems like the output handler writes to a folder before its creation. From my point of view, safeguarding the write command with the creation of parents folders, if they do not exist yet, seems a valid fix.