### PR TITLE
Add tool-info module for frama-c-sv

### DIFF
--- a/benchexec/tools/frama-c-sv.py
+++ b/benchexec/tools/frama-c-sv.py
@@ -5,7 +5,6 @@
 #
 # SPDX-License-Identifier: Apache-2.0
 
-import benchexec.util as util
 import benchexec.tools.template
 
 
@@ -29,7 +28,7 @@ class Tool(benchexec.tools.template.BaseTool2):
         return Tool._TOOL_NAME
 
     def cmdline(self, executable, options, task, rlimits):
-        cmd = [executable, "--program"] + list(task.input_files_or_identifier)
+        cmd = [executable, "--program"] + list(task.input_files)
         if task.property_file:
             cmd += ["--property", task.property_file]
         return cmd

--- a/benchexec/tools/frama-c-sv.py
+++ b/benchexec/tools/frama-c-sv.py
@@ -16,7 +16,7 @@ class Tool(benchexec.tools.template.BaseTool2):
     """
 
     REQUIRED_PATHS = ["."]
-    _TOOL_NAME = "frama-c-sv.py"
+    _TOOL_NAME = "frama-c-sv"
     _SCRIPT_NAME = _TOOL_NAME + ".py"
 
     def executable(self, _):

--- a/benchexec/tools/frama-c-sv.py
+++ b/benchexec/tools/frama-c-sv.py
@@ -1,0 +1,43 @@
+# This file is part of BenchExec, a framework for reliable benchmarking:
+# https://github.com/sosy-lab/benchexec
+#
+# SPDX-FileCopyrightText: 2007-2020 Dirk Beyer <https://www.sosy-lab.org>
+#
+# SPDX-License-Identifier: Apache-2.0
+
+import benchexec.util as util
+import benchexec.tools.template
+
+
+class Tool(benchexec.tools.template.BaseTool2):
+    """
+    Tool info for Frama-C with a wrapper for usage in the SVCOMP.
+    URL: https://gitlab.com/sosy-lab/software/frama-c-sv
+    """
+
+    REQUIRED_PATHS = ["."]
+    _TOOL_NAME = "frama-c-sv.py"
+    _SCRIPT_NAME = _TOOL_NAME + ".py"
+
+    def executable(self, _):
+        return util.find_executable(_SCRIPT_NAME)
+
+    def program_files(self, executable):
+        return self._program_files_from_executable(
+            executable, self.REQUIRED_PATHS, parent_dir=True
+        )
+
+    def version(self, executable):
+        return self._version_from_tool(executable)
+
+    def name(self):
+        return _TOOL_NAME
+
+    def cmdline(self, executable, options, task, rlimits):
+        cmd = [_SCRIPT_NAME, "--program"] + list(task.input_files_or_identifier)
+        if task.property_file:
+            cmd += ["--property", task.property_file]
+        return cmd
+
+    def determine_result(self, run):
+        return run.output[-1].split(":", maxsplit=2)[-1]

--- a/benchexec/tools/frama-c-sv.py
+++ b/benchexec/tools/frama-c-sv.py
@@ -19,22 +19,17 @@ class Tool(benchexec.tools.template.BaseTool2):
     _TOOL_NAME = "frama-c-sv"
     _SCRIPT_NAME = _TOOL_NAME + ".py"
 
-    def executable(self, _):
-        return util.find_executable(_SCRIPT_NAME)
-
-    def program_files(self, executable):
-        return self._program_files_from_executable(
-            executable, self.REQUIRED_PATHS, parent_dir=True
-        )
+    def executable(self, tool_locator):
+        return tool_locator.find_executable(Tool._SCRIPT_NAME)
 
     def version(self, executable):
         return self._version_from_tool(executable)
 
     def name(self):
-        return _TOOL_NAME
+        return Tool._TOOL_NAME
 
     def cmdline(self, executable, options, task, rlimits):
-        cmd = [_SCRIPT_NAME, "--program"] + list(task.input_files_or_identifier)
+        cmd = [executable, "--program"] + list(task.input_files_or_identifier)
         if task.property_file:
             cmd += ["--property", task.property_file]
         return cmd


### PR DESCRIPTION
We want to execute Frama-C as part of SV-COMP.
~~As such the tool-info
module needs to be updated. The previous version was never really
useful because previous efforts of running Frama-C in a portable
fashion where unsuccessful (due to hardcoded absolute paths).
Now we have a different approach where we rely on Frama-C being
installed on the benchmark system (from the official package sources)
and just call that executable.~~
For that we develop a wrapper around Frama-C named `frama-c-sv`.
We rely on Frama-C being installed on the
benchmark system and just call that executable.

The wrapper itself will:
- add some config selection based on the property
- add ACSL annotations where necessary (e.g. to mark reach_error)
- add a harness for the `__VERIFIER*` functions such that Frama-C
  can understand their SV-COMP-specific meaning.
- also support output of minimal witnesses.

~~and is developed at <https://gitlab.com/sosy-lab/software/frama-c-svcomp> (currently still private, will change soon).~~
and is developed at <https://gitlab.com/sosy-lab/software/frama-c-sv> (currently still private, will change soon).

~~If we want to have this as a separate tool-info module, we can
also do this, I have no strong feelings here.
@lembergerth would this rewrite be OK for you?~~
We decided to make it a separate tool-info module named `frama-c-sv`