### PR TITLE
removed access by index on determine_result (ESBMC)

### DIFF
--- a/benchexec/tools/esbmc.py
+++ b/benchexec/tools/esbmc.py
@@ -65,7 +65,7 @@ class Tool(benchexec.tools.template.BaseTool2):
         if status == result.RESULT_UNKNOWN:
             if run.was_timeout:
                 status = "TIMEOUT"
-            elif run.output[-1].endswith("error"):
+            elif not run.output.any_line_contains("Unknown"):
                 status = "ERROR"
 
         return status


### PR DESCRIPTION
ESBMC was having the following problem:

```
8:29:09   heap-manipulation/dll_of_dll-1.yml                                                                                     2020-11-24 18:29:09,171 - DEBUG - My subprocess returned exit signal 9.
multiprocessing.pool.RemoteTraceback: 
"""
Traceback (most recent call last):
  File "/usr/lib/python3.6/multiprocessing/pool.py", line 119, in worker
    result = (True, func(*args, **kwds))
  File "/localhome/dbeyer/sv-comp/benchexec/benchexec/containerized_tool.py", line 269, in _call_tool_func
    return getattr(tool, name)(*args, **kwargs)
  File "/localhome/dbeyer/sv-comp/benchexec/benchexec/tools/esbmc.py", line 68, in determine_result
    elif run.output[-1].endswith("error"):
  File "/localhome/dbeyer/sv-comp/benchexec/benchexec/tools/template.py", line 571, in __getitem__
    return self._lines[index].rstrip(os.linesep)
IndexError: list index out of range
```
I couldn't pin down the issue properly, however, when I could replicate, the program should have been a timeout.

Replacing the check for error fixed the issue. 

