### PR TITLE
Add tool info module for Vampire

### DIFF
--- a/benchexec/tools/vampire.py
+++ b/benchexec/tools/vampire.py
@@ -1,0 +1,128 @@
+# This file is part of BenchExec, a framework for reliable benchmarking:
+# https://github.com/sosy-lab/benchexec
+#
+# SPDX-FileCopyrightText: 2007-2020 Dirk Beyer <https://www.sosy-lab.org>
+#
+# SPDX-License-Identifier: Apache-2.0
+
+import benchexec
+import benchexec.result as result
+
+
+class Tool(benchexec.tools.template.BaseTool2):
+    """
+    Tool info for Vampire.
+    https://github.com/vprover/vampire
+    """
+
+    def name(self):
+        return "Vampire"
+
+    def executable(self, tool_locator):
+        return tool_locator.find_executable("vampire")
+
+    def version(self, executable):
+        line = self._version_from_tool(executable, line_prefix="Vampire")
+        line = line.strip()
+        line = line.split(" ")[0]
+        return line.strip()
+
+    def environment(self, executable):
+        return {"keepEnv": {"TPTP": 1}}
+
+    def cmdline(self, executable, options, task, rlimits):
+        assert len(task.input_files) <= 1, "only one input file supported"
+
+        if "-t" not in options and "--time_limit" not in options:
+            if rlimits.walltime is None:
+                # Default timeout of Vampire is 60s,
+                # so we set value of 0 explicitly (means unlimited)
+                options += ["-t", "0"]
+            else:
+                options += ["-t", f"{rlimits.walltime}s"]
+
+        if "-m" not in options and "--memory_limit" not in options:
+            if rlimits.memory is None:
+                # No memory limit has been set
+                # TODO: should we warn in this case? Vampire is going to use the default of 3000MiB
+                pass
+            else:
+                # Vampire's option '--memory_limit/-m' takes the value in MiB
+                memory_mb = int(rlimits.memory / (1024 * 1024))
+                options += ["-m", f"{memory_mb}"]
+
+        return [executable, *options, *task.input_files]
+
+    def determine_result(self, run):
+        status = self.get_szs_status(run.output)
+        if run.exit_code:
+            if status == "Timeout":
+                return "TIMEOUT"
+            if run.exit_code.value == 4:
+                # Some kind of system error happened
+                if run.output.text.startswith("Parsing Error"):
+                    return "PARSING ERROR"
+            if run.exit_code.value == 1:
+                # Error during portfolio mode
+                if run.output.text.startswith("% Exception at proof search level\n"):
+                    if any(line.startswith("Parsing Error") for line in run.output):
+                        return "PARSING ERROR"
+                # Not really an error but unable to finish
+                reasons = self.get_other_termination_reasons(run.output)
+                if reasons == ["Time limit"]:
+                    return "TIMEOUT"
+                if reasons == ["Memory limit"]:
+                    return "OUT OF MEMORY"
+                if reasons == ["Refutation not found, incomplete strategy"]:
+                    return "INCOMPLETE"
+                if reasons == ["Refutation not found, non-redundant clauses discarded"]:
+                    return "INCOMPLETE"
+            # Some other error
+            return result.RESULT_ERROR
+        else:
+            # Successfully finished
+            if status in self.SZS_UNSAT:
+                return result.RESULT_TRUE_PROP
+            elif status in self.SZS_SAT:
+                return result.RESULT_FALSE_PROP
+            else:
+                return result.RESULT_UNKNOWN
+
+    # SZS status values that Vampire returns
+    SZS_UNSAT = ["ContradictoryAxioms", "Theorem", "Unsatisfiable"]
+    SZS_SAT = ["CounterSatisfiable", "Satisfiable"]
+    SZS_FAIL = ["Timeout", "GaveUp", "User"]
+
+    def get_szs_status(self, output):
+        """
+        Extract the SZS status from the output.
+        @param output: The output of the tool as instance of class RunOutput.
+        @return a non-empty string, or None if no unique SZS status was found
+        """
+        status = None
+        for line in output:
+            if line.startswith("% SZS status"):
+                if status is None:
+                    words = line.split()
+                    status = words[3] if len(words) >= 4 else None
+                else:
+                    # More than one SZS status => this is an error!
+                    return None
+        return status
+
+    def get_other_termination_reasons(self, output):
+        """
+        Extract termination reasons from the output from lines starting with '% Termination reason'.
+        @param output: The output of the tool as instance of class RunOutput.
+        @return List of strings, the termination found in the output (without prefix).
+        """
+        prefix = "% Termination reason: "
+        reasons = []
+        for line in output:
+            if line.startswith(prefix):
+                reasons.append(line[len(prefix) :])
+        return reasons
+
+    def get_value_from_output(self, output, identifier):
+        if identifier == "szs-status":
+            return self.get_szs_status(output) or "--"


### PR DESCRIPTION
This PR adds a tool info module for the first-order theorem prover [Vampire](https://github.com/vprover/vampire). I have done a few runs and it seems to work well.

However, I'm not sure about the method `environment`. It seems to be working and correct (according to the doc-comment in `BaseTool2`), but `test_tool_info` gives the following warning:
```
WARNING: Tool module returned invalid entries for environment, these will be ignored: “{'keepEnv': {'TPTP': 1}}”
```