### PR TITLE
Make the vcloud Jar location configurable

### DIFF
--- a/contrib/vcloud-benchmark.py
+++ b/contrib/vcloud-benchmark.py
@@ -60,13 +60,16 @@ class VcloudBenchmark(VcloudBenchmarkBase):
     """
 
     def load_executor(self):
-        download_required_jars(self.config)
-
         import vcloud.benchmarkclient_executor as executor
 
-        executor.set_vcloud_jar_path(
-            os.path.join(_ROOT_DIR, "lib", "vcloud-jars", "vcloud.jar")
-        )
+        if self.config.vcloud_jar:
+            print(self.config.vcloud_jar)
+            executor.set_vcloud_jar_path(self.config.vcloud_jar)
+        else:
+            download_required_jars(self.config)
+            executor.set_vcloud_jar_path(
+                os.path.join(_ROOT_DIR, "lib", "vcloud-jars", "vcloud.jar")
+            )
 
         logging.debug(
             "This is vcloud-benchmark.py (based on benchexec %s) "

--- a/contrib/vcloud/vcloudbenchmarkbase.py
+++ b/contrib/vcloud/vcloudbenchmarkbase.py
@@ -85,6 +85,13 @@ class VcloudBenchmarkBase(benchexec.benchexec.BenchExec):
             type=str,
             help="Specify files or paths that shall also be transferred and be made available to the run in the cloud.",
         )
+        vcloud_args.add_argument(
+            self.get_param_name("cloudJar"),
+            dest="vcloud_jar",
+            metavar="FILE_OR_PATH",
+            type=str,
+            help="Use this vcloud jar instead of downloading it from the ivy repository.",
+        )
 
     def get_param_name(self, pname):
         return "--v" + pname


### PR DESCRIPTION
Running the vcloud client from benchexec works like a charm, but the vcloud Jar needs to be the same as deployed in the vcloud. Allowing the configuration of the used vcloud Jar file makes it easier for us to run the infrastructure on our machines. 