### PR TITLE
Minor improvement to warning message: add forgotten space after task-set name

### DIFF
--- a/benchexec/model.py
+++ b/benchexec/model.py
@@ -662,7 +662,7 @@ class RunSet(object):
                     for sourcefile_set in blocks
                 ):
                     logging.warning(
-                        'For run definition "%s" the selected tasks "%s"'
+                        'For run definition "%s" the selected tasks "%s" '
                         "do not exist in the benchmark definition, skipping them.",
                         rundef_name,
                         selected,


### PR DESCRIPTION
This fixes only a string for a user message (warning).