### PR TITLE
use explicit imports s.t. coveriteam can use their url feature to pull the tool-info module

### DIFF
--- a/benchexec/tools/ultimateautomizer.py
+++ b/benchexec/tools/ultimateautomizer.py
@@ -7,7 +7,7 @@
 
 # SPDX-License-Identifier: Apache-2.0
 
-from . import ultimate
+from benchexec.tools import ultimate
 
 
 class Tool(ultimate.UltimateTool):

--- a/benchexec/tools/ultimategemcutter.py
+++ b/benchexec/tools/ultimategemcutter.py
@@ -6,7 +6,7 @@
 #
 # SPDX-License-Identifier: Apache-2.0
 
-from . import ultimate
+from benchexec.tools import ultimate
 
 
 class Tool(ultimate.UltimateTool):

--- a/benchexec/tools/ultimatekojak.py
+++ b/benchexec/tools/ultimatekojak.py
@@ -6,7 +6,7 @@
 #
 # SPDX-License-Identifier: Apache-2.0
 
-from . import ultimate
+from benchexec.tools import ultimate
 
 
 class Tool(ultimate.UltimateTool):

--- a/benchexec/tools/ultimatetaipan.py
+++ b/benchexec/tools/ultimatetaipan.py
@@ -6,7 +6,7 @@
 #
 # SPDX-License-Identifier: Apache-2.0
 
-from . import ultimate
+from benchexec.tools import ultimate
 
 
 class Tool(ultimate.UltimateTool):


### PR DESCRIPTION
see https://gitlab.com/sosy-lab/software/coveriteam/-/issues/93 