### PR TITLE
Add required paths for witnesslint

### DIFF
--- a/benchexec/tools/witnesslint.py
+++ b/benchexec/tools/witnesslint.py
@@ -15,6 +15,8 @@ class Tool(benchexec.tools.template.BaseTool2):
     (https://github.com/sosy-lab/sv-witnesses)
     """
 
+    REQUIRED_PATHS = ["witnesslint"]
+
     def executable(self, tool_locator):
         return tool_locator.find_executable("witnesslinter.py")
 


### PR DESCRIPTION
The tool will fail otherwise in case we require its files to be transported (e.g. to a cloud-based executor).