### PR TITLE
Refactor metaval tool-info module:extend BaseTool2

### DIFF
--- a/benchexec/tools/metaval.py
+++ b/benchexec/tools/metaval.py
@@ -96,39 +96,36 @@ class Tool(benchexec.tools.template.BaseTool2):
                     "benchexec.tools." + verifierName, fromlist=["Tool"]
                 ).Tool()
 
-        if verifierName in self.wrappedTools:
-            tool = self.wrappedTools[verifierName]
-            assert isinstance(
-                tool, BaseTool2
-            ), "we expect that all wrapped tools extend BaseTool2"
-            wrapped_executable = tool.executable(
-                BaseTool2.ToolLocator(
-                    tool_directory=self.TOOL_TO_PATH_MAP[verifierName]
-                )
-            )
-            wrappedOptions = tool.cmdline(
-                wrapped_executable,
-                options,
-                [os.path.relpath(os.path.join(os.getcwd(), "output/ARG.c"))],
-                rlimits,
-            )
-
-            return (
-                [
-                    executable,
-                    "--verifier",
-                    self.TOOL_TO_PATH_MAP[verifierName],
-                    "--witness",
-                    witnessName,
-                ]
-                + additionalPathArgument
-                + witnessTypeArgument
-                + list(task.single_input_file)
-                + ["--"]
-                + wrappedOptions
-            )
-        else:
+        if not verifierName in self.wrappedTools:
             sys.exit("ERROR: Could not find wrapped tool")  # noqa: R503 always raises
+        tool = self.wrappedTools[verifierName]
+        assert isinstance(
+            tool, BaseTool2
+        ), "we expect that all wrapped tools extend BaseTool2"
+        wrapped_executable = tool.executable(
+            BaseTool2.ToolLocator(tool_directory=self.TOOL_TO_PATH_MAP[verifierName])
+        )
+        wrappedOptions = tool.cmdline(
+            wrapped_executable,
+            options,
+            [os.path.relpath(os.path.join(os.getcwd(), "output/ARG.c"))],
+            rlimits,
+        )
+
+        return (
+            [
+                executable,
+                "--verifier",
+                self.TOOL_TO_PATH_MAP[verifierName],
+                "--witness",
+                witnessName,
+            ]
+            + additionalPathArgument
+            + witnessTypeArgument
+            + list(task.single_input_file)
+            + ["--"]
+            + wrappedOptions
+        )
 
     def version(self, executable):
         stdout = self._version_from_tool(executable, "--version")

--- a/benchexec/tools/metaval.py
+++ b/benchexec/tools/metaval.py
@@ -29,7 +29,7 @@ class Tool(benchexec.tools.template.BaseTool2):
     """
 
     TOOL_TO_PATH_MAP = {
-        "cpachecker-metaval": "CPAchecker-backend",
+        "cpachecker-metaval": "CPAchecker-frontend",
         "cpachecker": "CPAchecker",
         "esbmc": "esbmc",
         "symbiotic": "symbiotic",

--- a/benchexec/tools/metaval.py
+++ b/benchexec/tools/metaval.py
@@ -9,10 +9,7 @@ import argparse
 import benchexec.util as util
 import benchexec.tools.template
 from benchexec.tools.template import BaseTool2
-import contextlib
-import os
 import re
-import sys
 import threading
 
 

--- a/benchexec/tools/metaval.py
+++ b/benchexec/tools/metaval.py
@@ -104,7 +104,7 @@ class Tool(benchexec.tools.template.BaseTool2):
             BaseTool2.ToolLocator(tool_directory=self.TOOL_TO_PATH_MAP[verifierName])
         )
         wrappedtask = BaseTool2.Task(
-            input_files=[os.path.relpath(os.path.join(os.getcwd(), "output/ARG.c"))],
+            input_files=["../output/ARG.c"],
             identifier=task.identifier,
             property_file=task.property_file,
             options=task.options,

--- a/benchexec/tools/metaval.py
+++ b/benchexec/tools/metaval.py
@@ -8,9 +8,11 @@
 import argparse
 import benchexec.util as util
 import benchexec.tools.template
-from benchexec.tools.template import BaseTool2
+import os
 import re
 import threading
+
+from benchexec.tools.template import BaseTool2
 
 
 class Tool(benchexec.tools.template.BaseTool2):
@@ -46,10 +48,10 @@ class Tool(benchexec.tools.template.BaseTool2):
     def name(self):
         return "metaval"
 
-    def determine_result(self, returncode, returnsignal, output, isTimeout):
+    def determine_result(self, run):
         verifierDir = None
         regex = re.compile("verifier used in MetaVal is (.*)")
-        for line in output[:20]:
+        for line in run.output[:20]:
             match = regex.match(line)
             if match is not None:
                 verifierDir = match.group(1)
@@ -66,7 +68,7 @@ class Tool(benchexec.tools.template.BaseTool2):
         assert isinstance(
             tool, BaseTool2
         ), "we expect that all wrapped tools extend BaseTool2"
-        return tool.determine_result(returncode, returnsignal, output, isTimeout)
+        return tool.determine_result(run)
 
     def cmdline(self, executable, options, task, rlimits):
         parser = argparse.ArgumentParser(add_help=False, usage=argparse.SUPPRESS)
@@ -101,7 +103,7 @@ class Tool(benchexec.tools.template.BaseTool2):
             BaseTool2.ToolLocator(tool_directory=self.TOOL_TO_PATH_MAP[verifierName])
         )
         wrappedtask = BaseTool2.Task(
-            input_files=["../output/ARG.c"],
+            input_files=["output/ARG.c"],
             identifier=task.identifier,
             property_file=task.property_file,
             options=task.options,
@@ -123,7 +125,7 @@ class Tool(benchexec.tools.template.BaseTool2):
             ]
             + additionalPathArgument
             + witnessTypeArgument
-            + list(task.single_input_file)
+            + [task.single_input_file]
             + ["--"]
             + wrappedOptions
         )

--- a/benchexec/tools/metaval.py
+++ b/benchexec/tools/metaval.py
@@ -124,6 +124,7 @@ class Tool(benchexec.tools.template.BaseTool2):
             ]
             + additionalPathArgument
             + witnessTypeArgument
+            + ["--property", task.property_file]
             + [task.single_input_file]
             + ["--"]
             + wrappedOptions

--- a/benchexec/tools/metaval.py
+++ b/benchexec/tools/metaval.py
@@ -103,10 +103,16 @@ class Tool(benchexec.tools.template.BaseTool2):
         wrapped_executable = tool.executable(
             BaseTool2.ToolLocator(tool_directory=self.TOOL_TO_PATH_MAP[verifierName])
         )
+        wrappedtask = BaseTool2.Task(
+            input_files=[os.path.relpath(os.path.join(os.getcwd(), "output/ARG.c"))],
+            identifier=task.identifier,
+            property_file=task.property_file,
+            options=task.options,
+        )
         wrappedOptions = tool.cmdline(
             wrapped_executable,
             options,
-            [os.path.relpath(os.path.join(os.getcwd(), "output/ARG.c"))],
+            wrappedtask,
             rlimits,
         )
 

--- a/benchexec/tools/metaval.py
+++ b/benchexec/tools/metaval.py
@@ -6,7 +6,6 @@
 # SPDX-License-Identifier: Apache-2.0
 
 import argparse
-import benchexec.util as util
 import benchexec.tools.template
 import os
 import re

--- a/benchexec/tools/metaval.py
+++ b/benchexec/tools/metaval.py
@@ -80,15 +80,10 @@ class Tool(benchexec.tools.template.BaseTool2):
         verifierName = self.PATH_TO_TOOL_MAP[verifierDir]
 
         tool = self.wrappedTools[verifierName]
-        if isinstance(tool, BaseTool2):
-            return tool.determine_result(returncode, returnsignal, output, isTimeout)
-        elif isinstance(tool, BaseTool):
-            with self._in_tool_directory(verifierName):
-                return tool.determine_result(
-                    returncode, returnsignal, output, isTimeout
-                )
-        else:
-            sys.exit("ERROR: unknown BaseTool version.")
+        assert isinstance(
+            tool, BaseTool2
+        ), "we expect that all wrapped tools extend BaseTool2"
+        return tool.determine_result(returncode, returnsignal, output, isTimeout)
 
     def cmdline(self, executable, options, task, rlimits):
         parser = argparse.ArgumentParser(add_help=False, usage=argparse.SUPPRESS)
@@ -117,7 +112,9 @@ class Tool(benchexec.tools.template.BaseTool2):
 
         if verifierName in self.wrappedTools:
             tool = self.wrappedTools[verifierName]
-            assert isinstance(tool, BaseTool2): "we expect that all wrapped tools extend BaseTool2"
+            assert isinstance(
+                tool, BaseTool2
+            ), "we expect that all wrapped tools extend BaseTool2"
             wrapped_executable = self.wrappedTools[verifierName].executable(
                 BaseTool2.ToolLocator(
                     tool_directory=self.TOOL_TO_PATH_MAP[verifierName]

--- a/benchexec/tools/metaval.py
+++ b/benchexec/tools/metaval.py
@@ -117,30 +117,18 @@ class Tool(benchexec.tools.template.BaseTool2):
 
         if verifierName in self.wrappedTools:
             tool = self.wrappedTools[verifierName]
-            if isinstance(tool, BaseTool2):
-                wrapped_executable = self.wrappedTools[verifierName].executable(
-                    BaseTool2.ToolLocator(
-                        tool_directory=self.TOOL_TO_PATH_MAP[verifierName]
-                    )
+            assert isinstance(tool, BaseTool2): "we expect that all wrapped tools extend BaseTool2"
+            wrapped_executable = self.wrappedTools[verifierName].executable(
+                BaseTool2.ToolLocator(
+                    tool_directory=self.TOOL_TO_PATH_MAP[verifierName]
                 )
-                wrappedOptions = self.wrappedTools[verifierName].cmdline(
-                    wrapped_executable,
-                    options,
-                    [os.path.relpath(os.path.join(os.getcwd(), "output/ARG.c"))],
-                    rlimits,
-                )
-            elif isinstance(tool, BaseTool):
-                with self._in_tool_directory(verifierName) as oldcwd:
-                    wrapped_executable = self.wrappedTools[verifierName].executable()
-                    wrappedOptions = self.wrappedTools[verifierName].cmdline(
-                        wrapped_executable,
-                        options,
-                        [os.path.relpath(os.path.join(oldcwd, "output/ARG.c"))],
-                        os.path.relpath(os.path.join(oldcwd, task.property_file)),
-                        rlimits,
-                    )
-            else:
-                sys.exit("ERROR: unknown BaseTool version.")
+            )
+            wrappedOptions = self.wrappedTools[verifierName].cmdline(
+                wrapped_executable,
+                options,
+                [os.path.relpath(os.path.join(os.getcwd(), "output/ARG.c"))],
+                rlimits,
+            )
 
             return (
                 [

--- a/benchexec/tools/metaval.py
+++ b/benchexec/tools/metaval.py
@@ -29,8 +29,8 @@ class Tool(benchexec.tools.template.BaseTool2):
     """
 
     TOOL_TO_PATH_MAP = {
-        "cpachecker-metaval": "CPAchecker",
-        "cpachecker": "CPAchecker-1.7-svn 29852-unix",
+        "cpachecker-metaval": "CPAchecker-backend",
+        "cpachecker": "CPAchecker",
         "esbmc": "esbmc",
         "symbiotic": "symbiotic",
         "yogar-cbmc": "yogar-cbmc",

--- a/benchexec/tools/metaval.py
+++ b/benchexec/tools/metaval.py
@@ -7,7 +7,6 @@
 
 import argparse
 import benchexec.tools.template
-import os
 import re
 import threading
 

--- a/benchexec/tools/metaval.py
+++ b/benchexec/tools/metaval.py
@@ -96,8 +96,6 @@ class Tool(benchexec.tools.template.BaseTool2):
                     "benchexec.tools." + verifierName, fromlist=["Tool"]
                 ).Tool()
 
-        if not verifierName in self.wrappedTools:
-            sys.exit("ERROR: Could not find wrapped tool")  # noqa: R503 always raises
         tool = self.wrappedTools[verifierName]
         assert isinstance(
             tool, BaseTool2

--- a/benchexec/tools/metaval.py
+++ b/benchexec/tools/metaval.py
@@ -8,7 +8,7 @@
 import argparse
 import benchexec.util as util
 import benchexec.tools.template
-from benchexec.tools.template import BaseTool, BaseTool2
+from benchexec.tools.template import BaseTool2
 import contextlib
 import os
 import re

--- a/benchexec/tools/metaval.py
+++ b/benchexec/tools/metaval.py
@@ -49,20 +49,6 @@ class Tool(benchexec.tools.template.BaseTool2):
     def name(self):
         return "metaval"
 
-    @contextlib.contextmanager
-    def _in_tool_directory(self, verifierName):
-        """
-        Context manager that sets the current working directory to the tool's directory
-        and resets its afterward. The returned value is the previous working directory.
-        """
-        with self.lock:
-            try:
-                oldcwd = os.getcwd()
-                os.chdir(os.path.join(oldcwd, self.TOOL_TO_PATH_MAP[verifierName]))
-                yield oldcwd
-            finally:
-                os.chdir(oldcwd)
-
     def determine_result(self, returncode, returnsignal, output, isTimeout):
         verifierDir = None
         regex = re.compile("verifier used in MetaVal is (.*)")
@@ -115,12 +101,12 @@ class Tool(benchexec.tools.template.BaseTool2):
             assert isinstance(
                 tool, BaseTool2
             ), "we expect that all wrapped tools extend BaseTool2"
-            wrapped_executable = self.wrappedTools[verifierName].executable(
+            wrapped_executable = tool.executable(
                 BaseTool2.ToolLocator(
                     tool_directory=self.TOOL_TO_PATH_MAP[verifierName]
                 )
             )
-            wrappedOptions = self.wrappedTools[verifierName].cmdline(
+            wrappedOptions = tool.cmdline(
                 wrapped_executable,
                 options,
                 [os.path.relpath(os.path.join(os.getcwd(), "output/ARG.c"))],
@@ -137,7 +123,7 @@ class Tool(benchexec.tools.template.BaseTool2):
                 ]
                 + additionalPathArgument
                 + witnessTypeArgument
-                + list(task.input_files_or_empty)
+                + list(task.single_input_file)
                 + ["--"]
                 + wrappedOptions
             )

--- a/benchexec/tools/ultimate.py
+++ b/benchexec/tools/ultimate.py
@@ -225,9 +225,7 @@ class UltimateTool(benchexec.tools.template.BaseTool2):
         )
         raise UnsupportedFeatureException(msg)
 
-    def _get_additional_data_model_from_task(
-        self, options, task
-    ) -> Optional[List[str]]:
+    def _get_additional_data_model_from_task(self, options, task) -> List[str]:
         data_model_param = get_data_model_from_task(
             task, {ILP32: "32bit", LP64: "64bit"}
         )
@@ -246,7 +244,7 @@ class UltimateTool(benchexec.tools.template.BaseTool2):
                     options,
                     arch,
                 )
-        return None
+        return []
 
     def _cmdline_no_wrapper(self, executable, options, task, resource_limits):
         mem_bytes = resource_limits.memory


### PR DESCRIPTION
This updates the metaval tool-info module to inherit from the new `BaseTool2` base class.