### PR TITLE
Change of status and category for mismatching witness type

### DIFF
--- a/contrib/mergeBenchmarkSets.py
+++ b/contrib/mergeBenchmarkSets.py
@@ -103,6 +103,12 @@ def get_witness_result(witness, verification_result):
             f"witness invalid ({status_from_verification})",
             result.CATEGORY_ERROR,
         )
+    # A mismatch of the witness type counts as error of the verifier.
+    if status_from_validation == "ERROR (unexpected witness type)":
+        return (
+            f"witness mismatch ({status_from_verification})",
+            result.CATEGORY_ERROR,
+        )
     # Other unconfirmed witnesses count as CATEGORY_CORRECT_UNCONFIRMED.
     if category_from_verification == result.CATEGORY_CORRECT:
         return status_from_verification, result.CATEGORY_CORRECT_UNCONFIRMED


### PR DESCRIPTION
Change of status and category if a validator (the linter `WitnessLint`) reported an unexpected witness type.

Explanation:  Assume a verification task with expected verdict TRUE.
Suppose a verifier returns TRUE (proved program correct) but returns a witness of type `violation_witness`.
Further suppose that the violation witness does not describe any feasible path that violates the specification,
and a validator returns TRUE as well (correctly, because no violation found).
Then the verifier gets the score points, but did not provide a witness with the necessary invariants.

Therefore, we have to change the status and category in order to assign 0 score points.