### PR TITLE
Include pycparserext-master in FShell Witness2Test

### DIFF
--- a/benchexec/tools/fshell-witness2test.py
+++ b/benchexec/tools/fshell-witness2test.py
@@ -23,6 +23,7 @@ class Tool(benchexec.tools.template.BaseTool2):
         "process_witness.py",
         "TestEnvGenerator.pl",
         "pycparser-master",
+        "pycparserext-master",
     ]
 
     def executable(self, tool_locator):


### PR DESCRIPTION
This directory is shipped in the archive, but apparently not included in
the container. It's required with all recent versions of FShell
witness2test.