### PR TITLE
Add a pre-defined result value for TIMEOUT

### DIFF
--- a/benchexec/model.py
+++ b/benchexec/model.py
@@ -31,9 +31,9 @@ WALLTIMELIMIT = "walltimelimit"
 _BYTE_FACTOR = 1000  # byte in kilobyte
 
 _ERROR_RESULTS_FOR_TERMINATION_REASON = {
-    "cputime": "TIMEOUT",
-    "cputime-soft": "TIMEOUT",
-    "walltime": "TIMEOUT",
+    "cputime": result.RESULT_TIMEOUT,
+    "cputime-soft": result.RESULT_TIMEOUT,
+    "walltime": result.RESULT_TIMEOUT,
     "memory": "OUT OF MEMORY",
     "killed": "KILLED",
     "failed": "FAILED",
@@ -1149,7 +1149,7 @@ class Run(object):
             # Termination reason was not fully precise for timeouts, so we double check
             # the consumed time against the limits. Since removal of ulimit time limit
             # this should not be necessary, but also does not harm.
-            status = "TIMEOUT"
+            status = result.RESULT_TIMEOUT
         elif termination_reason:
             status = _ERROR_RESULTS_FOR_TERMINATION_REASON.get(
                 termination_reason, termination_reason

--- a/benchexec/result.py
+++ b/benchexec/result.py
@@ -38,6 +38,8 @@ RESULT_DONE = "done"
 """tool terminated properly and true/false does not make sense"""
 RESULT_UNKNOWN = "unknown"
 """tool could not find out an answer due to incompleteness"""
+RESULT_TIMEOUT = "TIMEOUT"
+"""tool could not finish the task in the given time resources"""
 RESULT_ERROR = "ERROR"  # or any other value not listed here
 """tool could not complete due to an error
 (it is recommended to instead use a string with more details about the error)"""

--- a/benchexec/tools/acsar.py
+++ b/benchexec/tools/acsar.py
@@ -36,7 +36,7 @@ class Tool(benchexec.tools.template.BaseTool):
             status = "NO MAIN"
 
         elif "For Error Location <<ERROR_LOCATION>>: I don't Know " in output:
-            status = "TIMEOUT"
+            status = result.RESULT_TIMEOUT
 
         elif "received signal 6" in output:
             status = "ABORT"

--- a/benchexec/tools/blast.py
+++ b/benchexec/tools/blast.py
@@ -51,7 +51,7 @@ class Tool(benchexec.tools.template.BaseTool):
             elif line.startswith("Error: label 'ERROR' appears multiple times"):
                 status = "ERROR"
             elif returnsignal == 9:
-                status = "TIMEOUT"
+                status = result.RESULT_TIMEOUT
             elif "Ack! The gremlins again!" in line:
                 status = "EXCEPTION (Gremlins)"
         return status

--- a/benchexec/tools/cbmc.py
+++ b/benchexec/tools/cbmc.py
@@ -93,7 +93,7 @@ class Tool(benchexec.tools.template.BaseTool2):
         except Exception:
             if isTimeout:
                 # in this case an exception is expected as the XML is invalid
-                status = "TIMEOUT"
+                status = result.RESULT_TIMEOUT
             elif "Minisat::OutOfMemoryException" in output:
                 status = "OUT OF MEMORY"
             else:

--- a/benchexec/tools/ceagle.py
+++ b/benchexec/tools/ceagle.py
@@ -32,7 +32,7 @@ class Tool(benchexec.tools.template.BaseTool):
         stroutput = str(output)
 
         if isTimeout:
-            status = "TIMEOUT"
+            status = result.RESULT_TIMEOUT
         elif "TRUE" in stroutput:
             status = result.RESULT_TRUE_PROP
         elif "FALSE(valid-deref)" in stroutput:

--- a/benchexec/tools/cpachecker.py
+++ b/benchexec/tools/cpachecker.py
@@ -178,7 +178,7 @@ class Tool(benchexec.tools.template.BaseTool2):
                 and not status
                 and run.was_timeout
             ):
-                status = "TIMEOUT"
+                status = result.RESULT_TIMEOUT
 
             elif line.startswith("Verification result: "):
                 line = line[21:].strip()
@@ -208,7 +208,7 @@ class Tool(benchexec.tools.template.BaseTool2):
             and run.exit_code.value in [15, 143]
         ):
             # The JVM sets such an returncode if it receives signal 15 (143 is 15+128)
-            status = "TIMEOUT"
+            status = result.RESULT_TIMEOUT
 
         if not status:
             status = result.RESULT_ERROR

--- a/benchexec/tools/divine.py
+++ b/benchexec/tools/divine.py
@@ -100,7 +100,7 @@ class Tool(benchexec.tools.template.BaseTool2):
         last = run.output[-1]
 
         if run.was_timeout:
-            return "TIMEOUT"
+            return result.RESULT_TIMEOUT
 
         if run.exit_code.value and run.exit_code.value != 0:
             return "ERROR - Pre-run"

--- a/benchexec/tools/divine4.py
+++ b/benchexec/tools/divine4.py
@@ -97,7 +97,7 @@ class Tool(benchexec.tools.template.BaseTool2):
         last = run.output[-1]
 
         if run.was_timeout:
-            return "TIMEOUT"
+            return result.RESULT_TIMEOUT
 
         if run.exit_code.value and run.exit_code.value != 0:
             return f"ERROR - {last}"

--- a/benchexec/tools/ecav.py
+++ b/benchexec/tools/ecav.py
@@ -25,7 +25,7 @@ class Tool(benchexec.tools.template.BaseTool):
             elif line.startswith("1 safe, 0 unsafe"):
                 status = result.RESULT_TRUE_PROP
             elif ((returnsignal == 9) or (returnsignal == 15)) and isTimeout:
-                status = "TIMEOUT"
+                status = result.RESULT_TIMEOUT
             elif returnsignal == 9:
                 status = "KILLED BY SIGNAL 9"
 

--- a/benchexec/tools/esbmc.py
+++ b/benchexec/tools/esbmc.py
@@ -64,7 +64,7 @@ class Tool(benchexec.tools.template.BaseTool2):
 
         if status == result.RESULT_UNKNOWN:
             if run.was_timeout:
-                status = "TIMEOUT"
+                status = result.RESULT_TIMEOUT
             elif not run.output.any_line_contains("Unknown"):
                 status = "ERROR"
 

--- a/benchexec/tools/impara.py
+++ b/benchexec/tools/impara.py
@@ -86,7 +86,7 @@ class Tool(benchexec.tools.template.BaseTool):
             except Exception:
                 if isTimeout:
                     # in this case an exception is expected as the XML is invalid
-                    status = "TIMEOUT"
+                    status = result.RESULT_TIMEOUT
                 elif "Minisat::OutOfMemoryException" in output:
                     status = "OUT OF MEMORY"
                 else:

--- a/benchexec/tools/map2check.py
+++ b/benchexec/tools/map2check.py
@@ -99,7 +99,7 @@ class Tool(benchexec.tools.template.BaseTool2):
             elif output.endswith("UNKNOWN"):
                 status = result.RESULT_UNKNOWN
             elif run.was_timeout:
-                status = "TIMEOUT"
+                status = result.RESULT_TIMEOUT
             else:
                 status = "ERROR"
 
@@ -116,7 +116,7 @@ class Tool(benchexec.tools.template.BaseTool2):
             elif output.endswith("UNKNOWN"):
                 status = result.RESULT_UNKNOWN
             elif run.was_timeout:
-                status = "TIMEOUT"
+                status = result.RESULT_TIMEOUT
             else:
                 status = "ERROR"
 

--- a/benchexec/tools/mopsa.py
+++ b/benchexec/tools/mopsa.py
@@ -34,7 +34,7 @@ class Tool(benchexec.tools.template.BaseTool2):
 
     def determine_result(self, run):
         if run.was_timeout:
-            return "TIMEOUT"
+            return result.RESULT_TIMEOUT
         r = run.output[-1] or run.output[-2]  # last non-empty line
         if r.startswith("true"):
             return result.RESULT_TRUE_PROP

--- a/benchexec/tools/pagai.py
+++ b/benchexec/tools/pagai.py
@@ -24,7 +24,7 @@ class Tool(benchexec.tools.template.BaseTool):
     def determine_result(self, returncode, returnsignal, output, isTimeout):
         output = "\n".join(output)
         if ((returnsignal == 9) or (returnsignal == 15)) and isTimeout:
-            status = "TIMEOUT"
+            status = result.RESULT_TIMEOUT
         elif returnsignal == 9:
             status = "KILLED BY SIGNAL 9"
         elif "RESULT: TRUE" in output:

--- a/benchexec/tools/predatorhp.py
+++ b/benchexec/tools/predatorhp.py
@@ -54,5 +54,5 @@ class Tool(benchexec.tools.template.BaseTool2):
         elif run.output.any_line_contains("FALSE"):
             status = result.RESULT_FALSE_REACH
         if status == "UNKNOWN" and run.was_timeout:
-            status = "TIMEOUT"
+            status = result.RESULT_TIMEOUT
         return status

--- a/benchexec/tools/satabs.py
+++ b/benchexec/tools/satabs.py
@@ -29,7 +29,7 @@ class Tool(benchexec.tools.template.BaseTool):
             assert returncode == 10
             status = result.RESULT_FALSE_REACH
         elif returnsignal == 9:
-            status = "TIMEOUT"
+            status = result.RESULT_TIMEOUT
         elif returnsignal == 6:
             if "Assertion `!counterexample.steps.empty()' failed" in output:
                 status = "COUNTEREXAMPLE FAILED"  # TODO: other status?

--- a/benchexec/tools/seahorn.py
+++ b/benchexec/tools/seahorn.py
@@ -51,7 +51,7 @@ class Tool(benchexec.tools.template.BaseTool):
                 status = result.RESULT_FALSE_REACH
         elif returnsignal == 9 or returnsignal == (128 + 9):
             if isTimeout:
-                status = "TIMEOUT"
+                status = result.RESULT_TIMEOUT
             else:
                 status = "KILLED BY SIGNAL 9"
         elif returncode != 0:

--- a/benchexec/tools/smtlib2.py
+++ b/benchexec/tools/smtlib2.py
@@ -32,7 +32,7 @@ class Smtlib2Tool(benchexec.tools.template.BaseTool):
                 status = result.RESULT_UNKNOWN
 
         elif ((returnsignal == 9) or (returnsignal == 15)) and isTimeout:
-            status = "TIMEOUT"
+            status = result.RESULT_TIMEOUT
 
         elif returnsignal == 9:
             status = "KILLED BY SIGNAL 9"

--- a/benchexec/tools/symbiotic4.py
+++ b/benchexec/tools/symbiotic4.py
@@ -54,7 +54,7 @@ class Tool(benchexec.tools.template.BaseTool2):
 
     def determine_result(self, run):
         if run.was_timeout:
-            return "timeout"
+            return result.RESULT_TIMEOUT
 
         if not run.output:
             return "error (no output)"

--- a/benchexec/tools/symdivine.py
+++ b/benchexec/tools/symdivine.py
@@ -85,7 +85,7 @@ class Tool(benchexec.tools.template.BaseTool):
         join_output = "\n".join(output)
 
         if isTimeout:
-            return "TIMEOUT"
+            return result.RESULT_TIMEOUT
 
         if returncode == 2:
             return "ERROR - Pre-run"

--- a/benchexec/tools/tbf.py
+++ b/benchexec/tools/tbf.py
@@ -47,7 +47,7 @@ class Tool(benchexec.tools.template.BaseTool):
         for line in reversed(output):
             if line.startswith("ERROR:"):
                 if "timeout" in line.lower():
-                    return "TIMEOUT"
+                    return result.RESULT_TIMEOUT
                 else:
                     return f"ERROR ({returncode})"
             elif line.startswith("TBF") and "FALSE" in line:

--- a/benchexec/tools/tbf_testsuite_validator.py
+++ b/benchexec/tools/tbf_testsuite_validator.py
@@ -47,7 +47,7 @@ class Tool(benchexec.tools.template.BaseTool):
         for line in reversed(output):
             if line.startswith("ERROR:"):
                 if "timeout" in line.lower():
-                    return "TIMEOUT"
+                    return result.RESULT_TIMEOUT
                 else:
                     return f"ERROR ({returncode})"
             elif line.startswith("Result:") and "FALSE" in line:

--- a/benchexec/tools/testcov.py
+++ b/benchexec/tools/testcov.py
@@ -56,7 +56,7 @@ class Tool(benchexec.tools.template.BaseTool2):
         for line in reversed(run.output):
             if line.startswith("ERROR:"):
                 if "timeout" in line.lower():
-                    return "TIMEOUT"
+                    return result.RESULT_TIMEOUT
                 else:
                     return f"ERROR ({run.exit_code.value})"
             elif line.startswith("Result: FALSE"):

--- a/benchexec/tools/threader.py
+++ b/benchexec/tools/threader.py
@@ -48,6 +48,6 @@ class Tool(benchexec.tools.template.BaseTool):
             status = result.RESULT_UNKNOWN
 
         if status == result.RESULT_UNKNOWN and isTimeout:
-            status = "TIMEOUT"
+            status = result.RESULT_TIMEOUT
 
         return status

--- a/benchexec/tools/two_ls.py
+++ b/benchexec/tools/two_ls.py
@@ -38,7 +38,7 @@ class Tool(benchexec.tools.template.BaseTool2):
         if (
             (run.exit_code.signal == 9) or (run.exit_code.signal == 15)
         ) and run.was_timeout:
-            status = "TIMEOUT"
+            status = result.RESULT_TIMEOUT
         elif run.exit_code.signal == 9:
             status = "OUT OF MEMORY"
         elif run.exit_code.signal:

--- a/benchexec/tools/ufo.py
+++ b/benchexec/tools/ufo.py
@@ -5,6 +5,7 @@
 #
 # SPDX-License-Identifier: Apache-2.0
 
+import benchexec.result as result
 import benchexec.util as util
 import benchexec.tools.template
 
@@ -20,7 +21,7 @@ class Tool(benchexec.tools.template.BaseTool):
         output = "\n".join(output)
         if returnsignal == 9 or returnsignal == (128 + 9):
             if isTimeout:
-                status = "TIMEOUT"
+                status = result.RESULT_TIMEOUT
             else:
                 status = "KILLED BY SIGNAL 9"
         elif returncode == 1 and "program correct: ERROR unreachable" in output:

--- a/benchexec/tools/vampire.py
+++ b/benchexec/tools/vampire.py
@@ -49,7 +49,7 @@ class Tool(benchexec.tools.template.BaseTool2):
         status = self.get_szs_status(run.output)
         if run.exit_code:
             if status == "Timeout":
-                return "TIMEOUT"
+                return result.RESULT_TIMEOUT
             if run.exit_code.value == 4:
                 # Some kind of system error happened
                 if run.output.text.startswith("Parsing Error"):
@@ -62,7 +62,7 @@ class Tool(benchexec.tools.template.BaseTool2):
                 # Not really an error but unable to finish
                 reasons = self.get_other_termination_reasons(run.output)
                 if reasons == ["Time limit"]:
-                    return "TIMEOUT"
+                    return result.RESULT_TIMEOUT
                 if reasons == ["Memory limit"]:
                     return "OUT OF MEMORY"
                 if reasons == ["Refutation not found, incomplete strategy"]:

--- a/benchexec/tools/wasp-c.py
+++ b/benchexec/tools/wasp-c.py
@@ -41,7 +41,7 @@ class Tool(benchexec.tools.template.BaseTool2):
         ):
             return result.RESULT_ERROR
         elif run.was_timeout or run.output.any_line_contains("WASP timed out"):
-            return "TIMEOUT"
+            return result.RESULT_TIMEOUT
         elif run.was_terminated:
             return result.RESULT_UNKOWN
         elif run.exit_code == 0 and run.output.any_line_contains("Analysis done."):

--- a/benchexec/tools/wolverine.py
+++ b/benchexec/tools/wolverine.py
@@ -29,7 +29,7 @@ class Tool(benchexec.tools.template.BaseTool):
             assert returncode == 10
             status = result.RESULT_FALSE_REACH
         elif returnsignal == 9:
-            status = "TIMEOUT"
+            status = result.RESULT_TIMEOUT
         elif returnsignal == 6 or (returncode == 6 and "Out of memory" in output):
             status = "OUT OF MEMORY"
         elif returncode == 6 and "PARSING ERROR" in output:

--- a/benchexec/tools/yogar-cbmc.py
+++ b/benchexec/tools/yogar-cbmc.py
@@ -30,7 +30,7 @@ class Tool(benchexec.tools.template.BaseTool):
         stroutput = str(output)
 
         if isTimeout:
-            status = "TIMEOUT"
+            status = result.RESULT_TIMEOUT
         elif "SUCCESSFUL" in stroutput:
             status = result.RESULT_TRUE_PROP
         elif "FAILED" in stroutput:


### PR DESCRIPTION
The return values for TIMEOUT are inconsistent in the tool-info modules.
E.g., `symbiotic4` calls it "timeout" and `seahorn` calls it "TIMEOUT".

Solution: Let us add a pre-defined value for this return value.

Once merged, I would rewrite all tool-info modules to use this predefined return value.

Users are expecting such a pre-defined value: https://github.com/sosy-lab/benchexec/commit/c9a22a7275abb0f393071c2253682e852366184d