### PR TITLE
Add new result subtype for witnesslint

### DIFF
--- a/benchexec/tools/witnesslint.py
+++ b/benchexec/tools/witnesslint.py
@@ -35,8 +35,8 @@ class Tool(benchexec.tools.template.BaseTool2):
 
     def determine_result(self, run):
         exit_code = run.exit_code.value
-        witness_type_disagreement = self.get_value_from_output(
-            run.output, "Witness Type Disagreement"
+        witness_type_match = self.get_value_from_output(
+            run.output, "Witness Type-Match"
         )
         if "witnesslint finished" not in run.output[-1] or exit_code == 7:
             return "EXCEPTION"
@@ -46,7 +46,7 @@ class Tool(benchexec.tools.template.BaseTool2):
             return result.RESULT_ERROR + " (witness does not exist)"
         elif exit_code == 6:
             return result.RESULT_ERROR + " (program does not exist)"
-        elif witness_type_disagreement == "True":
+        elif witness_type_match == "False":
             return result.RESULT_ERROR + " (unexpected witness type)"
         elif exit_code == 0:
             return result.RESULT_DONE

--- a/benchexec/tools/witnesslint.py
+++ b/benchexec/tools/witnesslint.py
@@ -35,15 +35,21 @@ class Tool(benchexec.tools.template.BaseTool2):
 
     def determine_result(self, run):
         exit_code = run.exit_code.value
+        witness_type_disagreement = self.get_value_from_output(
+            run.output, "Witness Type Disagreement"
+        )
         if "witnesslint finished" not in run.output[-1] or exit_code == 7:
             return "EXCEPTION"
-        elif exit_code == 0:
-            return result.RESULT_DONE
         elif exit_code == 1:
             return result.RESULT_ERROR + " (invalid witness syntax)"
         elif exit_code == 5:
             return result.RESULT_ERROR + " (witness does not exist)"
         elif exit_code == 6:
             return result.RESULT_ERROR + " (program does not exist)"
+        elif witness_type_disagreement == "True":
+            return result.RESULT_ERROR + " (unexpected witness type)"
+        elif exit_code == 0:
+            return result.RESULT_DONE
+
         else:
             return result.UNKNOWN


### PR DESCRIPTION
This makes use of the feature added to the witness linter via https://gitlab.com/sosy-lab/benchmarking/sv-witnesses/-/merge_requests/66

For the competition (esp. the new validator track) we want to be able to detect those cases where the tool produced a syntactically fine witness, but just of wrong type (e.g. a correctness witness for a task where we would expect a violation witness).

