### PR TITLE
add launch config and npm script for debugging tests

### DIFF
--- a/benchexec/tablegenerator/react-table/.vscode/launch.json
+++ b/benchexec/tablegenerator/react-table/.vscode/launch.json
@@ -1,0 +1,17 @@
+{
+    // Use IntelliSense to learn about possible attributes.
+    // Hover to view descriptions of existing attributes.
+    // For more information, visit: https://go.microsoft.com/fwlink/?linkid=830387
+    "version": "0.2.0",
+    "configurations": [
+      {
+        "name": "Attach",
+        "port": 9229,
+        "address": "127.0.0.1",
+        "request": "attach",
+        "skipFiles": ["<node_internals>/**"],
+        "type": "pwa-node"
+      }
+    ]
+  }
+  

--- a/benchexec/tablegenerator/react-table/package.json
+++ b/benchexec/tablegenerator/react-table/package.json
@@ -31,6 +31,7 @@
     "start": "(test -f src/data/dependencies.json || node scripts/dependencies.js) && node scripts/start.js",
     "build": "node scripts/dependencies.js && react-app-rewired build",
     "test": "(test -f src/data/dependencies.json || node scripts/dependencies.js) && react-app-rewired test",
+    "test:debug": "(test -f src/data/dependencies.json || node scripts/dependencies.js) && react-app-rewired --inspect-brk test",
     "lint:fix": "(test -f src/data/dependencies.json || node scripts/dependencies.js) && eslint --fix --ignore-path .lintignores $(pwd)'/**/*.js' && prettier --ignore-path .lintignores --write $(pwd)'/**/*.+(css|scss|json)'",
     "lint": "(test -f src/data/dependencies.json || node scripts/dependencies.js) &&  eslint --max-warnings 0 --ignore-path .lintignores . && prettier --ignore-path .lintignores --check $(pwd)'/**/*.+(css|scss|json)'"
   },


### PR DESCRIPTION
This PR adds a configuration for vscode to attach its debugger to a running node instance started with `--inspect` or `--inspect-brk`. 
A command for running tests in debugging mode has been added additionally.