### PR TITLE
Improve tool-info module of frama-c-sv

### DIFF
--- a/benchexec/tools/frama-c-sv.py
+++ b/benchexec/tools/frama-c-sv.py
@@ -5,6 +5,7 @@
 #
 # SPDX-License-Identifier: Apache-2.0
 
+import benchexec.result
 import benchexec.tools.template
 from collections.abc import Mapping
 
@@ -34,7 +35,12 @@ class Tool(benchexec.tools.template.BaseTool2):
             cmd += ["--property", task.property_file]
         if isinstance(task.options, Mapping) and "data_model" in task.options:
             cmd += ["--datamodel", task.options["data_model"]]
+        cmd += options
         return cmd
 
     def determine_result(self, run):
-        return run.output[-1].split(":", maxsplit=2)[-1]
+        lastline = run.output[-1]
+        if lastline.startswith("INFO:RESULT:"):
+          return lastline.split(":", maxsplit=2)[-1]
+        else:
+          return benchexec.result.RESULT_UNKNOWN

--- a/benchexec/tools/frama-c-sv.py
+++ b/benchexec/tools/frama-c-sv.py
@@ -43,4 +43,4 @@ class Tool(benchexec.tools.template.BaseTool2):
         if lastline.startswith("INFO:RESULT:"):
             return lastline.split(":", maxsplit=2)[-1]
         else:
-            return benchexec.result.RESULT_UNKNOWN
+            return benchexec.result.RESULT_ERROR

--- a/benchexec/tools/frama-c-sv.py
+++ b/benchexec/tools/frama-c-sv.py
@@ -41,6 +41,6 @@ class Tool(benchexec.tools.template.BaseTool2):
     def determine_result(self, run):
         lastline = run.output[-1]
         if lastline.startswith("INFO:RESULT:"):
-          return lastline.split(":", maxsplit=2)[-1]
+            return lastline.split(":", maxsplit=2)[-1]
         else:
-          return benchexec.result.RESULT_UNKNOWN
+            return benchexec.result.RESULT_UNKNOWN


### PR DESCRIPTION
This adds the following improvements for frama-c-sv:

- We want to just return unknown and not the last line
in the tool output in case the tool process ended before
the final line with the result is printed
- We want to be able to pass options to the tool via
  the benchmark definition xml