### PR TITLE
Fix result files folder of benchmarkclient execut.

### DIFF
--- a/contrib/aws/awsexecutor.py
+++ b/contrib/aws/awsexecutor.py
@@ -515,9 +515,7 @@ def handleCloudResults(benchmark, output_handler, start_time, end_time):
             raw_path = run.log_file[: -len(".log")]
             dirname, filename = os.path.split(raw_path)
             aws_files_directory = raw_path + ".files"
-            benchexec_files_directory = os.path.join(
-                dirname[: -len(".logfiles")] + ".files", filename
-            )
+            benchexecFilesDirectory = run.result_files_folder
             if os.path.isdir(aws_files_directory) and not os.path.isdir(
                 benchexec_files_directory
             ):

--- a/contrib/vcloud/benchmarkclient_executor.py
+++ b/contrib/vcloud/benchmarkclient_executor.py
@@ -349,9 +349,7 @@ def handleCloudResults(benchmark, output_handler, start_time, end_time):
             rawPath = run.log_file[: -len(".log")]
             dirname, filename = os.path.split(rawPath)
             vcloudFilesDirectory = rawPath + ".files"
-            benchexecFilesDirectory = os.path.join(
-                dirname[: -len(".logfiles")] + ".files", filename
-            )
+            benchexecFilesDirectory = run.result_files_folder
             if os.path.isdir(vcloudFilesDirectory) and not os.path.isdir(
                 benchexecFilesDirectory
             ):


### PR DESCRIPTION
We want to put the result files into the same exact folder
as benchexec would do. We have all the necessary information
here so no need to hack together this filename manually, we
can just reuse run.result_files_folder. This will also ensure
that this will work if that folder should ever be named differently
by BenchExec.