### PR TITLE
Allow selection of measurements in statistics-tex.py

### DIFF
--- a/contrib/statistics-tex.py
+++ b/contrib/statistics-tex.py
@@ -60,9 +60,9 @@ class StatAccumulator(object):
         if not all(self.measurement_data.values()):
             return ""
 
-        stat_list = [
-            (k.title(), StatValue.from_list(v))
-            for k, v in self.measurement_data.items()
+        measurement_list = [
+            (m_name.title(), StatValue.from_list(data))
+            for m_name, data in self.measurement_data.items()
         ]
         assert len(name_parts) <= 4
         name_parts += [""] * (4 - len(name_parts))  # ensure length 4
@@ -73,19 +73,19 @@ class StatAccumulator(object):
                 + [
                     [
                         r"\StoreBenchExecResult{%s}{%s}{}{%s}%%"
-                        % (name, time_name, util.print_decimal(time_stats.sum)),
+                        % (name, m_name, util.print_decimal(data.sum)),
                         r"\StoreBenchExecResult{%s}{%s}{Avg}{%s}%%"
-                        % (name, time_name, util.print_decimal(time_stats.avg)),
+                        % (name, m_name, util.print_decimal(data.avg)),
                         r"\StoreBenchExecResult{%s}{%s}{Median}{%s}%%"
-                        % (name, time_name, util.print_decimal(time_stats.median)),
+                        % (name, m_name, util.print_decimal(data.median)),
                         r"\StoreBenchExecResult{%s}{%s}{Min}{%s}%%"
-                        % (name, time_name, util.print_decimal(time_stats.min)),
+                        % (name, m_name, util.print_decimal(data.min)),
                         r"\StoreBenchExecResult{%s}{%s}{Max}{%s}%%"
-                        % (name, time_name, util.print_decimal(time_stats.max)),
+                        % (name, m_name, util.print_decimal(data.max)),
                         r"\StoreBenchExecResult{%s}{%s}{Stdev}{%s}%%"
-                        % (name, time_name, util.print_decimal(time_stats.stdev)),
+                        % (name, m_name, util.print_decimal(data.stdev)),
                     ]
-                    for (time_name, time_stats) in stat_list
+                    for (m_name, data) in measurement_list
                 ]
             )
         )

--- a/contrib/statistics-tex.py
+++ b/contrib/statistics-tex.py
@@ -171,7 +171,7 @@ def main(args=None):
 
     options = parser.parse_args(args[1:])
 
-    options.measurements = options.measurements.replace(" ", "").split(",")
+    options.measurements = options.measurements.strip(",").replace(" ", "").split(",")
 
     pool = multiprocessing.Pool()
     stats = pool.map(

--- a/contrib/statistics-tex.py
+++ b/contrib/statistics-tex.py
@@ -48,20 +48,21 @@ def format_command_part(name):
 class StatAccumulator(object):
     def __init__(self):
         self.count = 0
-        self.measurements = {}
+        self.measurement_data = {}
 
     def add(self, result, measurements):
         self.count += 1
         for measurement in measurements:
-            current_measurement_list = self.measurements.setdefault(measurement, [])
+            current_measurement_list = self.measurement_data.setdefault(measurement, [])
             current_measurement_list.append(extract_measurement(measurement, result))
 
     def to_latex(self, name_parts):
-        if not all(self.measurements.values()):
+        if not all(self.measurement_data.values()):
             return ""
 
         stat_list = [
-            (k.title(), StatValue.from_list(v)) for k, v in self.measurements.items()
+            (k.title(), StatValue.from_list(v))
+            for k, v in self.measurement_data.items()
         ]
         assert len(name_parts) <= 4
         name_parts += [""] * (4 - len(name_parts))  # ensure length 4

--- a/contrib/statistics-tex.py
+++ b/contrib/statistics-tex.py
@@ -30,23 +30,12 @@ HEADER = r"""% The following definition defines a command for each value.
 \providecommand\StoreBenchExecResult[7]{\expandafter\newcommand\csname#1#2#3#4#5#6\endcsname{#7}}%"""
 
 
-def extract_time(column_title, time_name, run_result):
-    pos = None
+def extract_measurement(column_title, run_result):
     for i, column in enumerate(run_result.columns):
         if column.title == column_title:
-            pos = i
-            break
-    if pos is None:
-        sys.exit(f"{time_name} time missing for task {run_result.task_id}.")
-    return util.to_decimal(run_result.values[pos])
+            return util.to_decimal(run_result.values[i])
 
-
-def extract_cputime(run_result):
-    return extract_time("cputime", "CPU", run_result)
-
-
-def extract_walltime(run_result):
-    return extract_time("walltime", "Wall", run_result)
+    sys.exit("Measurement %s missing for task %s." % (column_title, run_result.task_id))
 
 
 def format_command_part(name):
@@ -64,8 +53,8 @@ class StatAccumulator(object):
 
     def add(self, result):
         self.count += 1
-        self.cputime_values.append(extract_cputime(result))
-        self.walltime_values.append(extract_walltime(result))
+        self.cputime_values.append(extract_measurement("cputime", result))
+        self.walltime_values.append(extract_measurement("walltime", result))
 
     def to_latex(self, name_parts):
         if not self.cputime_values or not self.walltime_values:

--- a/contrib/statistics-tex.py
+++ b/contrib/statistics-tex.py
@@ -164,8 +164,8 @@ def main(args=None):
         action="store",
         type=str,
         default="cputime,walltime",
-        help="Specifies all measurements which should be extracted from the XML file(s). "
-        "All measurements must me present in each task in each XML file.",
+        help="Comma separated string with all measurements which should be extracted from the XML file(s). "
+        "All measurements must be present in each task in each XML file.",
     )
 
     options = parser.parse_args(args[1:])

--- a/contrib/statistics-tex.py
+++ b/contrib/statistics-tex.py
@@ -56,13 +56,13 @@ class StatAccumulator(object):
             current_measurement_list = self.measurements.setdefault(measurement, [])
             current_measurement_list.append(extract_measurement(measurement, result))
 
-        # self.cputime_values.append(extract_measurement("cputime", result))
-        # self.walltime_values.append(extract_measurement("walltime", result))
-
     def to_latex(self, name_parts):
+        if not all(self.measurements.values()):
+            return ""
 
-        cputime_stats = StatValue.from_list(self.measurements["cputime"])
-        walltime_stats = StatValue.from_list(self.measurements["walltime"])
+        stat_list = [
+            (k.title(), StatValue.from_list(v)) for k, v in self.measurements.items()
+        ]
         assert len(name_parts) <= 4
         name_parts += [""] * (4 - len(name_parts))  # ensure length 4
         name = r"}{".join(map(format_command_part, name_parts))
@@ -84,10 +84,7 @@ class StatAccumulator(object):
                         r"\StoreBenchExecResult{%s}{%s}{Stdev}{%s}%%"
                         % (name, time_name, util.print_decimal(time_stats.stdev)),
                     ]
-                    for (time_name, time_stats) in [
-                        ("Cputime", cputime_stats),
-                        ("Walltime", walltime_stats),
-                    ]
+                    for (time_name, time_stats) in stat_list
                 ]
             )
         )


### PR DESCRIPTION
At the moment, `statistics-tex.py` creates Latex commands only for the CPU time and the wall time. However, `benchexec` measures far more values. I propose a command line parameter `--measurements` which allows the selection of these values. The default is the current selection (cputime and walltime).