### PR TITLE
remove equivalence check for property files during parsing task definitions

### DIFF
--- a/benchexec/model.py
+++ b/benchexec/model.py
@@ -853,9 +853,7 @@ class RunSet(object):
 
             # TODO We could reduce I/O by checking absolute paths and using os.path.samestat
             # with cached stat calls.
-            if prop.filename == expanded[0] or os.path.samefile(
-                prop.filename, expanded[0]
-            ):
+            if prop.filename == expanded[0]:
                 expected_result = prop_dict.get("expected_verdict")
                 if expected_result is not None and not isinstance(
                     expected_result, bool


### PR DESCRIPTION
The method `os.path.samefile` does not work reliably on Windows when using network storage.

Using VirtualBox with shared directories,
Python seems to be not able to distinguish reliably between different property files.
I do not know the exact reason, but the following benchmark definition causes a weird behaviour:
(requires CPAchecker r35613 and a current BenchExec version)
  `$> scripts/benchmark.py @webcloud test/test-sets/integration-bam.xml`

The benchmark is expected to have 1847 tasks,
and Linux shows that number when submitting the tasks.
Windows however finds for the same benchmark 2070 tasks,
because it ignores seme invalid property matches.
I have even seen other numbers, between 1847 and 2070.
The bug seems to depend on the provided inodes for those property files.
Windows provides identical data via `os.stat`, even if the files are different.

I do not know, when files need to be identical, whether this is a bug
in our scripts or in Python (3.9.0 for Win64) or in VirtualBox (5.2.42 on Ubuntu 18.04).
The change in these lines fixes the bug, however it removes the equivalence check.
I do not know a case where the equivalence check would have helped.

I would like to discuss about this issue. Maybe I am overlooking something.