### PR TITLE
Adding an option to use a fresh cache for ivy

### DIFF
--- a/contrib/vcloud-benchmark.py
+++ b/contrib/vcloud-benchmark.py
@@ -51,9 +51,8 @@ def download_required_jars(config):
     # Provide temporary directory
     if config.freshIvyCache:
         temp_dir = tempfile.mkdtemp()
-        print(temp_dir)
         cmd += ["-cache", str(temp_dir)]
-
+        logging.debug(f"Using fresh ivy cache: {temp_dir}")
     try:
         # install vcloud jar and dependencies
         subprocess.run(

--- a/contrib/vcloud-benchmark.py
+++ b/contrib/vcloud-benchmark.py
@@ -10,6 +10,8 @@
 import logging
 import os
 import sys
+import shutil
+import tempfile
 import urllib.request
 import subprocess
 
@@ -46,12 +48,22 @@ def download_required_jars(config):
         cmd += ["-warn"]
     cmd += ["-retrieve", "lib/vcloud-jars/[artifact](-[classifier]).[ext]"]
 
-    # install vcloud jar and dependencies
-    subprocess.run(
-        cmd,
-        cwd=_ROOT_DIR,
-        shell=vcloudutil.is_windows(),  # noqa: S602
-    )
+    # Provide temporary directory
+    if config.freshIvyCache:
+        temp_dir = tempfile.mkdtemp()
+        print(temp_dir)
+        cmd += ["-cache", str(temp_dir)]
+
+    try:
+        # install vcloud jar and dependencies
+        subprocess.run(
+            cmd,
+            cwd=_ROOT_DIR,
+            shell=vcloudutil.is_windows(),  # noqa: S602
+        )
+    finally:
+        if "temp_dir" in locals():
+            shutil.rmtree(temp_dir)
 
 
 class VcloudBenchmark(VcloudBenchmarkBase):

--- a/contrib/vcloud/vcloudbenchmarkbase.py
+++ b/contrib/vcloud/vcloudbenchmarkbase.py
@@ -85,6 +85,12 @@ class VcloudBenchmarkBase(benchexec.benchexec.BenchExec):
             type=str,
             help="Specify files or paths that shall also be transferred and be made available to the run in the cloud.",
         )
+        vcloud_args.add_argument(
+            "--fresh-ivy-cache",
+            dest="freshIvyCache",
+            action="store_true",
+            help="Uses new ivy cache for each execution, thus every jar file will be downloaded again. This is useful if this tool is used by multiple threads.",
+        )
 
     def get_param_name(self, pname):
         return "--v" + pname


### PR DESCRIPTION
When you use vcloud-benchmark.py in multiple threads at the same time and ivy has to download jars, it produces some errors. With the command line option --fresh-ivy-cache, every execution of vcloud-benchmark.py uses a new cache folder for ivy. 