### PR TITLE
bump setuptools to support latest PEPs

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -7,9 +7,8 @@
 
 [build-system]
 requires = [
-    # Require versions that support our license files
-    'setuptools >= 42.0.0',
-    'wheel >= 0.32.0',
+    # Require versions that support our license files and the latest PEPs
+    'setuptools >= 64.0.0',
 ]
 build-backend = 'setuptools.build_meta'
 

--- a/setup.py
+++ b/setup.py
@@ -13,6 +13,5 @@ import warnings
 warnings.filterwarnings("default", module=r"^benchexec\..*")
 
 # This file is still required for compatibility with pip<19.0
-# and for "pip install -e .".
 
 setuptools.setup()


### PR DESCRIPTION
- `setuptools` `64.0.0` supports editable installs directly from `pyproject.toml` - https://github.com/pypa/setuptools/blob/main/CHANGES.rst#v6400
- An appropriate version of `wheel` is automatically installed while installing `setuptools` - https://github.com/pypa/setuptools/commit/f7d30a9