### PR TITLE
Double the score if a validator refutes or confirms a wrong witness

### DIFF
--- a/benchexec/result.py
+++ b/benchexec/result.py
@@ -111,10 +111,14 @@ class Property(collections.namedtuple("Property", "filename is_svcomp name")):
 
     __slots__ = ()  # reduce per-instance memory consumption
 
-    def compute_score(self, category, result):
+    def compute_score(self, category, result, is_invalid_witness=False):
         if not self.is_svcomp:
             return None
-        return _svcomp_score(category, result)
+        score = _svcomp_score(category, result)
+        if is_invalid_witness:
+            # If a validator refutes (confirms) a wrong witness, it gets double the score (reduction).
+            score *= 2
+        return score
 
     def max_score(self, expected_result):
         """

--- a/benchexec/result.py
+++ b/benchexec/result.py
@@ -33,6 +33,25 @@ CATEGORY_MISSING = "missing"
 """BenchExec could not determine whether run result was correct or wrong
 because no property was defined, and no other categories apply."""
 
+# categorization of a witness of a run result
+# 'valid' and 'invalid' refer to whether the witness type matches the expected result.
+# For an explanation of 'valid*' and 'invalid',
+# see https://doi.org/10.1007/978-3-031-22308-2_8 (page 166, bottom).
+WITNESS_CATEGORY_CORRECT = "correct"
+"""witness given by tool is valid*"""
+
+WITNESS_CATEGORY_WRONG = "wrong"
+"""witness given by tool is invalid"""
+
+WITNESS_CATEGORY_UNKNOWN = "unknown"
+"""witness category cannot be determined"""
+
+WITNESS_CATEGORY_ERROR = "error"
+"""witness given by tool did not pass the syntax check, or syntax checker failed"""
+
+WITNESS_CATEGORY_MISSING = "missing"
+"""no witness given by tool"""
+
 # possible run results (output of a tool)
 RESULT_DONE = "done"
 """tool terminated properly and true/false does not make sense"""
@@ -85,7 +104,7 @@ _SCORE_WRONG_FALSE = -16
 _SCORE_WRONG_TRUE = -32
 # Score factor for validation results on invalid witnesses
 # as described in https://doi.org/10.1007/978-3-031-22308-2_8 (page 171, last paragraph, factor q)
-_SCORE_FACTOR_INVALID_WITNESS = 2
+_SCORE_FACTOR_WRONG_WITNESS = 2
 
 
 class ExpectedResult(collections.namedtuple("ExpectedResult", "result subproperty")):
@@ -114,13 +133,15 @@ class Property(collections.namedtuple("Property", "filename is_svcomp name")):
 
     __slots__ = ()  # reduce per-instance memory consumption
 
-    def compute_score(self, category, result, is_invalid_witness=False):
+    def compute_score(
+        self, category, result, witness_category=WITNESS_CATEGORY_UNKNOWN
+    ):
         if not self.is_svcomp:
             return None
         score = _svcomp_score(category, result)
-        if is_invalid_witness:
+        if witness_category == WITNESS_CATEGORY_WRONG:
             # If a validator refutes (confirms) a wrong witness, then the score (reduction) is multiplied by a factor.
-            score *= _SCORE_FACTOR_INVALID_WITNESS
+            score *= _SCORE_FACTOR_WRONG_WITNESS
         return score
 
     def max_score(self, expected_result):

--- a/benchexec/result.py
+++ b/benchexec/result.py
@@ -83,7 +83,9 @@ _SCORE_CORRECT_UNCONFIRMED_FALSE = 0
 _SCORE_UNKNOWN = 0
 _SCORE_WRONG_FALSE = -16
 _SCORE_WRONG_TRUE = -32
-
+# Score factor for validation results on invalid witnesses
+# as described in https://doi.org/10.1007/978-3-031-22308-2_8 (page 171, last paragraph, factor q)
+_SCORE_FACTOR_INVALID_WITNESS = 2
 
 class ExpectedResult(collections.namedtuple("ExpectedResult", "result subproperty")):
     """Stores the expected result and respective information for a task"""
@@ -116,8 +118,8 @@ class Property(collections.namedtuple("Property", "filename is_svcomp name")):
             return None
         score = _svcomp_score(category, result)
         if is_invalid_witness:
-            # If a validator refutes (confirms) a wrong witness, it gets double the score (reduction).
-            score *= 2
+            # If a validator refutes (confirms) a wrong witness, then the score (reduction) is multiplied by a factor.
+            score *= _SCORE_FACTOR_INVALID_WITNESS
         return score
 
     def max_score(self, expected_result):

--- a/benchexec/result.py
+++ b/benchexec/result.py
@@ -87,6 +87,7 @@ _SCORE_WRONG_TRUE = -32
 # as described in https://doi.org/10.1007/978-3-031-22308-2_8 (page 171, last paragraph, factor q)
 _SCORE_FACTOR_INVALID_WITNESS = 2
 
+
 class ExpectedResult(collections.namedtuple("ExpectedResult", "result subproperty")):
     """Stores the expected result and respective information for a task"""
 

--- a/benchexec/tablegenerator/__init__.py
+++ b/benchexec/tablegenerator/__init__.py
@@ -881,23 +881,16 @@ class RunResult(object):
 
         status = util.get_column_value(sourcefileTag, "status", "")
         category = util.get_column_value(sourcefileTag, "category")
-        witness_type = util.get_column_value(sourcefileTag, "witnesslint-witness-type")
+        witness_category = util.get_column_value(sourcefileTag, "witness-category")
         if not category:
             if status:  # only category missing
                 category = result.CATEGORY_MISSING
             else:  # probably everything is missing, special category for tables
                 category = "aborted"
 
-        is_invalid_witness = False
-        if (witness_type == "violation_witness" and expected_result[0]) or (
-            witness_type == "correctness_witness" and not expected_result[0]
-        ):
-            # Validator has refuted or confirmed an invalid witness
-            is_invalid_witness = True
-
         score = None
         if prop:
-            score = prop.compute_score(category, status, is_invalid_witness)
+            score = prop.compute_score(category, status, witness_category)
         logfileLines = None
 
         values = []

--- a/benchexec/tablegenerator/__init__.py
+++ b/benchexec/tablegenerator/__init__.py
@@ -888,14 +888,16 @@ class RunResult(object):
             else:  # probably everything is missing, special category for tables
                 category = "aborted"
 
+        is_invalid_witness = False
+        if (witness_type == "violation_witness" and expected_result[0]) or (
+            witness_type == "correctness_witness" and not expected_result[0]
+        ):
+            # Validator has refuted or confirmed an invalid witness
+            is_invalid_witness = True
+
         score = None
         if prop:
-            score = prop.compute_score(category, status)
-            if (witness_type == "violation_witness" and expected_result[0]) or (
-                witness_type == "correctness_witness" and not expected_result[0]
-            ):
-                # If a validator refutes (confirms) a wrong witness, it gets double the score (reduction).
-                score *= 2
+            score = prop.compute_score(category, status, is_invalid_witness)
         logfileLines = None
 
         values = []

--- a/benchexec/tablegenerator/__init__.py
+++ b/benchexec/tablegenerator/__init__.py
@@ -881,6 +881,7 @@ class RunResult(object):
 
         status = util.get_column_value(sourcefileTag, "status", "")
         category = util.get_column_value(sourcefileTag, "category")
+        witness_type = util.get_column_value(sourcefileTag, "witnesslint-witness-type")
         if not category:
             if status:  # only category missing
                 category = result.CATEGORY_MISSING
@@ -913,6 +914,11 @@ class RunResult(object):
             if column.title.lower() == "score" and value is None and score is not None:
                 # If no score column exists in the xml, take the internally computed score,
                 # if available
+                if (witness_type == "violation_witness" and expected_result[0]) or (
+                    witness_type == "correctness_witness" and not expected_result[0]
+                ):
+                    # If a validator refutes a wrong witness, it gets double the score.
+                    score *= 2
                 value = str(score)
             values.append(value)
 

--- a/benchexec/tablegenerator/__init__.py
+++ b/benchexec/tablegenerator/__init__.py
@@ -891,6 +891,11 @@ class RunResult(object):
         score = None
         if prop:
             score = prop.compute_score(category, status)
+            if (witness_type == "violation_witness" and expected_result[0]) or (
+                witness_type == "correctness_witness" and not expected_result[0]
+            ):
+                # If a validator refutes (confirms) a wrong witness, it gets double the score (reduction).
+                score *= 2
         logfileLines = None
 
         values = []
@@ -914,11 +919,6 @@ class RunResult(object):
             if column.title.lower() == "score" and value is None and score is not None:
                 # If no score column exists in the xml, take the internally computed score,
                 # if available
-                if (witness_type == "violation_witness" and expected_result[0]) or (
-                    witness_type == "correctness_witness" and not expected_result[0]
-                ):
-                    # If a validator refutes a wrong witness, it gets double the score.
-                    score *= 2
                 value = str(score)
             values.append(value)
 


### PR DESCRIPTION
ATTENTION: Do not squash because the commits are referenced in competition artifacts.

SV-COMP 2023 scoring schema is extended to double the score if a validator refutes or confirms a wrong witness.

Reference: https://doi.org/10.1007/978-3-031-22308-2_8 (page 171, last paragraph)