### PR TITLE
[draft] contrib/mergeBenchmarkSets.py: take correct + invalid witness file as correct-unconfirmed

### DIFF
--- a/contrib/mergeBenchmarkSets.py
+++ b/contrib/mergeBenchmarkSets.py
@@ -69,12 +69,7 @@ def getWitnessResult(witness, verification_result):
     # then leave status and category as is.
     if status_from_validation == status_from_verification:
         return status_from_verification, category_from_verification
-    # An invalid witness counts as error of the verifier.
-    if status_from_validation == "ERROR (invalid witness syntax)":
-        return (
-            "witness invalid (" + status_from_verification + ")",
-            result.CATEGORY_ERROR,
-        )
+
     # Other unconfirmed witnesses count as CATEGORY_CORRECT_UNCONFIRMED.
     if category_from_verification == result.CATEGORY_CORRECT:
         return status_from_verification, result.CATEGORY_CORRECT_UNCONFIRMED


### PR DESCRIPTION
This PR is meant to be mainly a remainder for the next SV-COMP, do not merge until the discussion is resolved.

Take correct answer + invalid witness false as correct-unconfirmed instead of error. This PR is related to the discussion in
https://gitlab.com/sosy-lab/sv-comp/archives-2021/-/issues/23#note_460576708 . 
