### PR TITLE
Limit number of workers for table-generator

### DIFF
--- a/benchexec/tablegenerator/__init__.py
+++ b/benchexec/tablegenerator/__init__.py
@@ -1581,8 +1581,9 @@ def main(args=None):
         cpu_count = os.cpu_count() or 1
     except AttributeError:
         pass
-    # Use up to cpu_count*2 workers because some tasks are I/O bound.
-    parallel = concurrent.futures.ProcessPoolExecutor(max_workers=cpu_count * 2)
+    # Use up to cpu_count*2 workers because some tasks are I/O bound,
+    # but limit the number of worker to avoid too many open files.
+    parallel = concurrent.futures.ProcessPoolExecutor(max_workers=min(cpu_count * 2, 256))
 
     name = options.output_name
     outputPath = options.outputPath

--- a/benchexec/tablegenerator/__init__.py
+++ b/benchexec/tablegenerator/__init__.py
@@ -1583,7 +1583,9 @@ def main(args=None):
         pass
     # Use up to cpu_count*2 workers because some tasks are I/O bound,
     # but limit the number of worker to avoid too many open files.
-    parallel = concurrent.futures.ProcessPoolExecutor(max_workers=min(cpu_count * 2, 256))
+    parallel = concurrent.futures.ProcessPoolExecutor(
+        max_workers=min(cpu_count * 2, 256)
+    )
 
     name = options.output_name
     outputPath = options.outputPath

--- a/benchexec/tablegenerator/__init__.py
+++ b/benchexec/tablegenerator/__init__.py
@@ -1584,7 +1584,7 @@ def main(args=None):
     # Use up to cpu_count*2 workers because some tasks are I/O bound,
     # but limit the number of worker to avoid too many open files.
     parallel = concurrent.futures.ProcessPoolExecutor(
-        max_workers=min(cpu_count * 2, 256)
+        max_workers=min(cpu_count * 2, 32)
     )
 
     name = options.output_name


### PR DESCRIPTION
When I run table-generator on a machine with many processing units,
then table-generator creates too many workers, such that the operating system
complains with `OSError: [Errno 24] Too many open files`.

Therefore, let us limit the number of workers for table-generator to max. 256.