### PR TITLE
Fixed outdated RESULT_FALSE_PROP status in Theta tool info

### DIFF
--- a/benchexec/tools/theta.py
+++ b/benchexec/tools/theta.py
@@ -37,7 +37,7 @@ class Tool(benchexec.tools.template.BaseTool2):
         status = result.RESULT_UNKNOWN
         for line in run.output:
             if "SafetyResult Unsafe" in line:
-                status = result.RESULT_FALSE_PROP
+                status = result.RESULT_FALSE_REACH
             if "SafetyResult Safe" in line:
                 status = result.RESULT_TRUE_PROP
 


### PR DESCRIPTION
This PR is a simple fix of the Theta tool info, as we used `RESULT_FALSE_PROP` instead of `RESULT_FALSE_REACH`.