### PR TITLE
Improvements for TableGenerator for its Windows Support

### DIFF
--- a/benchexec/tablegenerator/__init__.py
+++ b/benchexec/tablegenerator/__init__.py
@@ -1395,7 +1395,7 @@ def write_table_in_format(template_format, outfile, options, **kwargs):
             system = platform.system()
             try:
                 if system == "Windows":
-                    os.startfile(outfile, "open")
+                    os.startfile(os.path.normpath(outfile), "open")  # noqa: S606
                 else:
                     cmd = "open" if system == "Darwin" else "xdg-open"
                     subprocess.Popen(

--- a/benchexec/tablegenerator/__init__.py
+++ b/benchexec/tablegenerator/__init__.py
@@ -15,6 +15,7 @@ import io
 import itertools
 import logging
 import os.path
+import platform
 import signal
 import subprocess
 import sys
@@ -1391,12 +1392,22 @@ def write_table_in_format(template_format, outfile, options, **kwargs):
             callback(out, options=options, **kwargs)
 
         if options.show_table and template_format == "html":
+            system = platform.system()
             try:
-                subprocess.Popen(
-                    ["xdg-open", outfile],
-                    stdout=subprocess.DEVNULL,
-                    stderr=subprocess.DEVNULL,
-                )
+                if system == "Windows":
+                    os.startfile(outfile, "open")
+                elif system == "Darwin":
+                    subprocess.Popen(
+                        ["open", outfile],
+                        stdout=subprocess.DEVNULL,
+                        stderr=subprocess.DEVNULL,
+                    )
+                else:  # system == "Linux":
+                    subprocess.Popen(
+                        ["xdg-open", outfile],
+                        stdout=subprocess.DEVNULL,
+                        stderr=subprocess.DEVNULL,
+                    )
             except OSError:
                 pass
 

--- a/benchexec/tablegenerator/__init__.py
+++ b/benchexec/tablegenerator/__init__.py
@@ -57,7 +57,7 @@ MAIN_COLUMNS = [
 
 NAME_START = "results"  # first part of filename of table
 
-DEFAULT_OUTPUT_PATH = "results/"
+DEFAULT_OUTPUT_PATH = "results"
 
 TEMPLATE_FORMATS = ["html", "csv"]
 

--- a/benchexec/tablegenerator/__init__.py
+++ b/benchexec/tablegenerator/__init__.py
@@ -1396,15 +1396,10 @@ def write_table_in_format(template_format, outfile, options, **kwargs):
             try:
                 if system == "Windows":
                     os.startfile(outfile, "open")
-                elif system == "Darwin":
+                else:
+                    cmd = "open" if system == "Darwin" else "xdg-open"
                     subprocess.Popen(
-                        ["open", outfile],
-                        stdout=subprocess.DEVNULL,
-                        stderr=subprocess.DEVNULL,
-                    )
-                else:  # system == "Linux":
-                    subprocess.Popen(
-                        ["xdg-open", outfile],
+                        [cmd, outfile],
                         stdout=subprocess.DEVNULL,
                         stderr=subprocess.DEVNULL,
                     )


### PR DESCRIPTION
These small fixes improve usability of TableGenerator on Windows.

The first fix allows to call `table-generator ... --show` on Windows (tested) and MacOSX (untested)
and opens the default browser with the table.

The second small fix just removes an unimportant path separator that does not match the Windows path style.