### PR TITLE
Allow specifying path to libseccomp from ENV

### DIFF
--- a/benchexec/seccomp.py
+++ b/benchexec/seccomp.py
@@ -78,7 +78,8 @@ def _load_seccomp():
     # Load library with utility functions.
     global _lib
     try:
-        _lib = ctypes.CDLL("libseccomp.so.2", use_errno=True)
+        libseccomp = os.environ.get("LIBSECCOMP", "libseccomp.so.2")
+        _lib = ctypes.CDLL(libseccomp, use_errno=True)
     except OSError as e:
         logging.warning(
             "Could not load libseccomp2, "

--- a/benchexec/seccomp.py
+++ b/benchexec/seccomp.py
@@ -78,6 +78,7 @@ def _load_seccomp():
     # Load library with utility functions.
     global _lib
     try:
+        # Allow overriding library lookup for cases like NixOS
         libseccomp = os.environ.get("LIBSECCOMP", "libseccomp.so.2")
         _lib = ctypes.CDLL(libseccomp, use_errno=True)
     except OSError as e:


### PR DESCRIPTION
This allows operating systems like NixOS that do not install libraries
globally to easily set the path to libseccomp in a wrapper script during
build resulting in it being a runtime dependency.