### PR TITLE
Update several tool-info modules to BaseTool2

### DIFF
--- a/benchexec/tools/brick.py
+++ b/benchexec/tools/brick.py
@@ -45,17 +45,14 @@ class Tool(benchexec.tools.template.BaseTool2):
     def determine_result(self, run):
         status = result.RESULT_ERROR
 
-        for line in run.output._lines:
-            if line == "VERIFICATION SUCCESSFUL\n":
+        for line in run.output:
+            if line == "VERIFICATION SUCCESSFUL":
                 status = result.RESULT_TRUE_PROP
                 break
-            elif line == "VERIFICATION FAILED\n":
+            elif line == "VERIFICATION FAILED":
                 status = result.RESULT_FALSE_REACH
                 break
-            elif (
-                line == "VERIFICATION UNKNOWN\n"
-                or line == "VERIFICATION BOUNDED TRUE\n"
-            ):
+            elif line == "VERIFICATION UNKNOWN" or line == "VERIFICATION BOUNDED TRUE":
                 status = result.RESULT_UNKNOWN
                 break
 

--- a/benchexec/tools/brick.py
+++ b/benchexec/tools/brick.py
@@ -5,7 +5,7 @@
 #
 # SPDX-License-Identifier: Apache-2.0
 
-from benchexec.tools.sv_benchmarks_util import get_data_model_from_task
+from benchexec.tools.sv_benchmarks_util import get_data_model_from_task, ILP32, LP64
 import benchexec.tools.template
 import benchexec.result as result
 
@@ -25,9 +25,7 @@ class Tool(benchexec.tools.template.BaseTool2):
         return "BRICK"
 
     def cmdline(self, executable, options, task, rlimits):
-        data_model_param = get_data_model_from_task(
-            task, {"ILP32": "--32", "LP64": "--64"}
-        )
+        data_model_param = get_data_model_from_task(task, {ILP32: "--32", LP64: "--64"})
         if data_model_param and data_model_param not in options:
             options += [data_model_param]
 

--- a/benchexec/tools/brick.py
+++ b/benchexec/tools/brick.py
@@ -5,7 +5,7 @@
 #
 # SPDX-License-Identifier: Apache-2.0
 
-import benchexec.util as util
+from benchexec.tools.sv_benchmarks_util import get_data_model_from_task
 import benchexec.tools.template
 import benchexec.result as result
 
@@ -25,7 +25,7 @@ class Tool(benchexec.tools.template.BaseTool2):
         return "BRICK"
 
     def cmdline(self, executable, options, task, rlimits):
-        data_model_param = util.get_data_model_from_task(
+        data_model_param = get_data_model_from_task(
             task, {"ILP32": "--32", "LP64": "--64"}
         )
         if data_model_param and data_model_param not in options:

--- a/benchexec/tools/cbmc.py
+++ b/benchexec/tools/cbmc.py
@@ -109,11 +109,10 @@ class Tool(benchexec.tools.template.BaseTool2):
         return status
 
     def determine_result(self, run):
-        returnsignal = run.exit_code.signal or 0
         returncode = run.exit_code.value or 0
         output = run.output
 
-        if returnsignal == 0 and ((returncode == 0) or (returncode == 10)):
+        if not run.exit_code.signal and ((returncode == 0) or (returncode == 10)):
             status = result.RESULT_ERROR
             if "--xml-ui" in self.options:
                 status = self.parse_XML(output, returncode, run.was_timeout)

--- a/benchexec/tools/cbmc.py
+++ b/benchexec/tools/cbmc.py
@@ -8,7 +8,7 @@
 import logging
 from xml.etree import ElementTree
 
-import benchexec.util as util
+from benchexec.tools.sv_benchmarks_util import get_data_model_from_task
 import benchexec.tools.template
 import benchexec.result as result
 
@@ -38,7 +38,7 @@ class Tool(benchexec.tools.template.BaseTool2):
         elif "--xml-ui" not in options:
             options = options + ["--xml-ui"]
 
-        data_model_param = util.get_data_model_from_task(
+        data_model_param = get_data_model_from_task(
             task, {"ILP32": "--32", "LP64": "--64"}
         )
         if data_model_param and data_model_param not in options:

--- a/benchexec/tools/cbmc.py
+++ b/benchexec/tools/cbmc.py
@@ -8,7 +8,7 @@
 import logging
 from xml.etree import ElementTree
 
-from benchexec.tools.sv_benchmarks_util import get_data_model_from_task
+from benchexec.tools.sv_benchmarks_util import get_data_model_from_task, ILP32, LP64
 import benchexec.tools.template
 import benchexec.result as result
 
@@ -38,9 +38,7 @@ class Tool(benchexec.tools.template.BaseTool2):
         elif "--xml-ui" not in options:
             options = options + ["--xml-ui"]
 
-        data_model_param = get_data_model_from_task(
-            task, {"ILP32": "--32", "LP64": "--64"}
-        )
+        data_model_param = get_data_model_from_task(task, {ILP32: "--32", LP64: "--64"})
         if data_model_param and data_model_param not in options:
             options += [data_model_param]
 

--- a/benchexec/tools/cbmc.py
+++ b/benchexec/tools/cbmc.py
@@ -114,7 +114,7 @@ class Tool(benchexec.tools.template.BaseTool2):
         if run.exit_code.value in [0, 10]:
             status = result.RESULT_ERROR
             if "--xml-ui" in self.options:
-                status = self.parse_XML(output, run.exit_code.value, run.was_timeout)
+                status = self.parse_XML(output, run.exit_code, run.was_timeout)
             elif len(output) > 0:
                 # SV-COMP mode
                 result_str = output[-1].strip()
@@ -137,13 +137,13 @@ class Tool(benchexec.tools.template.BaseTool2):
                 elif "UNKNOWN" in output:
                     status = result.RESULT_UNKNOWN
 
-        elif run.exit_code.value == 64 and "Usage error!\n" in output:
+        elif run.exit_code.value == 64 and "Usage error!" in output:
             status = "INVALID ARGUMENTS"
 
-        elif run.exit_code.value == 6 and "Out of memory\n" in output:
+        elif run.exit_code.value == 6 and "Out of memory" in output:
             status = "OUT OF MEMORY"
 
-        elif run.exit_code.value == 6 and "SAT checker ran out of memory\n" in output:
+        elif run.exit_code.value == 6 and "SAT checker ran out of memory" in output:
             status = "OUT OF MEMORY"
 
         else:

--- a/benchexec/tools/cseq.py
+++ b/benchexec/tools/cseq.py
@@ -29,13 +29,13 @@ class CSeqTool(benchexec.tools.template.BaseTool2):
         are either absolute or have been made relative to the designated working directory.
         @param executable: the path to the executable of the tool (typically the result of executable())
         @param options: a list of options, in the same order as given in the XML-file.
-        @param tasks: instance of class Task containg the property and input file
+        @param task: instance of class Task containg the property and input file
                             This tool info module only supports one input file.
         @param rlimits: This dictionary contains resource-limits for a run,
                         for example: time-limit, soft-time-limit, hard-time-limit, memory-limit, cpu-core-limit.
                         All entries in rlimits are optional, so check for existence before usage!
         """
-        spec = ["--spec", task.property_file] if task.property_file is not None else []
+        spec = ["--spec", task.property_file] if task.property_file else []
         return [executable] + options + spec + ["--input", task.single_input_file]
 
     def determine_result(self, run):

--- a/benchexec/tools/cseq.py
+++ b/benchexec/tools/cseq.py
@@ -29,18 +29,14 @@ class CSeqTool(benchexec.tools.template.BaseTool2):
         are either absolute or have been made relative to the designated working directory.
         @param executable: the path to the executable of the tool (typically the result of executable())
         @param options: a list of options, in the same order as given in the XML-file.
-        @param tasks: a list of tasks, that should be analysed with the tool in one run.
-                            In most cases we we have only _one_ inputfile.
-        @param propertyfile: contains a specification for the verifier.
+        @param tasks: instance of class Task containg the property and input file
+                            This tool info module only supports one input file.
         @param rlimits: This dictionary contains resource-limits for a run,
                         for example: time-limit, soft-time-limit, hard-time-limit, memory-limit, cpu-core-limit.
                         All entries in rlimits are optional, so check for existence before usage!
         """
-        tasks = list(task.input_files_or_identifier)
-        assert len(tasks) == 1, "only one inputfile supported"
-        inputfile = ["--input", tasks[0]]
         spec = ["--spec", task.property_file] if task.property_file is not None else []
-        return [executable] + options + spec + inputfile
+        return [executable] + options + spec + ["--input", task.single_input_file]
 
     def determine_result(self, run):
         status = result.RESULT_UNKNOWN

--- a/benchexec/tools/cseq.py
+++ b/benchexec/tools/cseq.py
@@ -9,7 +9,7 @@ import benchexec.tools.template
 import benchexec.result as result
 
 
-class CSeqTool(benchexec.tools.template.BaseTool):
+class CSeqTool(benchexec.tools.template.BaseTool2):
     """
     Abstract tool info for CSeq-based tools (http://users.ecs.soton.ac.uk/gp4/cseq/cseq.html).
     """
@@ -19,7 +19,7 @@ class CSeqTool(benchexec.tools.template.BaseTool):
         first_line = output.splitlines()[0]
         return first_line.strip()
 
-    def cmdline(self, executable, options, tasks, propertyfile=None, rlimits={}):
+    def cmdline(self, executable, options, task, rlimits):
         """
         Compose the command line to execute from the name of the executable,
         the user-specified options, and the inputfile to analyze.
@@ -36,13 +36,14 @@ class CSeqTool(benchexec.tools.template.BaseTool):
                         for example: time-limit, soft-time-limit, hard-time-limit, memory-limit, cpu-core-limit.
                         All entries in rlimits are optional, so check for existence before usage!
         """
+        tasks = list(task.input_files_or_identifier)
         assert len(tasks) == 1, "only one inputfile supported"
         inputfile = ["--input", tasks[0]]
-        spec = ["--spec", propertyfile] if propertyfile is not None else []
+        spec = ["--spec", task.property_file] if task.property_file is not None else []
         return [executable] + options + spec + inputfile
 
-    def determine_result(self, returncode, returnsignal, output, isTimeout):
-        output = "\n".join(output)
+    def determine_result(self, run):
+        output = "\n".join(run.output)
         status = result.RESULT_UNKNOWN
         if "FALSE" in output:
             status = result.RESULT_FALSE_REACH

--- a/benchexec/tools/cseq.py
+++ b/benchexec/tools/cseq.py
@@ -43,11 +43,10 @@ class CSeqTool(benchexec.tools.template.BaseTool2):
         return [executable] + options + spec + inputfile
 
     def determine_result(self, run):
-        output = "\n".join(run.output)
         status = result.RESULT_UNKNOWN
-        if "FALSE" in output:
+        if run.output.any_line_contains("FALSE"):
             status = result.RESULT_FALSE_REACH
-        elif "TRUE" in output:
+        elif run.output.any_line_contains("TRUE"):
             status = result.RESULT_TRUE_PROP
         else:
             status = result.RESULT_UNKNOWN

--- a/benchexec/tools/dartagnan.py
+++ b/benchexec/tools/dartagnan.py
@@ -5,12 +5,11 @@
 #
 # SPDX-License-Identifier: Apache-2.0
 
-import benchexec.util as util
 import benchexec.tools.template
 import benchexec.result as result
 
 
-class Tool(benchexec.tools.template.BaseTool):
+class Tool(benchexec.tools.template.BaseTool2):
     """
     Tool info for Dartagnan (https://github.com/hernanponcedeleon/Dat3M).
     """
@@ -24,22 +23,22 @@ class Tool(benchexec.tools.template.BaseTool):
         "output",
     ]
 
-    def executable(self):
-        return util.find_executable("./Dartagnan-SVCOMP.sh")
+    def executable(self, tool_locator):
+        return tool_locator.find_executable("Dartagnan-SVCOMP.sh")
 
     def name(self):
         return "Dartagnan"
 
-    def cmdline(self, executable, options, tasks, propertyfile=None, rlimits={}):
-        return [executable] + options + tasks
+    def cmdline(self, executable, options, task, rlimits):
+        return [executable] + options + list(task.input_files_or_identifier)
 
     def version(self, executable):
         return self._version_from_tool(executable)
 
-    def determine_result(self, returncode, returnsignal, output, isTimeout):
+    def determine_result(self, run):
         status = result.RESULT_ERROR
-        if output:
-            result_str = output[-1].strip()
+        if run.output:
+            result_str = run.output[-1].strip()
             if "FAIL" in result_str:
                 status = result.RESULT_FALSE_REACH
             elif "PASS" in result_str:

--- a/benchexec/tools/divine.py
+++ b/benchexec/tools/divine.py
@@ -96,8 +96,6 @@ class Tool(benchexec.tools.template.BaseTool2):
         and should give some indication of the failure reason
         (e.g., "CRASH", "OUT_OF_MEMORY", etc.).
         """
-        returncode = run.exit_code.value or 0
-
         if not run.output:
             return "ERROR - no output"
 
@@ -106,7 +104,7 @@ class Tool(benchexec.tools.template.BaseTool2):
         if run.was_timeout:
             return "TIMEOUT"
 
-        if returncode != 0:
+        if run.exit_code.value != 0:
             return "ERROR - Pre-run"
 
         if last is None:

--- a/benchexec/tools/divine.py
+++ b/benchexec/tools/divine.py
@@ -5,7 +5,7 @@
 #
 # SPDX-License-Identifier: Apache-2.0
 
-from benchexec.tools.sv_benchmarks_util import get_data_model_from_task
+from benchexec.tools.sv_benchmarks_util import get_data_model_from_task, ILP32, LP64
 import benchexec.tools.template
 import benchexec.result as result
 
@@ -70,9 +70,7 @@ class Tool(benchexec.tools.template.BaseTool2):
                         for example: time-limit, soft-time-limit, hard-time-limit, memory-limit, cpu-core-limit.
                         All entries in rlimits are optional, so check for existence before usage!
         """
-        data_model_param = get_data_model_from_task(
-            task, {"ILP32": "--32", "LP64": "--64"}
-        )
+        data_model_param = get_data_model_from_task(task, {ILP32: "--32", LP64: "--64"})
         if data_model_param and data_model_param not in options:
             options += [data_model_param]
 

--- a/benchexec/tools/divine.py
+++ b/benchexec/tools/divine.py
@@ -5,7 +5,7 @@
 #
 # SPDX-License-Identifier: Apache-2.0
 
-import benchexec.util as util
+from benchexec.tools.sv_benchmarks_util import get_data_model_from_task
 import benchexec.tools.template
 import benchexec.result as result
 
@@ -70,7 +70,7 @@ class Tool(benchexec.tools.template.BaseTool2):
                         for example: time-limit, soft-time-limit, hard-time-limit, memory-limit, cpu-core-limit.
                         All entries in rlimits are optional, so check for existence before usage!
         """
-        data_model_param = util.get_data_model_from_task(
+        data_model_param = get_data_model_from_task(
             task, {"ILP32": "--32", "LP64": "--64"}
         )
         if data_model_param and data_model_param not in options:

--- a/benchexec/tools/divine.py
+++ b/benchexec/tools/divine.py
@@ -12,7 +12,7 @@ import benchexec.result as result
 import os
 
 
-class Tool(benchexec.tools.template.BaseTool):
+class Tool(benchexec.tools.template.BaseTool2):
     """
     DIVINE info object
     """
@@ -33,14 +33,14 @@ class Tool(benchexec.tools.template.BaseTool):
         "libz.so.1",
     ]
 
-    def executable(self):
+    def executable(self, tool_locator):
         """
         Find the path to the executable file that will get executed.
         This method always needs to be overridden,
         and most implementations will look similar to this one.
         The path returned should be relative to the current directory.
         """
-        return util.find_executable(self.BINS[0], os.path.join("bin", self.BINS[0]))
+        return tool_locator.find_executable(self.BINS[0], subdir="bin")
 
     def version(self, executable):
         return self._version_from_tool(executable)
@@ -51,7 +51,7 @@ class Tool(benchexec.tools.template.BaseTool):
         """
         return "DIVINE"
 
-    def cmdline(self, executable, options, tasks, propertyfile=None, rlimits={}):
+    def cmdline(self, executable, options, task, rlimits):
         """
         Compose the command line to execute from the name of the executable,
         the user-specified options, and the inputfile to analyze.
@@ -70,13 +70,23 @@ class Tool(benchexec.tools.template.BaseTool):
                         for example: time-limit, soft-time-limit, hard-time-limit, memory-limit, cpu-core-limit.
                         All entries in rlimits are optional, so check for existence before usage!
         """
+        data_model_param = util.get_data_model_from_task(
+            task, {"ILP32": "--32", "LP64": "--64"}
+        )
+        if data_model_param and data_model_param not in options:
+            options += [data_model_param]
+
         directory = os.path.dirname(executable)
 
         # Ignore propertyfile since we run only reachability
-        run = [os.path.join(".", directory, self.BINS[1]), directory] + options + tasks
+        run = (
+            [os.path.join(".", directory, self.BINS[1]), directory]
+            + options
+            + list(task.input_files_or_identifier)
+        )
         return run
 
-    def determine_result(self, returncode, returnsignal, output, isTimeout):
+    def determine_result(self, run):
         """
         Parse the output of the tool and extract the verification result.
         This method always needs to be overridden.
@@ -87,15 +97,15 @@ class Tool(benchexec.tools.template.BaseTool):
         (e.g., "CRASH", "OUT_OF_MEMORY", etc.).
         """
 
-        if not output:
+        if not run.output:
             return "ERROR - no output"
 
-        last = output[-1]
+        last = run.output[-1]
 
-        if isTimeout:
+        if run.was_timeout:
             return "TIMEOUT"
 
-        if returncode != 0:
+        if run.exit_code.value != 0:
             return "ERROR - Pre-run"
 
         if last is None:

--- a/benchexec/tools/divine.py
+++ b/benchexec/tools/divine.py
@@ -96,6 +96,7 @@ class Tool(benchexec.tools.template.BaseTool2):
         and should give some indication of the failure reason
         (e.g., "CRASH", "OUT_OF_MEMORY", etc.).
         """
+        returncode = run.exit_code.value or 0
 
         if not run.output:
             return "ERROR - no output"
@@ -105,7 +106,7 @@ class Tool(benchexec.tools.template.BaseTool2):
         if run.was_timeout:
             return "TIMEOUT"
 
-        if run.exit_code.value != 0:
+        if returncode != 0:
             return "ERROR - Pre-run"
 
         if last is None:

--- a/benchexec/tools/divine.py
+++ b/benchexec/tools/divine.py
@@ -104,12 +104,10 @@ class Tool(benchexec.tools.template.BaseTool2):
         if run.was_timeout:
             return "TIMEOUT"
 
-        if run.exit_code.value != 0:
+        if run.exit_code.value and run.exit_code.value != 0:
             return "ERROR - Pre-run"
 
-        if last is None:
-            return "ERROR - no output"
-        elif "result: true" in last:
+        if "result: true" in last:
             return result.RESULT_TRUE_PROP
         elif "result: false" in last:
             return result.RESULT_FALSE_REACH

--- a/benchexec/tools/divine4.py
+++ b/benchexec/tools/divine4.py
@@ -6,7 +6,7 @@
 #
 # SPDX-License-Identifier: Apache-2.0
 
-import benchexec.util as util
+from benchexec.tools.sv_benchmarks_util import get_data_model_from_task
 import benchexec.tools.template
 import benchexec.result as result
 
@@ -68,7 +68,7 @@ class Tool(benchexec.tools.template.BaseTool2):
                         for example: time-limit, soft-time-limit, hard-time-limit, memory-limit, cpu-core-limit.
                         All entries in rlimits are optional, so check for existence before usage!
         """
-        data_model_param = util.get_data_model_from_task(
+        data_model_param = get_data_model_from_task(
             task, {"ILP32": "--32", "LP64": "--64"}
         )
         if data_model_param and data_model_param not in options:

--- a/benchexec/tools/divine4.py
+++ b/benchexec/tools/divine4.py
@@ -94,6 +94,7 @@ class Tool(benchexec.tools.template.BaseTool2):
         and should give some indication of the failure reason
         (e.g., "CRASH", "OUT_OF_MEMORY", etc.).
         """
+        returncode = run.exit_code.value or 0
 
         if not run.output:
             return "ERROR - no output"
@@ -103,7 +104,7 @@ class Tool(benchexec.tools.template.BaseTool2):
         if run.was_timeout:
             return "TIMEOUT"
 
-        if run.exit_code.value != 0:
+        if returncode != 0:
             return "ERROR - {0}".format(last)
 
         if "result:" in last:

--- a/benchexec/tools/divine4.py
+++ b/benchexec/tools/divine4.py
@@ -102,7 +102,7 @@ class Tool(benchexec.tools.template.BaseTool2):
         if run.was_timeout:
             return "TIMEOUT"
 
-        if run.exit_code.value != 0:
+        if run.exit_code.value and run.exit_code.value != 0:
             return "ERROR - {0}".format(last)
 
         if "result:" in last:

--- a/benchexec/tools/divine4.py
+++ b/benchexec/tools/divine4.py
@@ -6,7 +6,7 @@
 #
 # SPDX-License-Identifier: Apache-2.0
 
-from benchexec.tools.sv_benchmarks_util import get_data_model_from_task
+from benchexec.tools.sv_benchmarks_util import get_data_model_from_task, ILP32, LP64
 import benchexec.tools.template
 import benchexec.result as result
 
@@ -68,9 +68,7 @@ class Tool(benchexec.tools.template.BaseTool2):
                         for example: time-limit, soft-time-limit, hard-time-limit, memory-limit, cpu-core-limit.
                         All entries in rlimits are optional, so check for existence before usage!
         """
-        data_model_param = get_data_model_from_task(
-            task, {"ILP32": "--32", "LP64": "--64"}
-        )
+        data_model_param = get_data_model_from_task(task, {ILP32: "--32", LP64: "--64"})
         if data_model_param and data_model_param not in options:
             options += [data_model_param]
 

--- a/benchexec/tools/divine4.py
+++ b/benchexec/tools/divine4.py
@@ -94,7 +94,7 @@ class Tool(benchexec.tools.template.BaseTool2):
         and should give some indication of the failure reason
         (e.g., "CRASH", "OUT_OF_MEMORY", etc.).
         """
-        returncode = run.exit_code.value or 0
+        run.exit_code.value = run.exit_code.value or 0
 
         if not run.output:
             return "ERROR - no output"
@@ -104,7 +104,7 @@ class Tool(benchexec.tools.template.BaseTool2):
         if run.was_timeout:
             return "TIMEOUT"
 
-        if returncode != 0:
+        if run.exit_code.value != 0:
             return "ERROR - {0}".format(last)
 
         if "result:" in last:

--- a/benchexec/tools/divine4.py
+++ b/benchexec/tools/divine4.py
@@ -94,8 +94,6 @@ class Tool(benchexec.tools.template.BaseTool2):
         and should give some indication of the failure reason
         (e.g., "CRASH", "OUT_OF_MEMORY", etc.).
         """
-        run.exit_code.value = run.exit_code.value or 0
-
         if not run.output:
             return "ERROR - no output"
 

--- a/benchexec/tools/esbmc.py
+++ b/benchexec/tools/esbmc.py
@@ -39,7 +39,7 @@ class Tool(benchexec.tools.template.BaseTool2):
         data_model_param = util.get_data_model_from_task(
             task, {"ILP32": "32", "LP64": "64"}
         )
-        if data_model_param and data_model_param not in options:
+        if data_model_param and "--arch" not in options:
             options += ["--arch", data_model_param]
         return [executable] + ["-p", task.property_file] + options + [inputfile]
 

--- a/benchexec/tools/esbmc.py
+++ b/benchexec/tools/esbmc.py
@@ -43,43 +43,29 @@ class Tool(benchexec.tools.template.BaseTool2):
         )
 
     def determine_result(self, run):
-        output = "\n".join(run.output)
         status = result.RESULT_UNKNOWN
 
-        if self.allInText(["FALSE_DEREF"], output):
+        if run.output.any_line_contains("FALSE_DEREF"):
             status = result.RESULT_FALSE_DEREF
-        elif self.allInText(["FALSE_FREE"], output):
+        elif run.output.any_line_contains("FALSE_FREE"):
             status = result.RESULT_FALSE_FREE
-        elif self.allInText(["FALSE_MEMTRACK"], output):
+        elif run.output.any_line_contains("FALSE_MEMTRACK"):
             status = result.RESULT_FALSE_MEMTRACK
-        elif self.allInText(["FALSE_OVERFLOW"], output):
+        elif run.output.any_line_contains("FALSE_OVERFLOW"):
             status = result.RESULT_FALSE_OVERFLOW
-        elif self.allInText(["FALSE_TERMINATION"], output):
+        elif run.output.any_line_contains("FALSE_TERMINATION"):
             status = result.RESULT_FALSE_TERMINATION
-        elif self.allInText(["FALSE"], output):
+        elif run.output.any_line_contains("FALSE"):
             status = result.RESULT_FALSE_REACH
-        elif "TRUE" in output:
+        elif run.output.any_line_contains("TRUE"):
             status = result.RESULT_TRUE_PROP
-        elif "DONE" in output:
+        elif run.output.any_line_contains("DONE"):
             status = result.RESULT_DONE
 
         if status == result.RESULT_UNKNOWN:
             if run.was_timeout:
                 status = "TIMEOUT"
-            elif output.endswith(("error", "error\n")):
+            elif run.output[-1].endswith("error"):
                 status = "ERROR"
 
         return status
-
-    """ helper method """
-
-    def allInText(self, words, text):
-        """
-        This function checks, if all the words appear in the given order in the text.
-        """
-        index = 0
-        for word in words:
-            index = text[index:].find(word)
-            if index == -1:
-                return False
-        return True

--- a/benchexec/tools/esbmc.py
+++ b/benchexec/tools/esbmc.py
@@ -6,7 +6,7 @@
 # SPDX-License-Identifier: Apache-2.0
 
 import os
-import benchexec.util as util
+from benchexec.tools.sv_benchmarks_util import get_data_model_from_task
 import benchexec.tools.template
 import benchexec.result as result
 
@@ -32,9 +32,7 @@ class Tool(benchexec.tools.template.BaseTool2):
         return "ESBMC"
 
     def cmdline(self, executable, options, task, rlimits):
-        data_model_param = util.get_data_model_from_task(
-            task, {"ILP32": "32", "LP64": "64"}
-        )
+        data_model_param = get_data_model_from_task(task, {"ILP32": "32", "LP64": "64"})
         if data_model_param and "--arch" not in options:
             options += ["--arch", data_model_param]
         return (

--- a/benchexec/tools/esbmc.py
+++ b/benchexec/tools/esbmc.py
@@ -6,7 +6,7 @@
 # SPDX-License-Identifier: Apache-2.0
 
 import os
-from benchexec.tools.sv_benchmarks_util import get_data_model_from_task
+from benchexec.tools.sv_benchmarks_util import get_data_model_from_task, ILP32, LP64
 import benchexec.tools.template
 import benchexec.result as result
 
@@ -32,7 +32,7 @@ class Tool(benchexec.tools.template.BaseTool2):
         return "ESBMC"
 
     def cmdline(self, executable, options, task, rlimits):
-        data_model_param = get_data_model_from_task(task, {"ILP32": "32", "LP64": "64"})
+        data_model_param = get_data_model_from_task(task, {ILP32: "32", LP64: "64"})
         if data_model_param and "--arch" not in options:
             options += ["--arch", data_model_param]
         return (

--- a/benchexec/tools/esbmc.py
+++ b/benchexec/tools/esbmc.py
@@ -32,16 +32,17 @@ class Tool(benchexec.tools.template.BaseTool2):
         return "ESBMC"
 
     def cmdline(self, executable, options, task, rlimits):
-        tasks = list(task.input_files_or_identifier)
-        assert len(tasks) == 1, "only one inputfile supported"
-        inputfile = tasks[0]
-
         data_model_param = util.get_data_model_from_task(
             task, {"ILP32": "32", "LP64": "64"}
         )
         if data_model_param and "--arch" not in options:
             options += ["--arch", data_model_param]
-        return [executable] + ["-p", task.property_file] + options + [inputfile]
+        return (
+            [executable]
+            + ["-p", task.property_file]
+            + options
+            + [task.single_input_file]
+        )
 
     def determine_result(self, run):
         output = "\n".join(run.output)

--- a/benchexec/tools/fshell-witness2test.py
+++ b/benchexec/tools/fshell-witness2test.py
@@ -80,17 +80,16 @@ class Tool(benchexec.tools.template.BaseTool2):
         Otherwise an arbitrary string can be returned that will be shown to the user
         and should give some indication of the failure reason
         (e.g., "CRASH", "OUT_OF_MEMORY", etc.).
-        @param returncode: the exit code of the program, 0 if the program was killed
-        @param returnsignal: the signal that killed the program, 0 if program exited itself
+        @param run.exit_code.value: the exit code of the program, None if the program was killed
+        @param runb.exi_code.signal: the signal that killed the program, None if program exited itself
         @param output: a list of strings of output lines of the tool (both stdout and stderr)
         @param isTimeout: whether the result is a timeout
         (useful to distinguish between program killed because of error and timeout)
         @return a non-empty string, usually one of the benchexec.result.RESULT_* constants
         """
-        returncode = run.exit_code.value or 0
         output = run.output
         status = result.RESULT_ERROR
-        if not run.exit_code.signal and returncode == 0:
+        if run.exit_code.value == 0:
             if output:
                 result_str = output[-1].strip()
 

--- a/benchexec/tools/fshell-witness2test.py
+++ b/benchexec/tools/fshell-witness2test.py
@@ -9,7 +9,7 @@ import re
 
 import benchexec.result as result
 import benchexec.tools.template
-import benchexec.util as util
+from benchexec.tools.sv_benchmarks_util import get_data_model_from_task
 
 
 class Tool(benchexec.tools.template.BaseTool2):
@@ -63,7 +63,7 @@ class Tool(benchexec.tools.template.BaseTool2):
         if task.property_file:
             options = options + ["--propertyfile", task.property_file]
 
-        data_model_param = util.get_data_model_from_task(
+        data_model_param = get_data_model_from_task(
             task, {"ILP32": "-m32", "LP64": "-m64"}
         )
         if data_model_param and data_model_param not in options:

--- a/benchexec/tools/fshell-witness2test.py
+++ b/benchexec/tools/fshell-witness2test.py
@@ -9,7 +9,7 @@ import re
 
 import benchexec.result as result
 import benchexec.tools.template
-from benchexec.tools.sv_benchmarks_util import get_data_model_from_task
+from benchexec.tools.sv_benchmarks_util import get_data_model_from_task, ILP32, LP64
 
 
 class Tool(benchexec.tools.template.BaseTool2):
@@ -63,9 +63,7 @@ class Tool(benchexec.tools.template.BaseTool2):
         if task.property_file:
             options = options + ["--propertyfile", task.property_file]
 
-        data_model_param = get_data_model_from_task(
-            task, {"ILP32": "-m32", "LP64": "-m64"}
-        )
+        data_model_param = get_data_model_from_task(task, {ILP32: "-m32", LP64: "-m64"})
         if data_model_param and data_model_param not in options:
             options += [data_model_param]
 

--- a/benchexec/tools/fshell-witness2test.py
+++ b/benchexec/tools/fshell-witness2test.py
@@ -87,11 +87,10 @@ class Tool(benchexec.tools.template.BaseTool2):
         (useful to distinguish between program killed because of error and timeout)
         @return a non-empty string, usually one of the benchexec.result.RESULT_* constants
         """
-        returnsignal = run.exit_code.signal or 0
         returncode = run.exit_code.value or 0
         output = run.output
         status = result.RESULT_ERROR
-        if returnsignal == 0 and returncode == 0:
+        if not run.exit_code.signal and returncode == 0:
             if output:
                 result_str = output[-1].strip()
 

--- a/benchexec/tools/gacal.py
+++ b/benchexec/tools/gacal.py
@@ -5,7 +5,7 @@
 #
 # SPDX-License-Identifier: Apache-2.0
 
-import benchexec.util as util
+from benchexec.tools.sv_benchmarks_util import get_data_model_from_task
 import benchexec.tools.template
 import benchexec.result as result
 
@@ -35,9 +35,7 @@ class Tool(benchexec.tools.template.BaseTool2):
         return self._version_from_tool(executable)
 
     def cmdline(self, executable, options, task, rlimits):
-        data_model_param = util.get_data_model_from_task(
-            task, {"ILP32": "32", "LP64": "64"}
-        )
+        data_model_param = get_data_model_from_task(task, {"ILP32": "32", "LP64": "64"})
         if data_model_param and "--architecture" not in options:
             options += ["--architecture", data_model_param]
 

--- a/benchexec/tools/gacal.py
+++ b/benchexec/tools/gacal.py
@@ -10,7 +10,7 @@ import benchexec.tools.template
 import benchexec.result as result
 
 
-class Tool(benchexec.tools.template.BaseTool):
+class Tool(benchexec.tools.template.BaseTool2):
     """
     Tool info for GACAL.
     URL: https://gitlab.com/bquiring/sv-comp-submission
@@ -25,8 +25,8 @@ class Tool(benchexec.tools.template.BaseTool):
         "scripts",
     ]
 
-    def executable(self):
-        return util.find_executable("run-gacal.py")
+    def executable(self, tool_locator):
+        return tool_locator.find_executable("run-gacal.py")
 
     def name(self):
         return "GACAL"
@@ -34,11 +34,17 @@ class Tool(benchexec.tools.template.BaseTool):
     def version(self, executable):
         return self._version_from_tool(executable)
 
-    def cmdline(self, executable, options, tasks, propertyfile, rlimits):
-        return [executable] + options + tasks
+    def cmdline(self, executable, options, task, rlimits):
+        data_model_param = util.get_data_model_from_task(
+            task, {"ILP32": "32", "LP64": "64"}
+        )
+        if data_model_param and data_model_param not in options:
+            options += ["--architecture", data_model_param]
 
-    def determine_result(self, returncode, returnsignal, output, is_timeout):
-        for line in output:
+        return [executable] + options + list(task.input_files_or_identifier)
+
+    def determine_result(self, run):
+        for line in run.output:
             if "VERIFICATION_SUCCESSFUL" in line:
                 return result.RESULT_TRUE_PROP
             elif "VERIFICATION_FAILED" in line:

--- a/benchexec/tools/gacal.py
+++ b/benchexec/tools/gacal.py
@@ -38,7 +38,7 @@ class Tool(benchexec.tools.template.BaseTool2):
         data_model_param = util.get_data_model_from_task(
             task, {"ILP32": "32", "LP64": "64"}
         )
-        if data_model_param and data_model_param not in options:
+        if data_model_param and "--architecture" not in options:
             options += ["--architecture", data_model_param]
 
         return [executable] + options + list(task.input_files_or_identifier)

--- a/benchexec/tools/gacal.py
+++ b/benchexec/tools/gacal.py
@@ -5,7 +5,7 @@
 #
 # SPDX-License-Identifier: Apache-2.0
 
-from benchexec.tools.sv_benchmarks_util import get_data_model_from_task
+from benchexec.tools.sv_benchmarks_util import get_data_model_from_task, ILP32, LP64
 import benchexec.tools.template
 import benchexec.result as result
 
@@ -35,7 +35,7 @@ class Tool(benchexec.tools.template.BaseTool2):
         return self._version_from_tool(executable)
 
     def cmdline(self, executable, options, task, rlimits):
-        data_model_param = get_data_model_from_task(task, {"ILP32": "32", "LP64": "64"})
+        data_model_param = get_data_model_from_task(task, {ILP32: "32", LP64: "64"})
         if data_model_param and "--architecture" not in options:
             options += ["--architecture", data_model_param]
 

--- a/benchexec/tools/klee.py
+++ b/benchexec/tools/klee.py
@@ -6,20 +6,20 @@
 # SPDX-License-Identifier: Apache-2.0
 
 import benchexec.result as result
-import benchexec.util as util
 import benchexec.tools.template
 import benchexec.model
+from benchexec.tools.sv_benchmarks_util import get_data_model_from_task
 
 
-class Tool(benchexec.tools.template.BaseTool):
+class Tool(benchexec.tools.template.BaseTool2):
     """
     Tool info for KLEE (https://klee.github.io).
     """
 
     REQUIRED_PATHS = ["bin", "include", "klee_build", "libraries"]
 
-    def executable(self):
-        return util.find_executable("bin/klee")
+    def executable(self, tool_locator):
+        return tool_locator.find_executable("klee", subdir="bin")
 
     def program_files(self, executable):
         return self._program_files_from_executable(
@@ -45,30 +45,32 @@ class Tool(benchexec.tools.template.BaseTool):
         version = self._version_from_tool(executable, line_prefix="KLEE")
         return version.split("(")[0].strip()
 
-    def cmdline(self, executable, options, tasks, propertyfile=None, rlimits={}):
-        if propertyfile:
-            options += ["--property-file=" + propertyfile]
-        if benchexec.model.MEMLIMIT in rlimits:
-            options += ["--max-memory=" + str(rlimits[benchexec.model.MEMLIMIT])]
-        if benchexec.model.TIMELIMIT in rlimits:
-            options += ["--max-time=" + str(rlimits[benchexec.model.TIMELIMIT])]
-        if benchexec.model.WALLTIMELIMIT in rlimits:
-            options += ["--max-walltime=" + str(rlimits[benchexec.model.WALLTIMELIMIT])]
-        if benchexec.model.SOFTTIMELIMIT in rlimits:
-            options += [
-                "--max-cputime-soft=" + str(rlimits[benchexec.model.SOFTTIMELIMIT])
-            ]
-        if benchexec.model.HARDTIMELIMIT in rlimits:
-            options += [
-                "--max-cputime-hard=" + str(rlimits[benchexec.model.HARDTIMELIMIT])
-            ]
+    def cmdline(self, executable, options, task, rlimits):
+        if task.property_file:
+            options += ["--property-file=" + task.property_file]
+        if rlimits.memory:
+            options += ["--max-memory=" + str(rlimits.memory)]
+        if rlimits.cputime_hard:
+            options += ["--max-time=" + str(rlimits.cputime_hard)]
+        if rlimits.walltime:
+            options += ["--max-walltime=" + str(rlimits.walltime)]
+        if rlimits.cputime:
+            options += ["--max-cputime-soft=" + str(rlimits.cputime)]
+        if rlimits.cputime_hard:
+            options += ["--max-cputime-hard=" + str(rlimits.cputime_hard)]
 
-        return [executable] + options + tasks
+        data_model_param = get_data_model_from_task(
+            task, {"ILP32": "--32", "LP64": "--64"}
+        )
+        if data_model_param and data_model_param not in options:
+            options += [data_model_param]
+
+        return [executable] + options + list(task.input_files_or_identifier)
 
     def name(self):
         return "KLEE"
 
-    def determine_result(self, returncode, returnsignal, output, isTimeout):
+    def determine_result(self, run):
         """
         Parse the output of the tool and extract the verification result.
         This method always needs to be overridden.
@@ -78,7 +80,7 @@ class Tool(benchexec.tools.template.BaseTool):
         and should give some indication of the failure reason
         (e.g., "CRASH", "OUT_OF_MEMORY", etc.).
         """
-        for line in output:
+        for line in run.output:
             if line.startswith("KLEE: ERROR: "):
                 if line.find("ASSERTION FAIL:") != -1:
                     return result.RESULT_FALSE_REACH
@@ -87,7 +89,7 @@ class Tool(benchexec.tools.template.BaseTool):
                 elif line.find("overflow") != -1:
                     return result.RESULT_FALSE_OVERFLOW
                 else:
-                    return "ERROR ({0})".format(returncode)
+                    return "ERROR ({0})".format(run.exit_code.value)
             if line.startswith("KLEE: done"):
                 return result.RESULT_DONE
         return result.RESULT_UNKNOWN

--- a/benchexec/tools/klee.py
+++ b/benchexec/tools/klee.py
@@ -8,7 +8,7 @@
 import benchexec.result as result
 import benchexec.tools.template
 import benchexec.model
-from benchexec.tools.sv_benchmarks_util import get_data_model_from_task
+from benchexec.tools.sv_benchmarks_util import get_data_model_from_task, ILP32, LP64
 
 
 class Tool(benchexec.tools.template.BaseTool2):
@@ -53,9 +53,7 @@ class Tool(benchexec.tools.template.BaseTool2):
         if rlimits.cputime:
             options += ["--max-cputime-soft=" + str(rlimits.cputime)]
 
-        data_model_param = get_data_model_from_task(
-            task, {"ILP32": "--32", "LP64": "--64"}
-        )
+        data_model_param = get_data_model_from_task(task, {ILP32: "--32", LP64: "--64"})
         if data_model_param and data_model_param not in options:
             options += [data_model_param]
 

--- a/benchexec/tools/klee.py
+++ b/benchexec/tools/klee.py
@@ -50,14 +50,8 @@ class Tool(benchexec.tools.template.BaseTool2):
             options += ["--property-file=" + task.property_file]
         if rlimits.memory:
             options += ["--max-memory=" + str(rlimits.memory)]
-        if rlimits.cputime_hard:
-            options += ["--max-time=" + str(rlimits.cputime_hard)]
-        if rlimits.walltime:
-            options += ["--max-walltime=" + str(rlimits.walltime)]
         if rlimits.cputime:
             options += ["--max-cputime-soft=" + str(rlimits.cputime)]
-        if rlimits.cputime_hard:
-            options += ["--max-cputime-hard=" + str(rlimits.cputime_hard)]
 
         data_model_param = get_data_model_from_task(
             task, {"ILP32": "--32", "LP64": "--64"}

--- a/benchexec/tools/lazycseq.py
+++ b/benchexec/tools/lazycseq.py
@@ -5,7 +5,6 @@
 #
 # SPDX-License-Identifier: Apache-2.0
 
-import benchexec.util as util
 from . import cseq
 
 
@@ -27,8 +26,8 @@ class Tool(cseq.CSeqTool):
         "backends",
     ]
 
-    def executable(self):
-        return util.find_executable("lazy-cseq.py")
+    def executable(self, tool_locator):
+        return tool_locator.find_executable("lazy-cseq.py")
 
     def name(self):
         return "Lazy-CSeq"

--- a/benchexec/tools/lazycseqabs.py
+++ b/benchexec/tools/lazycseqabs.py
@@ -5,7 +5,6 @@
 #
 # SPDX-License-Identifier: Apache-2.0
 
-import benchexec.util as util
 from . import cseq
 
 
@@ -23,8 +22,8 @@ class Tool(cseq.CSeqTool):
         "modules",
     ]
 
-    def executable(self):
-        return util.find_executable("lazy-cseq-abs.py")
+    def executable(self, tool_locator):
+        return tool_locator.find_executable("lazy-cseq-abs.py")
 
     def name(self):
         return "Lazy-CSeq-Abs"

--- a/benchexec/tools/lazycseqswarm.py
+++ b/benchexec/tools/lazycseqswarm.py
@@ -5,7 +5,6 @@
 #
 # SPDX-License-Identifier: Apache-2.0
 
-import benchexec.util as util
 from . import cseq
 
 
@@ -24,8 +23,8 @@ class Tool(cseq.CSeqTool):
         "modules",
     ]
 
-    def executable(self):
-        return util.find_executable("lazy-cseq-swarm.py")
+    def executable(self, tool_locator):
+        return tool_locator.find_executable("lazy-cseq-swarm.py")
 
     def name(self):
         return "Lazy-CSeq-Swarm"

--- a/benchexec/tools/legion.py
+++ b/benchexec/tools/legion.py
@@ -5,11 +5,11 @@
 #
 # SPDX-License-Identifier: Apache-2.0
 
-import benchexec.util as util
 import benchexec.tools.template
+from benchexec.tools.sv_benchmarks_util import get_data_model_from_task
 
 
-class Tool(benchexec.tools.template.BaseTool):
+class Tool(benchexec.tools.template.BaseTool2):
     """
     Tool info for Legion (https://github.com/Alan32Liu/Legion).
     """
@@ -27,11 +27,20 @@ class Tool(benchexec.tools.template.BaseTool):
         "lib",
     ]
 
-    def executable(self):
-        return util.find_executable("legion-sv")
+    def executable(self, tool_locator):
+        return tool_locator.find_executable("legion-sv")
 
     def version(self, executable):
         return self._version_from_tool(executable, ignore_stderr=False)
 
     def name(self):
         return "Legion"
+
+    def cmdline(self, executable, options, task, rlimits):
+        data_model_param = get_data_model_from_task(
+            task, {"ILP32": "-32", "LP64": "-64"}
+        )
+        if data_model_param and data_model_param not in options:
+            options += [data_model_param]
+
+        return super().cmdline(executable, options, task, rlimits)

--- a/benchexec/tools/legion.py
+++ b/benchexec/tools/legion.py
@@ -43,4 +43,4 @@ class Tool(benchexec.tools.template.BaseTool2):
         if data_model_param and data_model_param not in options:
             options += [data_model_param]
 
-        return super().cmdline(executable, options, task, rlimits)
+        return [executable, *options, *task.input_files_or_identifier]

--- a/benchexec/tools/legion.py
+++ b/benchexec/tools/legion.py
@@ -6,7 +6,7 @@
 # SPDX-License-Identifier: Apache-2.0
 
 import benchexec.tools.template
-from benchexec.tools.sv_benchmarks_util import get_data_model_from_task
+from benchexec.tools.sv_benchmarks_util import get_data_model_from_task, ILP32, LP64
 
 
 class Tool(benchexec.tools.template.BaseTool2):
@@ -37,9 +37,7 @@ class Tool(benchexec.tools.template.BaseTool2):
         return "Legion"
 
     def cmdline(self, executable, options, task, rlimits):
-        data_model_param = get_data_model_from_task(
-            task, {"ILP32": "-32", "LP64": "-64"}
-        )
+        data_model_param = get_data_model_from_task(task, {ILP32: "-32", LP64: "-64"})
         if data_model_param and data_model_param not in options:
             options += [data_model_param]
 

--- a/benchexec/tools/libkluzzer.py
+++ b/benchexec/tools/libkluzzer.py
@@ -37,4 +37,4 @@ class Tool(benchexec.tools.template.BaseTool2):
         if data_model_param and data_model_param not in options:
             options += [data_model_param]
 
-        return super().cmdline(executable, options, task, rlimits)
+        return [executable, *options, *task.input_files_or_identifier]

--- a/benchexec/tools/libkluzzer.py
+++ b/benchexec/tools/libkluzzer.py
@@ -6,7 +6,7 @@
 # SPDX-License-Identifier: Apache-2.0
 
 import benchexec.tools.template
-from benchexec.tools.sv_benchmarks_util import get_data_model_from_task
+from benchexec.tools.sv_benchmarks_util import get_data_model_from_task, ILP32, LP64
 
 
 class Tool(benchexec.tools.template.BaseTool2):
@@ -31,9 +31,7 @@ class Tool(benchexec.tools.template.BaseTool2):
         return "LibKluzzer"
 
     def cmdline(self, executable, options, task, rlimits):
-        data_model_param = get_data_model_from_task(
-            task, {"ILP32": "--32", "LP64": "--64"}
-        )
+        data_model_param = get_data_model_from_task(task, {ILP32: "--32", LP64: "--64"})
         if data_model_param and data_model_param not in options:
             options += [data_model_param]
 

--- a/benchexec/tools/libkluzzer.py
+++ b/benchexec/tools/libkluzzer.py
@@ -5,11 +5,11 @@
 #
 # SPDX-License-Identifier: Apache-2.0
 
-import benchexec.util as util
 import benchexec.tools.template
+from benchexec.tools.sv_benchmarks_util import get_data_model_from_task
 
 
-class Tool(benchexec.tools.template.BaseTool):
+class Tool(benchexec.tools.template.BaseTool2):
     """
     Tool info for LibKluzzer (http://unihb.eu/kluzzer).
     """
@@ -21,11 +21,20 @@ class Tool(benchexec.tools.template.BaseTool):
             executable, self.REQUIRED_PATHS, parent_dir=True
         )
 
-    def executable(self):
-        return util.find_executable("LibKluzzer", "bin/LibKluzzer")
+    def executable(self, tool_locator):
+        return tool_locator.find_executable("LibKluzzer", subdir="bin")
 
     def version(self, executable):
         return self._version_from_tool(executable)
 
     def name(self):
         return "LibKluzzer"
+
+    def cmdline(self, executable, options, task, rlimits):
+        data_model_param = get_data_model_from_task(
+            task, {"ILP32": "--32", "LP64": "--64"}
+        )
+        if data_model_param and data_model_param not in options:
+            options += [data_model_param]
+
+        return super().cmdline(executable, options, task, rlimits)

--- a/benchexec/tools/map2check.py
+++ b/benchexec/tools/map2check.py
@@ -57,16 +57,20 @@ class Tool(benchexec.tools.template.BaseTool2):
         return "Map2Check"
 
     def cmdline(self, executable, options, task, rlimits):
-        sourcefiles = list(task.input_files_or_identifier)
-
-        assert len(sourcefiles) == 1, "only one sourcefile supported"
         assert task.property_file, "property file required"
 
-        sourcefile = sourcefiles[0]
         if self.__version == 6:
-            return [executable] + options + ["-c", task.property_file, sourcefile]
+            return (
+                [executable]
+                + options
+                + ["-c", task.property_file, task.single_input_file]
+            )
         elif self.__version > 6:
-            return [executable] + options + ["-p", task.property_file, sourcefile]
+            return (
+                [executable]
+                + options
+                + ["-p", task.property_file, task.single_input_file]
+            )
         assert False, "Unexpected version " + self.__version
 
     def determine_result(self, run):

--- a/benchexec/tools/map2check.py
+++ b/benchexec/tools/map2check.py
@@ -28,10 +28,10 @@ class Tool(benchexec.tools.template.BaseTool2):
     def executable(self, tool_locator):
         try:
             executable = tool_locator.find_executable("map2check-wrapper.sh")
-            self.__version = 6
+            self._version = 6
         except ToolNotFoundException:
             executable = tool_locator.find_executable("map2check-wrapper.py")
-            self.__version = 7
+            self._version = 7
 
         return executable
 
@@ -39,9 +39,9 @@ class Tool(benchexec.tools.template.BaseTool2):
         """
         Determine the file paths to be adopted
         """
-        if self.__version == 6:
+        if self._version == 6:
             paths = self.REQUIRED_PATHS_6
-        elif self.__version > 6:
+        elif self._version > 6:
             paths = self.REQUIRED_PATHS_7_1
 
         return paths
@@ -59,19 +59,19 @@ class Tool(benchexec.tools.template.BaseTool2):
     def cmdline(self, executable, options, task, rlimits):
         assert task.property_file, "property file required"
 
-        if self.__version == 6:
+        if self._version == 6:
             return (
                 [executable]
                 + options
                 + ["-c", task.property_file, task.single_input_file]
             )
-        elif self.__version > 6:
+        elif self._version > 6:
             return (
                 [executable]
                 + options
                 + ["-p", task.property_file, task.single_input_file]
             )
-        assert False, "Unexpected version " + self.__version
+        assert False, "Unexpected version " + self._version
 
     def determine_result(self, run):
         output = run.output
@@ -80,7 +80,7 @@ class Tool(benchexec.tools.template.BaseTool2):
         output = output[-1].strip()
         status = result.RESULT_UNKNOWN
 
-        if self.__version > 6:
+        if self._version > 6:
             if output.endswith("TRUE"):
                 status = result.RESULT_TRUE_PROP
             elif "FALSE" in output:
@@ -103,7 +103,7 @@ class Tool(benchexec.tools.template.BaseTool2):
             else:
                 status = "ERROR"
 
-        elif self.__version == 6:
+        elif self._version == 6:
             if output.endswith("TRUE"):
                 status = result.RESULT_TRUE_PROP
             elif "FALSE" in output:

--- a/benchexec/tools/map2check.py
+++ b/benchexec/tools/map2check.py
@@ -6,12 +6,12 @@
 # SPDX-License-Identifier: Apache-2.0
 
 import os
-import benchexec.util as util
 import benchexec.tools.template
 import benchexec.result as result
+from benchexec.tools.template import ToolNotFoundException
 
 
-class Tool(benchexec.tools.template.BaseTool):
+class Tool(benchexec.tools.template.BaseTool2):
     """
     This class serves as tool adaptor for Map2Check (https://github.com/hbgit/Map2Check)
     """
@@ -25,12 +25,15 @@ class Tool(benchexec.tools.template.BaseTool):
 
     REQUIRED_PATHS_7_1 = ["map2check", "map2check-wrapper.py", "bin", "include", "lib"]
 
-    def executable(self):
+    def executable(self, tool_locator):
+        # This is used in _get_version
+        self._tool_locator = tool_locator
+
         # Relative path to map2check wrapper
         if self._get_version() == 6:
-            return util.find_executable("map2check-wrapper.sh")
+            return tool_locator.find_executable("map2check-wrapper.sh")
         elif self._get_version() > 6:
-            return util.find_executable("map2check-wrapper.py")
+            return tool_locator.find_executable("map2check-wrapper.py")
         assert False, "Unexpected version " + self._get_version()
 
     def program_files(self, executable):
@@ -48,10 +51,10 @@ class Tool(benchexec.tools.template.BaseTool):
         """
         Determine the version based on map2check-wrapper.sh file
         """
-        exe_v6 = util.find_executable("map2check-wrapper.sh", exitOnError=False)
-        if exe_v6:
+        try:
+            self._tool_locator.find_executable("map2check-wrapper.sh")
             return 6
-        else:
+        except ToolNotFoundException:
             return 7
 
     def working_directory(self, executable):
@@ -64,17 +67,21 @@ class Tool(benchexec.tools.template.BaseTool):
     def name(self):
         return "Map2Check"
 
-    def cmdline(self, executable, options, sourcefiles, propertyfile, rlimits):
+    def cmdline(self, executable, options, task, rlimits):
+        sourcefiles = list(task.input_files_or_identifier)
+
         assert len(sourcefiles) == 1, "only one sourcefile supported"
-        assert propertyfile, "property file required"
+        assert task.property_file, "property file required"
+
         sourcefile = sourcefiles[0]
         if self._get_version() == 6:
-            return [executable] + options + ["-c", propertyfile, sourcefile]
+            return [executable] + options + ["-c", task.property_file, sourcefile]
         elif self._get_version() > 6:
-            return [executable] + options + ["-p", propertyfile, sourcefile]
+            return [executable] + options + ["-p", task.property_file, sourcefile]
         assert False, "Unexpected version " + self._get_version()
 
-    def determine_result(self, returncode, returnsignal, output, isTimeout):
+    def determine_result(self, run):
+        output = run.output
         if not output:
             return result.RESULT_UNKNOWN
         output = output[-1].strip()
@@ -98,7 +105,7 @@ class Tool(benchexec.tools.template.BaseTool):
                     status = result.RESULT_FALSE_REACH
             elif output.endswith("UNKNOWN"):
                 status = result.RESULT_UNKNOWN
-            elif isTimeout:
+            elif run.was_timeout:
                 status = "TIMEOUT"
             else:
                 status = "ERROR"
@@ -115,7 +122,7 @@ class Tool(benchexec.tools.template.BaseTool):
                     status = result.RESULT_FALSE_FREE
             elif output.endswith("UNKNOWN"):
                 status = result.RESULT_UNKNOWN
-            elif isTimeout:
+            elif run.was_timeout:
                 status = "TIMEOUT"
             else:
                 status = "ERROR"

--- a/benchexec/tools/pinaka.py
+++ b/benchexec/tools/pinaka.py
@@ -5,7 +5,7 @@
 #
 # SPDX-License-Identifier: Apache-2.0
 
-from benchexec.tools.sv_benchmarks_util import get_data_model_from_task
+from benchexec.tools.sv_benchmarks_util import get_data_model_from_task, ILP32, LP64
 import benchexec.tools.template
 import benchexec.result as result
 
@@ -26,9 +26,7 @@ class Tool(benchexec.tools.template.BaseTool2):
     def cmdline(self, executable, options, task, rlimits):
         if task.property_file:
             options = options + ["--propertyfile", task.property_file]
-        data_model_param = get_data_model_from_task(
-            task, {"ILP32": "--32", "LP64": "--64"}
-        )
+        data_model_param = get_data_model_from_task(task, {ILP32: "--32", LP64: "--64"})
         if data_model_param and data_model_param not in options:
             options += [data_model_param]
 

--- a/benchexec/tools/pinaka.py
+++ b/benchexec/tools/pinaka.py
@@ -5,7 +5,7 @@
 #
 # SPDX-License-Identifier: Apache-2.0
 
-import benchexec.util as util
+from benchexec.tools.sv_benchmarks_util import get_data_model_from_task
 import benchexec.tools.template
 import benchexec.result as result
 
@@ -26,7 +26,7 @@ class Tool(benchexec.tools.template.BaseTool2):
     def cmdline(self, executable, options, task, rlimits):
         if task.property_file:
             options = options + ["--propertyfile", task.property_file]
-        data_model_param = util.get_data_model_from_task(
+        data_model_param = get_data_model_from_task(
             task, {"ILP32": "--32", "LP64": "--64"}
         )
         if data_model_param and data_model_param not in options:

--- a/benchexec/tools/pinaka.py
+++ b/benchexec/tools/pinaka.py
@@ -38,11 +38,11 @@ class Tool(benchexec.tools.template.BaseTool2):
         status = ""
 
         if run.exit_code.value in [0, 10]:
-            if run.output.any_line_contains("VERIFICATION FAILED (ReachSafety)"):
+            if "VERIFICATION FAILED (ReachSafety)" in run.output:
                 status = result.RESULT_FALSE_REACH
-            elif run.output.any_line_contains("VERIFICATION FAILED (NoOverflow)"):
+            elif "VERIFICATION FAILED (NoOverflow)" in run.output:
                 status = result.RESULT_FALSE_OVERFLOW
-            elif run.output.any_line_contains("VERIFICATION SUCCESSFUL"):
+            elif "VERIFICATION SUCCESSFUL" in run.output:
                 status = result.RESULT_TRUE_PROP
             else:
                 status = result.RESULT_UNKNOWN

--- a/benchexec/tools/pinaka.py
+++ b/benchexec/tools/pinaka.py
@@ -35,11 +35,10 @@ class Tool(benchexec.tools.template.BaseTool2):
         return [executable] + options + list(task.input_files_or_identifier)
 
     def determine_result(self, run):
-        returncode = run.exit_code.value or 0
         output = run.output._lines
         status = ""
 
-        if not run.exit_code.signal and ((returncode == 0) or (returncode == 10)):
+        if run.exit_code.value in [0, 10]:
             if "VERIFICATION FAILED (ReachSafety)\n" in output:
                 status = result.RESULT_FALSE_REACH
             elif "VERIFICATION FAILED (NoOverflow)\n" in output:

--- a/benchexec/tools/pinaka.py
+++ b/benchexec/tools/pinaka.py
@@ -35,12 +35,11 @@ class Tool(benchexec.tools.template.BaseTool2):
         return [executable] + options + list(task.input_files_or_identifier)
 
     def determine_result(self, run):
-        returnsignal = run.exit_code.signal or 0
         returncode = run.exit_code.value or 0
         output = run.output._lines
         status = ""
 
-        if returnsignal == 0 and ((returncode == 0) or (returncode == 10)):
+        if not run.exit_code.signal and ((returncode == 0) or (returncode == 10)):
             if "VERIFICATION FAILED (ReachSafety)\n" in output:
                 status = result.RESULT_FALSE_REACH
             elif "VERIFICATION FAILED (NoOverflow)\n" in output:

--- a/benchexec/tools/pinaka.py
+++ b/benchexec/tools/pinaka.py
@@ -35,15 +35,14 @@ class Tool(benchexec.tools.template.BaseTool2):
         return [executable] + options + list(task.input_files_or_identifier)
 
     def determine_result(self, run):
-        output = run.output._lines
         status = ""
 
         if run.exit_code.value in [0, 10]:
-            if "VERIFICATION FAILED (ReachSafety)\n" in output:
+            if run.output.any_line_contains("VERIFICATION FAILED (ReachSafety)"):
                 status = result.RESULT_FALSE_REACH
-            elif "VERIFICATION FAILED (NoOverflow)\n" in output:
+            elif run.output.any_line_contains("VERIFICATION FAILED (NoOverflow)"):
                 status = result.RESULT_FALSE_OVERFLOW
-            elif "VERIFICATION SUCCESSFUL\n" in output:
+            elif run.output.any_line_contains("VERIFICATION SUCCESSFUL"):
                 status = result.RESULT_TRUE_PROP
             else:
                 status = result.RESULT_UNKNOWN

--- a/benchexec/tools/predatorhp.py
+++ b/benchexec/tools/predatorhp.py
@@ -5,7 +5,7 @@
 #
 # SPDX-License-Identifier: Apache-2.0
 
-from benchexec.tools.sv_benchmarks_util import get_data_model_from_task
+from benchexec.tools.sv_benchmarks_util import get_data_model_from_task, ILP32, LP64
 import benchexec.tools.template
 import benchexec.result as result
 
@@ -32,7 +32,7 @@ class Tool(benchexec.tools.template.BaseTool2):
 
         data_model_param = get_data_model_from_task(
             task,
-            {"ILP32": "--compiler-options=-m32", "LP64": "--compiler-options=-m64"},
+            {ILP32: "--compiler-options=-m32", LP64: "--compiler-options=-m64"},
         )
         if data_model_param and data_model_param not in options:
             options += [data_model_param]

--- a/benchexec/tools/predatorhp.py
+++ b/benchexec/tools/predatorhp.py
@@ -5,7 +5,7 @@
 #
 # SPDX-License-Identifier: Apache-2.0
 
-import benchexec.util as util
+from benchexec.tools.sv_benchmarks_util import get_data_model_from_task
 import benchexec.tools.template
 import benchexec.result as result
 
@@ -34,7 +34,7 @@ class Tool(benchexec.tools.template.BaseTool2):
             else []
         )
 
-        data_model_param = util.get_data_model_from_task(
+        data_model_param = get_data_model_from_task(
             task,
             {"ILP32": "--compiler-options=-m32", "LP64": "--compiler-options=-m64"},
         )

--- a/benchexec/tools/predatorhp.py
+++ b/benchexec/tools/predatorhp.py
@@ -35,10 +35,11 @@ class Tool(benchexec.tools.template.BaseTool2):
         )
 
         data_model_param = util.get_data_model_from_task(
-            task, {"ILP32": "-m32", "LP64": "-m64"}
+            task,
+            {"ILP32": "--compiler-options=-m32", "LP64": "--compiler-options=-m64"},
         )
         if data_model_param and data_model_param not in options:
-            options += ["--compiler-options", data_model_param]
+            options += [data_model_param]
 
         return [executable] + options + spec + list(task.input_files_or_identifier)
 

--- a/benchexec/tools/predatorhp.py
+++ b/benchexec/tools/predatorhp.py
@@ -28,11 +28,7 @@ class Tool(benchexec.tools.template.BaseTool2):
         return self._version_from_tool(executable, use_stderr=True)
 
     def cmdline(self, executable, options, task, rlimits):
-        spec = (
-            ["--propertyfile", task.property_file]
-            if task.property_file is not None
-            else []
-        )
+        spec = ["--propertyfile", task.property_file] if task.property_file else []
 
         data_model_param = get_data_model_from_task(
             task,

--- a/benchexec/tools/predatorhp.py
+++ b/benchexec/tools/predatorhp.py
@@ -44,21 +44,20 @@ class Tool(benchexec.tools.template.BaseTool2):
         return [executable] + options + spec + list(task.input_files_or_identifier)
 
     def determine_result(self, run):
-        output = "\n".join(run.output)
         status = "UNKNOWN"
-        if "UNKNOWN" in output:
+        if run.output.any_line_contains("UNKNOWN"):
             status = result.RESULT_UNKNOWN
-        elif "TRUE" in output:
+        elif run.output.any_line_contains("TRUE"):
             status = result.RESULT_TRUE_PROP
-        elif "FALSE(valid-memtrack)" in output:
+        elif run.output.any_line_contains("FALSE(valid-memtrack)"):
             status = result.RESULT_FALSE_MEMTRACK
-        elif "FALSE(valid-deref)" in output:
+        elif run.output.any_line_contains("FALSE(valid-deref)"):
             status = result.RESULT_FALSE_DEREF
-        elif "FALSE(valid-free)" in output:
+        elif run.output.any_line_contains("FALSE(valid-free)"):
             status = result.RESULT_FALSE_FREE
-        elif "FALSE(valid-memcleanup)" in output:
+        elif run.output.any_line_contains("FALSE(valid-memcleanup)"):
             status = result.RESULT_FALSE_MEMCLEANUP
-        elif "FALSE" in output:
+        elif run.output.any_line_contains("FALSE"):
             status = result.RESULT_FALSE_REACH
         if status == "UNKNOWN" and run.was_timeout:
             status = "TIMEOUT"

--- a/benchexec/tools/prtest.py
+++ b/benchexec/tools/prtest.py
@@ -6,7 +6,7 @@
 # SPDX-License-Identifier: Apache-2.0
 
 import benchexec.tools.template
-from benchexec.tools.sv_benchmarks_util import get_data_model_from_task
+from benchexec.tools.sv_benchmarks_util import get_data_model_from_task, ILP32, LP64
 
 
 class Tool(benchexec.tools.template.BaseTool2):
@@ -31,9 +31,7 @@ class Tool(benchexec.tools.template.BaseTool2):
         return "PRTest"
 
     def cmdline(self, executable, options, task, rlimits):
-        data_model_param = get_data_model_from_task(
-            task, {"ILP32": "-m32", "LP64": "-m64"}
-        )
+        data_model_param = get_data_model_from_task(task, {ILP32: "-m32", LP64: "-m64"})
         if data_model_param and data_model_param not in options:
             options += [data_model_param]
 

--- a/benchexec/tools/prtest.py
+++ b/benchexec/tools/prtest.py
@@ -37,4 +37,4 @@ class Tool(benchexec.tools.template.BaseTool2):
         if data_model_param and data_model_param not in options:
             options += [data_model_param]
 
-        return super().cmdline(executable, options, task, rlimits)
+        return [executable, *options, *task.input_files_or_identifier]

--- a/benchexec/tools/prtest.py
+++ b/benchexec/tools/prtest.py
@@ -5,11 +5,11 @@
 #
 # SPDX-License-Identifier: Apache-2.0
 
-import benchexec.util as util
 import benchexec.tools.template
+from benchexec.tools.sv_benchmarks_util import get_data_model_from_task
 
 
-class Tool(benchexec.tools.template.BaseTool):
+class Tool(benchexec.tools.template.BaseTool2):
     """
     Tool info for PRTest (https://gitlab.com/sosy-lab/software/prtest).
     """
@@ -21,11 +21,20 @@ class Tool(benchexec.tools.template.BaseTool):
             executable, self.REQUIRED_PATHS, parent_dir=True
         )
 
-    def executable(self):
-        return util.find_executable("prtest", "bin/prtest")
+    def executable(self, tool_locator):
+        return tool_locator.find_executable("prtest", subdir="bin")
 
     def version(self, executable):
         return self._version_from_tool(executable)
 
     def name(self):
         return "PRTest"
+
+    def cmdline(self, executable, options, task, rlimits):
+        data_model_param = get_data_model_from_task(
+            task, {"ILP32": "-m32", "LP64": "-m64"}
+        )
+        if data_model_param and data_model_param not in options:
+            options += [data_model_param]
+
+        return super().cmdline(executable, options, task, rlimits)

--- a/benchexec/tools/sv_benchmarks_util.py
+++ b/benchexec/tools/sv_benchmarks_util.py
@@ -8,16 +8,28 @@
 """
 This module contains some useful functions related to tasks in the sv-benchmarks
 repository: https://github.com/sosy-lab/sv-benchmarks
+
+Note the following points before using any function in this util:
+    1. This is not a part of stable benchexec API.
+       We do not provide any guarantee of backward compatibility of this module.
+    2. Out-of-tree modules should not use this util
+    3. Any function in this util may change at any point in time
 """
 
 import benchexec.tools.template
 
 
-def get_data_model_from_task(task, data_models):
+def get_data_model_from_task(task, param_dict):
+    """
+    This function tries to extract tool parameter for data model
+    depending on the data model in the task.
+    @param task: An instance of of class Task, e.g., with the input files
+    @param param_dict: Dictionary mapping data model to the tool param value
+    """
     if isinstance(task.options, dict) and task.options.get("language") == "C":
         data_model = task.options.get("data_model")
         if data_model:
-            data_model_option = data_models.get(data_model)
+            data_model_option = param_dict.get(data_model)
             if data_model_option:
                 return data_model_option
             else:

--- a/benchexec/tools/sv_benchmarks_util.py
+++ b/benchexec/tools/sv_benchmarks_util.py
@@ -1,0 +1,28 @@
+# This file is part of BenchExec, a framework for reliable benchmarking:
+# https://github.com/sosy-lab/benchexec
+#
+# SPDX-FileCopyrightText: 2007-2020 Dirk Beyer <https://www.sosy-lab.org>
+#
+# SPDX-License-Identifier: Apache-2.0
+
+"""
+This module contains some useful functions related to tasks in the sv-benchmarks
+repository: https://github.com/sosy-lab/sv-benchmarks
+"""
+
+import benchexec.tools.template
+
+def get_data_model_from_task(task, data_models):
+    if isinstance(task.options, dict) and task.options.get("language") == "C":
+        data_model = task.options.get("data_model")
+        if data_model:
+            data_model_option = data_models.get(data_model)
+            if data_model_option:
+                return data_model_option
+            else:
+                raise benchexec.tools.template.UnsupportedFeatureException(
+                    "Unsupported data_model '{}' defined for task '{}'".format(
+                        data_model, task
+                    )
+                )
+    return None

--- a/benchexec/tools/sv_benchmarks_util.py
+++ b/benchexec/tools/sv_benchmarks_util.py
@@ -18,6 +18,10 @@ Note the following points before using any function in this util:
 
 import benchexec.tools.template
 
+# Defining constants for data model.
+ILP32 = "ILP32"
+LP64 = "LP64"
+
 
 def get_data_model_from_task(task, param_dict):
     """

--- a/benchexec/tools/sv_benchmarks_util.py
+++ b/benchexec/tools/sv_benchmarks_util.py
@@ -12,6 +12,7 @@ repository: https://github.com/sosy-lab/sv-benchmarks
 
 import benchexec.tools.template
 
+
 def get_data_model_from_task(task, data_models):
     if isinstance(task.options, dict) and task.options.get("language") == "C":
         data_model = task.options.get("data_model")

--- a/benchexec/tools/symbiotic.py
+++ b/benchexec/tools/symbiotic.py
@@ -38,7 +38,7 @@ class Tool(OldSymbiotic):
             # this may be the old version of Symbiotic
             executable = OldSymbiotic.executable(self, tool_locator)
 
-        self.__version = self.version(executable)
+        self._version = self.version(executable)
         return executable
 
     def program_files(self, executable):
@@ -61,7 +61,7 @@ class Tool(OldSymbiotic):
         """
         Determine whether the version is greater than some given version
         """
-        vers_num = self.__version[: self.__version.index("-")]
+        vers_num = self._version[: self._version.index("-")]
         if not vers_num[0].isdigit():
             # this is the old version which is "older" than any given version
             return False

--- a/benchexec/tools/symbiotic.py
+++ b/benchexec/tools/symbiotic.py
@@ -107,7 +107,7 @@ class Tool(OldSymbiotic):
         returnsignal = run.exit_code.signal or 0
         returncode = run.exit_code.value or 0
 
-        if run.output is None:
+        if not run.output:
             return "{0}(no output)".format(result.RESULT_ERROR)
 
         if self._version_newer_than("4.0.1"):

--- a/benchexec/tools/symbiotic.py
+++ b/benchexec/tools/symbiotic.py
@@ -104,8 +104,6 @@ class Tool(OldSymbiotic):
         return lastphase
 
     def determine_result(self, run):
-        returncode = run.exit_code.value or 0
-
         if not run.output:
             return "{0}(no output)".format(result.RESULT_ERROR)
 
@@ -142,9 +140,9 @@ class Tool(OldSymbiotic):
             return "KILLED (signal {0}, {1})".format(
                 run.exit_code.signal, self._getPhase(run.output)
             )
-        elif returncode != 0:
+        elif run.exit_code.value != 0:
             return "{0}(returned {1}, {2})".format(
-                result.RESULT_ERROR, returncode, self._getPhase(run.output)
+                result.RESULT_ERROR, run.exit_code.value, self._getPhase(run.output)
             )
 
         return "{0}(unknown, {1})".format(

--- a/benchexec/tools/symbiotic.py
+++ b/benchexec/tools/symbiotic.py
@@ -104,7 +104,6 @@ class Tool(OldSymbiotic):
         return lastphase
 
     def determine_result(self, run):
-        returnsignal = run.exit_code.signal or 0
         returncode = run.exit_code.value or 0
 
         if not run.output:
@@ -139,9 +138,9 @@ class Tool(OldSymbiotic):
 
         if run.was_timeout:
             return self._getPhase(run.output)  # generates TIMEOUT(phase)
-        elif returnsignal != 0:
+        elif run.exit_code.signal:
             return "KILLED (signal {0}, {1})".format(
-                returnsignal, self._getPhase(run.output)
+                run.exit_code.signal, self._getPhase(run.output)
             )
         elif returncode != 0:
             return "{0}(returned {1}, {2})".format(

--- a/benchexec/tools/symbiotic.py
+++ b/benchexec/tools/symbiotic.py
@@ -32,14 +32,14 @@ class Tool(OldSymbiotic):
         and most implementations will look similar to this one.
         The path returned should be relative to the current directory.
         """
-        # This is used in the function _version_newer_than.
-        # I don't know a better way to do it.
-        self.tool_locator = tool_locator
         try:
-            return tool_locator.find_executable("symbiotic", subdir="bin")
+            executable = tool_locator.find_executable("symbiotic", subdir="bin")
         except ToolNotFoundException:
             # this may be the old version of Symbiotic
-            return OldSymbiotic.executable(self, tool_locator)
+            executable = OldSymbiotic.executable(self, tool_locator)
+
+        self.__version = self.version(executable)
+        return executable
 
     def program_files(self, executable):
         if self._version_newer_than("7.0.0"):
@@ -61,8 +61,7 @@ class Tool(OldSymbiotic):
         """
         Determine whether the version is greater than some given version
         """
-        v = self.version(self.executable(self.tool_locator))
-        vers_num = v[: v.index("-")]
+        vers_num = self.__version[: self.__version.index("-")]
         if not vers_num[0].isdigit():
             # this is the old version which is "older" than any given version
             return False

--- a/benchexec/tools/symbiotic4.py
+++ b/benchexec/tools/symbiotic4.py
@@ -5,7 +5,7 @@
 #
 # SPDX-License-Identifier: Apache-2.0
 
-from benchexec.tools.sv_benchmarks_util import get_data_model_from_task
+from benchexec.tools.sv_benchmarks_util import get_data_model_from_task, ILP32, LP64
 import benchexec.tools.template
 import benchexec.result as result
 
@@ -54,9 +54,7 @@ class Tool(benchexec.tools.template.BaseTool2):
         if task.property_file:
             options = options + ["--prp={0}".format(task.property_file)]
 
-        data_model_param = get_data_model_from_task(
-            task, {"ILP32": "--32", "LP64": "--64"}
-        )
+        data_model_param = get_data_model_from_task(task, {ILP32: "--32", LP64: "--64"})
         if data_model_param and data_model_param not in options:
             options += [data_model_param]
 

--- a/benchexec/tools/symbiotic4.py
+++ b/benchexec/tools/symbiotic4.py
@@ -66,7 +66,7 @@ class Tool(benchexec.tools.template.BaseTool2):
         if run.was_timeout:
             return "timeout"
 
-        if run.output is None:
+        if not run.output:
             return "error (no output)"
 
         for line in run.output:

--- a/benchexec/tools/symbiotic4.py
+++ b/benchexec/tools/symbiotic4.py
@@ -51,7 +51,7 @@ class Tool(benchexec.tools.template.BaseTool2):
         Compose the command line to execute from the name of the executable
         """
 
-        if task.property_file is not None:
+        if task.property_file:
             options = options + ["--prp={0}".format(task.property_file)]
 
         data_model_param = get_data_model_from_task(

--- a/benchexec/tools/symbiotic4.py
+++ b/benchexec/tools/symbiotic4.py
@@ -5,7 +5,7 @@
 #
 # SPDX-License-Identifier: Apache-2.0
 
-import benchexec.util as util
+from benchexec.tools.sv_benchmarks_util import get_data_model_from_task
 import benchexec.tools.template
 import benchexec.result as result
 
@@ -54,7 +54,7 @@ class Tool(benchexec.tools.template.BaseTool2):
         if task.property_file is not None:
             options = options + ["--prp={0}".format(task.property_file)]
 
-        data_model_param = util.get_data_model_from_task(
+        data_model_param = get_data_model_from_task(
             task, {"ILP32": "--32", "LP64": "--64"}
         )
         if data_model_param and data_model_param not in options:

--- a/benchexec/tools/symbiotic4.py
+++ b/benchexec/tools/symbiotic4.py
@@ -10,7 +10,7 @@ import benchexec.tools.template
 import benchexec.result as result
 
 
-class Tool(benchexec.tools.template.BaseTool):
+class Tool(benchexec.tools.template.BaseTool2):
     """
     Symbiotic tool info object
     """
@@ -25,14 +25,14 @@ class Tool(benchexec.tools.template.BaseTool):
         "symbiotic",
     ]
 
-    def executable(self):
+    def executable(self, tool_locator):
         """
         Find the path to the executable file that will get executed.
         This method always needs to be overridden,
         and most implementations will look similar to this one.
         The path returned should be relative to the current directory.
         """
-        return util.find_executable("symbiotic")
+        return tool_locator.find_executable("symbiotic")
 
     def version(self, executable):
         """
@@ -46,24 +46,30 @@ class Tool(benchexec.tools.template.BaseTool):
         """
         return "symbiotic"
 
-    def cmdline(self, executable, options, tasks, propertyfile=None, rlimits={}):
+    def cmdline(self, executable, options, task, rlimits):
         """
         Compose the command line to execute from the name of the executable
         """
 
-        if propertyfile is not None:
-            options = options + ["--prp={0}".format(propertyfile)]
+        if task.property_file is not None:
+            options = options + ["--prp={0}".format(task.property_file)]
 
-        return [executable] + options + tasks
+        data_model_param = util.get_data_model_from_task(
+            task, {"ILP32": "--32", "LP64": "--64"}
+        )
+        if data_model_param and data_model_param not in options:
+            options += [data_model_param]
 
-    def determine_result(self, returncode, returnsignal, output, isTimeout):
-        if isTimeout:
+        return [executable] + options + list(task.input_files_or_identifier)
+
+    def determine_result(self, run):
+        if run.was_timeout:
             return "timeout"
 
-        if output is None:
+        if run.output is None:
             return "error (no output)"
 
-        for line in output:
+        for line in run.output:
             line = line.strip()
             if line == "TRUE":
                 return result.RESULT_TRUE_PROP

--- a/benchexec/tools/testcov.py
+++ b/benchexec/tools/testcov.py
@@ -8,7 +8,7 @@
 import re
 import benchexec.result as result
 import benchexec.tools.template
-from benchexec.tools.sv_benchmarks_util import get_data_model_from_task
+from benchexec.tools.sv_benchmarks_util import get_data_model_from_task, ILP32, LP64
 
 
 class Tool(benchexec.tools.template.BaseTool):
@@ -27,9 +27,7 @@ class Tool(benchexec.tools.template.BaseTool):
         return tool_locator.find_executable("testcov", subdir="bin")
 
     def cmdline(self, executable, options, task, rlimits):
-        data_model_param = get_data_model_from_task(
-            task, {"ILP32": "-32", "LP64": "-64"}
-        )
+        data_model_param = get_data_model_from_task(task, {ILP32: "-32", LP64: "-64"})
         if data_model_param and data_model_param not in options:
             options += [data_model_param]
 

--- a/benchexec/tools/testcov.py
+++ b/benchexec/tools/testcov.py
@@ -7,8 +7,8 @@
 
 import re
 import benchexec.result as result
-import benchexec.util as util
 import benchexec.tools.template
+from benchexec.tools.sv_benchmarks_util import get_data_model_from_task
 
 
 class Tool(benchexec.tools.template.BaseTool):
@@ -23,15 +23,21 @@ class Tool(benchexec.tools.template.BaseTool):
             executable, self.REQUIRED_PATHS, parent_dir=True
         )
 
-    def executable(self):
-        return util.find_executable("testcov", "bin/testcov")
+    def executable(self, tool_locator):
+        return tool_locator.find_executable("testcov", subdir="bin")
 
-    def cmdline(self, executable, options, tasks, propertyfile=None, rlimits={}):
+    def cmdline(self, executable, options, task, rlimits):
+        data_model_param = get_data_model_from_task(
+            task, {"ILP32": "-32", "LP64": "-64"}
+        )
+        if data_model_param and data_model_param not in options:
+            options += [data_model_param]
+
         cmd = [executable] + options
-        if propertyfile:
-            cmd += ["--goal", propertyfile]
+        if task.property_file:
+            cmd += ["--goal", task.property_file]
 
-        return cmd + tasks
+        return cmd + list(task.input_files_or_identifier)
 
     def version(self, executable):
         return self._version_from_tool(executable)
@@ -39,7 +45,7 @@ class Tool(benchexec.tools.template.BaseTool):
     def name(self):
         return "TestCov"
 
-    def determine_result(self, returncode, returnsignal, output, isTimeout):
+    def determine_result(self, run):
         """
         Parse the output of the tool and extract the verification result.
         This method always needs to be overridden.
@@ -49,12 +55,12 @@ class Tool(benchexec.tools.template.BaseTool):
         and should give some indication of the failure reason
         (e.g., "CRASH", "OUT_OF_MEMORY", etc.).
         """
-        for line in reversed(output):
+        for line in reversed(run.output):
             if line.startswith("ERROR:"):
                 if "timeout" in line.lower():
                     return "TIMEOUT"
                 else:
-                    return "ERROR ({0})".format(returncode)
+                    return "ERROR ({0})".format(run.exit_code.value)
             elif line.startswith("Result: FALSE"):
                 return result.RESULT_FALSE_REACH
             elif line.startswith("Result: TRUE"):

--- a/benchexec/tools/tracerx.py
+++ b/benchexec/tools/tracerx.py
@@ -54,14 +54,8 @@ class Tool(benchexec.tools.template.BaseTool2):
             options += ["--property-file=" + task.property_file]
         if rlimits.memory:
             options += ["--max-memory=" + str(rlimits.memory)]
-        if rlimits.cputime_hard:
-            options += ["--max-time=" + str(rlimits.cputime_hard)]
-        if rlimits.walltime:
-            options += ["--max-walltime=" + str(rlimits.walltime)]
         if rlimits.cputime:
             options += ["--max-cputime-soft=" + str(rlimits.cputime)]
-        if rlimits.cputime_hard:
-            options += ["--max-cputime-hard=" + str(rlimits.cputime_hard)]
 
         data_model_param = get_data_model_from_task(
             task, {"ILP32": "--32", "LP64": "--64"}

--- a/benchexec/tools/tracerx.py
+++ b/benchexec/tools/tracerx.py
@@ -6,12 +6,12 @@
 # SPDX-License-Identifier: Apache-2.0
 
 import benchexec.result as result
-import benchexec.util as util
 import benchexec.tools.template
 import benchexec.model
+from benchexec.tools.sv_benchmarks_util import get_data_model_from_task
 
 
-class Tool(benchexec.tools.template.BaseTool):
+class Tool(benchexec.tools.template.BaseTool2):
     """
     Tool info for Tracer-X (https://www.comp.nus.edu.sg/~tracerx/).
     """
@@ -24,8 +24,8 @@ class Tool(benchexec.tools.template.BaseTool):
         "tracerx_build",
     ]
 
-    def executable(self):
-        return util.find_executable("bin/tracerx")
+    def executable(self, tool_locator):
+        return tool_locator.find_executable("tracerx", subdir="bin")
 
     def program_files(self, executable):
         return self._program_files_from_executable(
@@ -49,30 +49,32 @@ class Tool(benchexec.tools.template.BaseTool):
         version = self._version_from_tool(executable, line_prefix="KLEE")
         return version.split("(")[0].strip()
 
-    def cmdline(self, executable, options, tasks, propertyfile=None, rlimits={}):
-        if propertyfile:
-            options += ["--property-file=" + propertyfile]
-        if benchexec.model.MEMLIMIT in rlimits:
-            options += ["--max-memory=" + str(rlimits[benchexec.model.MEMLIMIT])]
-        if benchexec.model.TIMELIMIT in rlimits:
-            options += ["--max-time=" + str(rlimits[benchexec.model.TIMELIMIT])]
-        if benchexec.model.WALLTIMELIMIT in rlimits:
-            options += ["--max-walltime=" + str(rlimits[benchexec.model.WALLTIMELIMIT])]
-        if benchexec.model.SOFTTIMELIMIT in rlimits:
-            options += [
-                "--max-cputime-soft=" + str(rlimits[benchexec.model.SOFTTIMELIMIT])
-            ]
-        if benchexec.model.HARDTIMELIMIT in rlimits:
-            options += [
-                "--max-cputime-hard=" + str(rlimits[benchexec.model.HARDTIMELIMIT])
-            ]
+    def cmdline(self, executable, options, task, rlimits):
+        if task.property_file:
+            options += ["--property-file=" + task.property_file]
+        if rlimits.memory:
+            options += ["--max-memory=" + str(rlimits.memory)]
+        if rlimits.cputime_hard:
+            options += ["--max-time=" + str(rlimits.cputime_hard)]
+        if rlimits.walltime:
+            options += ["--max-walltime=" + str(rlimits.walltime)]
+        if rlimits.cputime:
+            options += ["--max-cputime-soft=" + str(rlimits.cputime)]
+        if rlimits.cputime_hard:
+            options += ["--max-cputime-hard=" + str(rlimits.cputime_hard)]
 
-        return [executable] + options + tasks
+        data_model_param = get_data_model_from_task(
+            task, {"ILP32": "--32", "LP64": "--64"}
+        )
+        if data_model_param and data_model_param not in options:
+            options += [data_model_param]
+
+        return [executable] + options + list(task.input_files_or_identifier)
 
     def name(self):
         return "Tracer-X"
 
-    def determine_result(self, returncode, returnsignal, output, isTimeout):
+    def determine_result(self, run):
         """
         Parse the output of the tool and extract the verification result.
         This method always needs to be overridden.
@@ -82,7 +84,7 @@ class Tool(benchexec.tools.template.BaseTool):
         and should give some indication of the failure reason
         (e.g., "CRASH", "OUT_OF_MEMORY", etc.).
         """
-        for line in output:
+        for line in run.output:
             if line.startswith("KLEE: ERROR: "):
                 if "ASSERTION FAIL:" in line:
                     return result.RESULT_FALSE_REACH
@@ -91,7 +93,7 @@ class Tool(benchexec.tools.template.BaseTool):
                 elif "overflow" in line:
                     return result.RESULT_FALSE_OVERFLOW
                 else:
-                    return "ERROR ({0})".format(returncode)
+                    return "ERROR ({0})".format(run.exit_code.value)
             if line.startswith("KLEE: done"):
                 return result.RESULT_DONE
         return result.RESULT_UNKNOWN

--- a/benchexec/tools/tracerx.py
+++ b/benchexec/tools/tracerx.py
@@ -8,7 +8,7 @@
 import benchexec.result as result
 import benchexec.tools.template
 import benchexec.model
-from benchexec.tools.sv_benchmarks_util import get_data_model_from_task
+from benchexec.tools.sv_benchmarks_util import get_data_model_from_task, ILP32, LP64
 
 
 class Tool(benchexec.tools.template.BaseTool2):
@@ -57,9 +57,7 @@ class Tool(benchexec.tools.template.BaseTool2):
         if rlimits.cputime:
             options += ["--max-cputime-soft=" + str(rlimits.cputime)]
 
-        data_model_param = get_data_model_from_task(
-            task, {"ILP32": "--32", "LP64": "--64"}
-        )
+        data_model_param = get_data_model_from_task(task, {ILP32: "--32", LP64: "--64"})
         if data_model_param and data_model_param not in options:
             options += [data_model_param]
 

--- a/benchexec/tools/two_ls.py
+++ b/benchexec/tools/two_ls.py
@@ -5,7 +5,7 @@
 #
 # SPDX-License-Identifier: Apache-2.0
 
-import benchexec.util as util
+from benchexec.tools.sv_benchmarks_util import get_data_model_from_task
 import benchexec.tools.template
 import benchexec.result as result
 
@@ -30,7 +30,7 @@ class Tool(benchexec.tools.template.BaseTool2):
         if task.property_file:
             options = options + ["--propertyfile", task.property_file]
 
-        data_model_param = util.get_data_model_from_task(
+        data_model_param = get_data_model_from_task(
             task, {"ILP32": "--32", "LP64": "--64"}
         )
         if data_model_param and data_model_param not in options:

--- a/benchexec/tools/two_ls.py
+++ b/benchexec/tools/two_ls.py
@@ -39,16 +39,17 @@ class Tool(benchexec.tools.template.BaseTool2):
         return [executable] + options + list(task.input_files_or_identifier)
 
     def determine_result(self, run):
-        returncode = run.exit_code.value or 0
-        if ((run.exit_code.signal == 9) or (run.exit_code.signal == 15)) and run.was_timeout:
+        if (
+            (run.exit_code.signal == 9) or (run.exit_code.signal == 15)
+        ) and run.was_timeout:
             status = "TIMEOUT"
         elif run.exit_code.signal == 9:
             status = "OUT OF MEMORY"
         elif run.exit_code.signal:
             status = "ERROR(SIGNAL " + str(run.exit_code.signal) + ")"
-        elif returncode == 0:
+        elif run.exit_code.value == 0:
             status = result.RESULT_TRUE_PROP
-        elif returncode == 10:
+        elif run.exit_code.value == 10:
             if run.output:
                 result_str = run.output[-1].strip()
                 if result_str == "FALSE(valid-memtrack)":

--- a/benchexec/tools/two_ls.py
+++ b/benchexec/tools/two_ls.py
@@ -5,7 +5,7 @@
 #
 # SPDX-License-Identifier: Apache-2.0
 
-from benchexec.tools.sv_benchmarks_util import get_data_model_from_task
+from benchexec.tools.sv_benchmarks_util import get_data_model_from_task, ILP32, LP64
 import benchexec.tools.template
 import benchexec.result as result
 
@@ -30,9 +30,7 @@ class Tool(benchexec.tools.template.BaseTool2):
         if task.property_file:
             options = options + ["--propertyfile", task.property_file]
 
-        data_model_param = get_data_model_from_task(
-            task, {"ILP32": "--32", "LP64": "--64"}
-        )
+        data_model_param = get_data_model_from_task(task, {ILP32: "--32", LP64: "--64"})
         if data_model_param and data_model_param not in options:
             options += [data_model_param]
 

--- a/benchexec/tools/two_ls.py
+++ b/benchexec/tools/two_ls.py
@@ -39,14 +39,13 @@ class Tool(benchexec.tools.template.BaseTool2):
         return [executable] + options + list(task.input_files_or_identifier)
 
     def determine_result(self, run):
-        returnsignal = run.exit_code.signal or 0
         returncode = run.exit_code.value or 0
-        if ((returnsignal == 9) or (returnsignal == 15)) and run.was_timeout:
+        if ((run.exit_code.signal == 9) or (run.exit_code.signal == 15)) and run.was_timeout:
             status = "TIMEOUT"
-        elif returnsignal == 9:
+        elif run.exit_code.signal == 9:
             status = "OUT OF MEMORY"
-        elif returnsignal != 0:
-            status = "ERROR(SIGNAL " + str(returnsignal) + ")"
+        elif run.exit_code.signal:
+            status = "ERROR(SIGNAL " + str(run.exit_code.signal) + ")"
         elif returncode == 0:
             status = result.RESULT_TRUE_PROP
         elif returncode == 10:

--- a/benchexec/tools/two_ls.py
+++ b/benchexec/tools/two_ls.py
@@ -50,7 +50,7 @@ class Tool(benchexec.tools.template.BaseTool2):
         elif returncode == 0:
             status = result.RESULT_TRUE_PROP
         elif returncode == 10:
-            if len(run.output) > 0:
+            if run.output:
                 result_str = run.output[-1].strip()
                 if result_str == "FALSE(valid-memtrack)":
                     status = result.RESULT_FALSE_MEMTRACK

--- a/benchexec/tools/verifuzz.py
+++ b/benchexec/tools/verifuzz.py
@@ -48,7 +48,7 @@ class Tool(benchexec.tools.template.BaseTool2):
         data_model_param = util.get_data_model_from_task(
             task, {"ILP32": "32", "LP64": "64"}
         )
-        if data_model_param and data_model_param not in options:
+        if data_model_param and "--bit" not in options:
             options += ["--bit", data_model_param]
 
         return [executable] + options + [task.single_input_file]

--- a/benchexec/tools/verifuzz.py
+++ b/benchexec/tools/verifuzz.py
@@ -5,7 +5,7 @@
 #
 # SPDX-License-Identifier: Apache-2.0
 
-from benchexec.tools.sv_benchmarks_util import get_data_model_from_task
+from benchexec.tools.sv_benchmarks_util import get_data_model_from_task, ILP32, LP64
 import benchexec.tools.template
 import benchexec.result as result
 
@@ -45,7 +45,7 @@ class Tool(benchexec.tools.template.BaseTool2):
         if task.property_file:
             options = options + ["--propertyFile", task.property_file]
 
-        data_model_param = get_data_model_from_task(task, {"ILP32": "32", "LP64": "64"})
+        data_model_param = get_data_model_from_task(task, {ILP32: "32", LP64: "64"})
         if data_model_param and "--bit" not in options:
             options += ["--bit", data_model_param]
 

--- a/benchexec/tools/verifuzz.py
+++ b/benchexec/tools/verifuzz.py
@@ -5,7 +5,7 @@
 #
 # SPDX-License-Identifier: Apache-2.0
 
-import benchexec.util as util
+from benchexec.tools.sv_benchmarks_util import get_data_model_from_task
 import benchexec.tools.template
 import benchexec.result as result
 
@@ -45,9 +45,7 @@ class Tool(benchexec.tools.template.BaseTool2):
         if task.property_file:
             options = options + ["--propertyFile", task.property_file]
 
-        data_model_param = util.get_data_model_from_task(
-            task, {"ILP32": "32", "LP64": "64"}
-        )
+        data_model_param = get_data_model_from_task(task, {"ILP32": "32", "LP64": "64"})
         if data_model_param and "--bit" not in options:
             options += ["--bit", data_model_param]
 

--- a/benchexec/tools/verifuzz.py
+++ b/benchexec/tools/verifuzz.py
@@ -5,6 +5,7 @@
 #
 # SPDX-License-Identifier: Apache-2.0
 
+import benchexec.util as util
 import benchexec.tools.template
 import benchexec.result as result
 
@@ -43,6 +44,13 @@ class Tool(benchexec.tools.template.BaseTool2):
     def cmdline(self, executable, options, task, rlimits):
         if task.property_file:
             options = options + ["--propertyFile", task.property_file]
+
+        data_model_param = util.get_data_model_from_task(
+            task, {"ILP32": "32", "LP64": "64"}
+        )
+        if data_model_param and data_model_param not in options:
+            options += ["--bit", data_model_param]
+
         return [executable] + options + [task.single_input_file]
 
     def determine_result(self, run):

--- a/benchexec/util.py
+++ b/benchexec/util.py
@@ -767,6 +767,7 @@ def check_msr():
 def get_data_model_from_task(task, data_models):
     # Importing it here, otherwise it will result in cyclic dependency.
     import benchexec.tools.template
+
     if isinstance(task.options, dict) and task.options.get("language") == "C":
         data_model = task.options.get("data_model")
         if data_model:

--- a/benchexec/util.py
+++ b/benchexec/util.py
@@ -762,22 +762,3 @@ def check_msr():
         if all(os.access("/dev/cpu/{}/msr".format(cpu), os.W_OK) for cpu in cpu_dirs):
             res["write"] = True
     return res
-
-
-def get_data_model_from_task(task, data_models):
-    # Importing it here, otherwise it will result in cyclic dependency.
-    import benchexec.tools.template
-
-    if isinstance(task.options, dict) and task.options.get("language") == "C":
-        data_model = task.options.get("data_model")
-        if data_model:
-            data_model_option = data_models.get(data_model)
-            if data_model_option:
-                return data_model_option
-            else:
-                raise benchexec.tools.template.UnsupportedFeatureException(
-                    "Unsupported data_model '{}' defined for task '{}'".format(
-                        data_model, task
-                    )
-                )
-    return None

--- a/benchexec/util.py
+++ b/benchexec/util.py
@@ -762,3 +762,21 @@ def check_msr():
         if all(os.access("/dev/cpu/{}/msr".format(cpu), os.W_OK) for cpu in cpu_dirs):
             res["write"] = True
     return res
+
+
+def get_data_model_from_task(task, data_models):
+    # Importing it here, otherwise it will result in cyclic dependency.
+    import benchexec.tools.template
+    if isinstance(task.options, dict) and task.options.get("language") == "C":
+        data_model = task.options.get("data_model")
+        if data_model:
+            data_model_option = data_models.get(data_model)
+            if data_model_option:
+                return data_model_option
+            else:
+                raise benchexec.tools.template.UnsupportedFeatureException(
+                    "Unsupported data_model '{}' defined for task '{}'".format(
+                        data_model, task
+                    )
+                )
+    return None


### PR DESCRIPTION
updated tool info modules of verification (and validation) tools from sv-comp 20 to start using data models from the task dict.
this is required for the competition after [PR 169](https://github.com/sosy-lab/sv-comp/pull/169) in benchmark definitions repo is merged

The following are still remaining: 
1. ultimate based tools - it is a bit more complicated. Should be dealt separately

