### PR TITLE
Add tool-info module for Locksmith

### DIFF
--- a/benchexec/tools/locksmith.py
+++ b/benchexec/tools/locksmith.py
@@ -8,6 +8,7 @@
 import benchexec.tools.template
 import benchexec.result as result
 
+
 class Tool(benchexec.tools.template.BaseTool2):
     """
     Tool info for Locksmith.
@@ -18,7 +19,7 @@ class Tool(benchexec.tools.template.BaseTool2):
         return tool_locator.find_executable("locksmith")
 
     def version(self, executable):
-        return self._version_from_tool(executable, line_prefix="Cil version: ")
+        return self._version_from_tool(executable, line_prefix="LockSmith version: ")
 
     def name(self):
         return "Locksmith"


### PR DESCRIPTION
This is a simple tool info module. I have tested this on our local instance of benchexec and it seems to work. I will create a pull request of my own compiled binary of Locksmith shortly. I will also create a pull request to the locksmith source repo with changes needed to build it and these sv-comp files. This should make it very easy for the original authors to compete if they desire; otherwise, I'm ready to compete with Locksmith, the gold standard in race detection. 