### PR TITLE
Update result matching for frama-c-sv.

### DIFF
--- a/benchexec/tools/frama-c-sv.py
+++ b/benchexec/tools/frama-c-sv.py
@@ -42,5 +42,7 @@ class Tool(benchexec.tools.template.BaseTool2):
         lastline = run.output[-1]
         if lastline.startswith("INFO\tRESULT\t"):
             return lastline.split("\t", maxsplit=3)[-1]
+        elif lastline.startswith("INFO:RESULT:"):
+            return lastline.split(":", maxsplit=2)[-1]
         else:
             return benchexec.result.RESULT_ERROR

--- a/benchexec/tools/frama-c-sv.py
+++ b/benchexec/tools/frama-c-sv.py
@@ -40,7 +40,7 @@ class Tool(benchexec.tools.template.BaseTool2):
 
     def determine_result(self, run):
         lastline = run.output[-1]
-        if lastline.startswith("INFO:RESULT:"):
-            return lastline.split(":", maxsplit=2)[-1]
+        if lastline.startswith("INFO\tRESULT\t"):
+            return lastline.split("\t", maxsplit=3)[-1]
         else:
             return benchexec.result.RESULT_ERROR


### PR DESCRIPTION
We recently changed the output format of frama-c-sv which causes
Benchexec to report all new run results as error.
This commit adjusts result determination to match the new ouput
format.