### PR TITLE
Tool-info module for Mopsa: Shorten Status Message

### DIFF
--- a/benchexec/tools/mopsa.py
+++ b/benchexec/tools/mopsa.py
@@ -44,4 +44,4 @@ class Tool(benchexec.tools.template.BaseTool2):
         elif r.startswith("error"):
             return result.RESULT_ERROR + r[len("ERROR") :]
         else:
-            return result.RESULT_ERROR + f"(unknown: {r})"
+            return result.RESULT_ERROR + "(unknown)"


### PR DESCRIPTION
Remove large volume of log dumping from status message.

The variable `r` can contain huge amounts of log dumps.
The status message should be very brief, to be shown in a table column.

The command that is called is always available as first line in the log output,
and further information can be retrieved from the log output as well.
No need to put this into the status.

Example status string:
`OUT OF MEMORY (ERROR(unknown: running /tmp/vcloud_worker_vcloud-master_on_vcloud-master/run_dir_595f7703-0f2a-48bd-84c7-311f3fc051fb/bin/mopsa-cfsnv5euho/bin/mopsa-c -config=c/cell-string-length-itv-congr.json -additional-stubs=c/sv-comp.c -use-stub=reach_error -no-warning -ccopt=-fbracket-depth=2048 -stub-ignore-case=malloc.failure,malloc.empty -c-check-signed-implicit-cast-overflow=false -c-check-unsigned-implicit-cast-overflow=false -c-check-unreachable-memory ../../sv-benchmarks/c/hardware-verification-bv/btor2c-lazymod.unknown_ridecore.c /tmp/vcloud_worker_vcloud-master_on_vcloud-master/run_dir_595f7703-0f2a-48bd-84c7-311f3fc051fb/bin/mopsa-cfsnv5euho/share/mopsa/stubs/c/libc/assert.c /tmp/vcloud_worker_vcloud-master_on_vcloud-master/run_dir_595f7703-0f2a-48bd-84c7-311f3fc051fb/bin/mopsa-cfsnv5euho/share/mopsa/stubs/c/libc/sys/socket.c /tmp/vcloud_worker_vcloud-master_on_vcloud-master/run_dir_595f7703-0f2a-48bd-84c7-311f3fc051fb/bin/mopsa-cfsnv5euho/share/mopsa/stubs/c/libc/netinet/in.c /tmp/vcloud_worker_vcloud-master_on_vcloud-master/run_dir_595f7703-0f2a-48bd-84c7-311f3fc051fb/bin/mopsa-cfsnv5euho/share/mopsa/stubs/c/libc/arpa/inet.c /tmp/vcloud_worker_vcloud-master_on_vcloud-master/run_dir_595f7703-0f2a-48bd-84c7-311f3fc051fb/bin/mopsa-cfsnv5euho/share/mopsa/stubs/c/libc/math.c /tmp/vcloud_worker_vcloud-master_on_vcloud-master/run_dir_595f7703-0f2a-48bd-84c7-311f3fc051fb/bin/mopsa-cfsnv5euho/share/mopsa/stubs/c/libc/stdio.c /tmp/vcloud_worker_vcloud-master_on_vcloud-master/run_dir_595f7703-0f2a-48bd-84c7-311f3fc051fb/bin/mopsa-cfsnv5euho/share/mopsa/stubs/c/libc/stdlib.c -format=json))`