### PR TITLE
remove variables that are assigned twice.

### DIFF
--- a/benchexec/tools/ceagle.py
+++ b/benchexec/tools/ceagle.py
@@ -29,7 +29,6 @@ class Tool(benchexec.tools.template.BaseTool):
 
     def determine_result(self, returncode, returnsignal, output, isTimeout):
 
-        status = result.RESULT_UNKNOWN
         stroutput = str(output)
 
         if isTimeout:

--- a/benchexec/tools/cseq.py
+++ b/benchexec/tools/cseq.py
@@ -39,7 +39,6 @@ class CSeqTool(benchexec.tools.template.BaseTool2):
         return [executable] + options + spec + ["--input", task.single_input_file]
 
     def determine_result(self, run):
-        status = result.RESULT_UNKNOWN
         if run.output.any_line_contains("FALSE"):
             status = result.RESULT_FALSE_REACH
         elif run.output.any_line_contains("TRUE"):


### PR DESCRIPTION
Found by lgtm.com:
Assignment to a variable occurs multiple times
without any intermediate use of that variable.