### PR TITLE
Add additional column for witnesslint

### DIFF
--- a/benchexec/tools/witnesslint.py
+++ b/benchexec/tools/witnesslint.py
@@ -27,6 +27,12 @@ class Tool(benchexec.tools.template.BaseTool2):
         version_string = self._version_from_tool(executable)
         return version_string.partition("version")[2].strip().split(" ")[0]
 
+    def get_witness_type(self, run):
+        for line in run.output:
+            if line.startswith("Witness Type:"):
+                return line.split(" ", maxsplit=2)[-1]
+        return None
+
     def determine_result(self, run):
         exit_code = run.exit_code.value
         if "witnesslint finished" not in run.output[-1] or exit_code == 7:

--- a/benchexec/tools/witnesslint.py
+++ b/benchexec/tools/witnesslint.py
@@ -27,10 +27,10 @@ class Tool(benchexec.tools.template.BaseTool2):
         version_string = self._version_from_tool(executable)
         return version_string.partition("version")[2].strip().split(" ")[0]
 
-    def get_witness_type(self, run):
-        for line in run.output:
-            if line.startswith("Witness Type:"):
-                return line.split(" ", maxsplit=2)[-1]
+    def get_value_from_output(self, output, identifier):
+        for line in output:
+            if line.startswith(identifier):
+                return line.split(":", maxsplit=1)[-1].strip()
         return None
 
     def determine_result(self, run):


### PR DESCRIPTION
As discussed in **https://github.com/sosy-lab/sv-witnesses/issues/55**, the witness type of the checked witness should be extracted into a new column.

@PhilippWendler I added a function to extract the witness type from the linter output, but how to create the new column? Looking at how it is done for CPAchecker, it seems that the columns have to be declared in the benchmark xml. Is it enough then to just implement `get_value_for_output` here?