### PR TITLE
Scoring Schema for Results with Expected Verdict TRUE

### DIFF
--- a/benchexec/result.py
+++ b/benchexec/result.py
@@ -75,7 +75,7 @@ RESULT_CLASS_OTHER = "other"
 # Score values taken from http://sv-comp.sosy-lab.org/
 # (use values 0 to disable scores completely for a given property).
 _SCORE_CORRECT_TRUE = 2
-_SCORE_CORRECT_UNCONFIRMED_TRUE = 1
+_SCORE_CORRECT_UNCONFIRMED_TRUE = 0
 _SCORE_CORRECT_FALSE = 1
 _SCORE_CORRECT_UNCONFIRMED_FALSE = 0
 _SCORE_UNKNOWN = 0


### PR DESCRIPTION
Until last year, 1 point was assigned to unconfirmed witnesses for correct results true.
A few years back, the community decided that from SV-COMP 2020 onwards, this point should not be assigned anymore. Points should be assigned only for results with confirmed witnesses. Results without witnesses are considered value-less.