### PR TITLE
GDart tool: add support for explicitly reporting RESULT_FALSE_REACH

### DIFF
--- a/benchexec/tools/gdart.py
+++ b/benchexec/tools/gdart.py
@@ -35,7 +35,9 @@ class Tool(BaseTool2):
 
     def determine_result(self, run):
         status = result.RESULT_ERROR
-        if run.output.any_line_contains("== ERROR"):
+        if run.output.any_line_contains("== ERROR-UNREACH-CALL"):
+            status = result.RESULT_FALSE_REACH
+        elif run.output.any_line_contains("== ERROR"):
             status = result.RESULT_FALSE_PROP
         elif run.output.any_line_contains("== OK"):
             status = result.RESULT_TRUE_PROP


### PR DESCRIPTION
At the moment, GDart always reports `RESULT_FALSE_PROP` for a violation signaled by the engine. This adds support for reporting `RESULT_FALSE_REACH` in a downward-compatible way. The fix was originally suggested by @PhilippWendler [here](https://gitlab.com/sosy-lab/sv-comp/archives-2023/-/issues/51#note_1181080378).