### PR TITLE
Determine result for coveriteam-verifier-validator more precisely

### DIFF
--- a/benchexec/tools/coveriteam-verifier-validator.py
+++ b/benchexec/tools/coveriteam-verifier-validator.py
@@ -52,7 +52,7 @@ class Tool(coveriteam.Tool):
         If more than one dict is printed, the first matching one.
         """
         verdict = None
-        verdict_regex = re.compile(r"'verdict': '([a-zA-Z\(\)\ ]*)'")
+        verdict_regex = re.compile(r"'verdict': '([a-zA-Z\(\)\ \-]*)'")
         for line in reversed(run.output):
             line = line.strip()
             verdict_match = verdict_regex.search(line)

--- a/benchexec/tools/coveriteam-verifier-validator.py
+++ b/benchexec/tools/coveriteam-verifier-validator.py
@@ -59,7 +59,7 @@ class Tool(coveriteam.Tool):
             if verdict_match and verdict is None:
                 # CoVeriTeam outputs benchexec result categories as verdicts.
                 verdict = verdict_match.group(1).lower()
-            if 'Traceback (most recent call last)' in line:
+            if "Traceback (most recent call last)" in line:
                 verdict = "EXCEPTION"
         if verdict is None:
             return result.RESULT_UNKNOWN

--- a/benchexec/tools/coveriteam-verifier-validator.py
+++ b/benchexec/tools/coveriteam-verifier-validator.py
@@ -52,15 +52,13 @@ class Tool(coveriteam.Tool):
         If more than one dict is printed, the first matching one.
         """
         verdict = None
+        verdict_regex = re.compile(r"'verdict': '([a-zA-Z\(\)\ ]*)'")
         for line in reversed(run.output):
             line = line.strip()
-            if "'verdict':" in line and verdict is None:
+            verdict_match = verdict_regex.search(line)
+            if verdict_match and verdict is None:
                 # CoVeriTeam outputs benchexec result categories as verdicts.
-                try:
-                    verdict = re.search(r"'verdict': '([a-zA-Z\(\)\ ]*)'", line).group(1).lower()
-                except AttributeError:
-                    # re.search didn't find anything, so this is not a valid verdict line
-                    pass
+                verdict = verdict_match.group(1).lower()
             if 'Traceback (most recent call last)' in line:
                 verdict = "EXCEPTION"
         if verdict is None:

--- a/benchexec/tools/coveriteam-verifier-validator.py
+++ b/benchexec/tools/coveriteam-verifier-validator.py
@@ -10,6 +10,7 @@ import benchexec.result as result
 from benchexec.tools.template import UnsupportedFeatureException
 from benchexec.tools.sv_benchmarks_util import get_data_model_from_task, ILP32, LP64
 import ast
+import re
 
 
 class Tool(coveriteam.Tool):
@@ -50,14 +51,17 @@ class Tool(coveriteam.Tool):
         will print out the produced aftifacts.
         If more than one dict is printed, the first matching one.
         """
-        for line in run.output:
+        verdict = None
+        for line in reversed(run.output):
             line = line.strip()
-            if "verdict" in line:
+            if "'verdict':" in line and verdict is None:
                 # CoVeriTeam outputs benchexec result categories as verdicts.
                 try:
-                    d = ast.literal_eval(line)
-                    if isinstance(d, dict):
-                        return d.get("verdict", result.RESULT_ERROR)
-                except SyntaxError:
+                    verdict = re.search(r"'verdict': '([a-zA-Z\(\)\ ]*)'", line).group(1).lower()
+                except:
                     pass
-        return result.RESULT_ERROR
+            if 'Traceback (most recent call last)' in line:
+                verdict = "EXCEPTION"
+        if verdict is None:
+            return result.RESULT_UNKNOWN
+        return verdict

--- a/benchexec/tools/coveriteam-verifier-validator.py
+++ b/benchexec/tools/coveriteam-verifier-validator.py
@@ -58,7 +58,7 @@ class Tool(coveriteam.Tool):
             verdict_match = verdict_regex.search(line)
             if verdict_match and verdict is None:
                 # CoVeriTeam outputs benchexec result categories as verdicts.
-                verdict = verdict_match.group(1).lower()
+                verdict = verdict_match.group(1)
             if "Traceback (most recent call last)" in line:
                 verdict = "EXCEPTION"
         if verdict is None:

--- a/benchexec/tools/coveriteam-verifier-validator.py
+++ b/benchexec/tools/coveriteam-verifier-validator.py
@@ -58,7 +58,8 @@ class Tool(coveriteam.Tool):
                 # CoVeriTeam outputs benchexec result categories as verdicts.
                 try:
                     verdict = re.search(r"'verdict': '([a-zA-Z\(\)\ ]*)'", line).group(1).lower()
-                except:
+                except AttributeError:
+                    # re.search didn't find anything, so this is not a valid verdict line
                     pass
             if 'Traceback (most recent call last)' in line:
                 verdict = "EXCEPTION"


### PR DESCRIPTION
If multiple verdicts are printed (happens for intermediate steps with option --debug)
take the last verdict printed.
If there's an exception, return EXCEPTION-status instead. And if there's no verdict,
do not assume error, but assume UNKNOWN.

Also make parsing of the verdict-result more robust:
Don't parse the string printed by CoVeriTeam into a dict, but use a regular expression to get the verdict.
Parsing of the string into a dict does not work if any output artifact of CoVeriTeam is None, which results in CoVeriTeam printing something like the following:
`{'verdict': 'true', 'witness': }`. This can't be parsed into a dict then.