### PR TITLE
Adjust location of task-definition format

### DIFF
--- a/doc/benchexec.md
+++ b/doc/benchexec.md
@@ -115,7 +115,7 @@ such as tasks with several input files
 or tasks where BenchExec should compare the produced tool output against an expected result.
 The files need to be in [YAML format](http://yaml.org/) (which is a superset of JSON)
 and their structure needs to adhere to the
-[task-definition format](https://gitlab.com/sosy-lab/software/task-definition-format)
+[task-definition format](https://gitlab.com/sosy-lab/benchmarking/task-definition-format)
 (cf. also our [example file doc/task-definition-example.yml](task-definition-example.yml)).
 BenchExec supports versions 1.0 and 2.0 of the format.
 For creating task-definition files for existing tasks

--- a/doc/task-definition-example.yml
+++ b/doc/task-definition-example.yml
@@ -6,7 +6,7 @@
 # SPDX-License-Identifier: Apache-2.0
 
 # The official definition of this format is at
-# https://gitlab.com/sosy-lab/software/task-definition-format
+# https://gitlab.com/sosy-lab/benchmarking/task-definition-format
 
 # Required, string with format version of this file
 format_version: "2.0"


### PR DESCRIPTION
Repo for task-definition format was inappropriate in group `software` and was now moved to the more appropriate group `benchmarking`.