### PR TITLE
Add gazer-theta tool-info

### DIFF
--- a/benchexec/tools/gazer-theta.py
+++ b/benchexec/tools/gazer-theta.py
@@ -8,6 +8,7 @@
 import benchexec.result as result
 import benchexec.tools.template
 
+
 class Tool(benchexec.tools.template.BaseTool2):
     """
     Tool info for gazer-theta
@@ -40,7 +41,11 @@ class Tool(benchexec.tools.template.BaseTool2):
             elif "Result of gazer-theta run: TRUE" in line:
                 status = result.RESULT_TRUE_PROP
 
-        if not run.was_timeout and status == result.RESULT_UNKNOWN and run.exit_code.value != 0:
+        if (
+            not run.was_timeout
+            and status == result.RESULT_UNKNOWN
+            and run.exit_code.value != 0
+        ):
             status = result.RESULT_ERROR
 
         return status

--- a/benchexec/tools/gazer-theta.py
+++ b/benchexec/tools/gazer-theta.py
@@ -8,7 +8,6 @@
 import benchexec.result as result
 import benchexec.tools.template
 
-
 class Tool(benchexec.tools.template.BaseTool2):
     """
     Tool info for gazer-theta
@@ -17,10 +16,10 @@ class Tool(benchexec.tools.template.BaseTool2):
     https://github.com/ftsrg/theta
     """
 
-    REQUIRED_PATHS = ["gazer", "gazer/tools/gazer-bmc", "gazer/tools/gazer-theta"]
+    REQUIRED_PATHS = [".."]
 
     def executable(self, tool_locator):
-        return tool_locator.find_executable("gazer_starter.py", subdir="gazer/scripts")
+        return tool_locator.find_executable("gazer_starter.py", subdir="scripts")
 
     def name(self):
         return "gazer-theta"
@@ -29,22 +28,19 @@ class Tool(benchexec.tools.template.BaseTool2):
         return self._version_from_tool(executable)
 
     def cmdline(self, executable, options, task, rlimits):
-        assert len(list(task.input_files_or_identifier)) == 1
+        assert len(list(task.input_files)) == 1
         # possible option: --output (default value if flag isn't used: working directory)
-        return [executable] + options + list(task.input_files_or_identifier)
+        return [executable] + options + list(task.input_files)
 
     def determine_result(self, run):
         status = result.RESULT_UNKNOWN
-        if run.was_timeout:
-            status = "TIMEOUT"
-        else:
-            for line in run.output:
-                if "Result of gazer-theta run: FALSE" in line:
-                    status = result.RESULT_FALSE_REACH
-                elif "Result of gazer-theta run: TRUE" in line:
-                    status = result.RESULT_TRUE_PROP
+        for line in run.output:
+            if "Result of gazer-theta run: FALSE" in line:
+                status = result.RESULT_FALSE_REACH
+            elif "Result of gazer-theta run: TRUE" in line:
+                status = result.RESULT_TRUE_PROP
 
-        if status == result.RESULT_UNKNOWN and run.exit_code.value != 0:
+        if not run.was_timeout and status == result.RESULT_UNKNOWN and run.exit_code.value != 0:
             status = result.RESULT_ERROR
 
         return status

--- a/benchexec/tools/gazer-theta.py
+++ b/benchexec/tools/gazer-theta.py
@@ -1,0 +1,50 @@
+# This file is part of BenchExec, a framework for reliable benchmarking:
+# https://github.com/sosy-lab/benchexec
+#
+# SPDX-FileCopyrightText: 2007-2020 Dirk Beyer <https://www.sosy-lab.org>
+#
+# SPDX-License-Identifier: Apache-2.0
+
+import benchexec.result as result
+import benchexec.tools.template
+
+
+class Tool(benchexec.tools.template.BaseTool2):
+    """
+    Tool info for gazer-theta
+    (combined tool of Gazer and Theta)
+    https://github.com/ftsrg/gazer
+    https://github.com/ftsrg/theta
+    """
+
+    REQUIRED_PATHS = ["gazer", "gazer/tools/gazer-bmc", "gazer/tools/gazer-theta"]
+
+    def executable(self, tool_locator):
+        return tool_locator.find_executable("gazer_starter.py", subdir="gazer/scripts")
+
+    def name(self):
+        return "gazer-theta"
+
+    def version(self, executable):
+        return self._version_from_tool(executable)
+
+    def cmdline(self, executable, options, task, rlimits):
+        assert len(list(task.input_files_or_identifier)) == 1
+        # possible option: --output (default value if flag isn't used: working directory)
+        return [executable] + options + list(task.input_files_or_identifier)
+
+    def determine_result(self, run):
+        status = result.RESULT_UNKNOWN
+        if run.was_timeout:
+            status = "TIMEOUT"
+        else:
+            for line in run.output:
+                if "Result of gazer-theta run: FALSE" in line:
+                    status = result.RESULT_FALSE_REACH
+                elif "Result of gazer-theta run: TRUE" in line:
+                    status = result.RESULT_TRUE_PROP
+
+        if status == result.RESULT_UNKNOWN and run.exit_code.value != 0:
+            status = result.RESULT_ERROR
+
+        return status


### PR DESCRIPTION
[Gazer](https://github.com/ftsrg/gazer)
[Theta](https://github.com/ftsrg/theta)
[FMCAD Paper](https://ftsrg.mit.bme.hu/theta/publications/fmcad2017.pdf)

Note: I tried to use `BaseTool2` based on the migration guide, but I still couldn't use --tool-directory.
(`Error: Tool-info module for gazer-theta does not support parameter --tool-directory. Instead, you can add the tool to PATH, execute benchexec from the tool directory, or upgrade the tool-info module.`).
If you can tell me, what to upgrade, I'll update the tool-info.