### PR TITLE
Update swat module-info

### DIFF
--- a/benchexec/tools/swat.py
+++ b/benchexec/tools/swat.py
@@ -15,6 +15,15 @@ class Tool(BaseTool2):
     SWAT is currently being developed by the Institute for IT Security at the University of Luebeck.
     """
 
+    REQUIRED_PATHS = [
+        "knife-fuzzer/symbolic-executor/lib/symbolic-executor.jar",
+        "knife-fuzzer/symbolic-explorer",
+        "local_z3_installation",
+        "WitnessCreator",
+        "run-swat.sh",
+        "run_swat.py"
+    ]
+
     def executable(self, tool_locator):
         return tool_locator.find_executable("run-swat.sh")
 
@@ -23,6 +32,14 @@ class Tool(BaseTool2):
 
     def project_url(self):
         return "https://www.its.uni-luebeck.de/en/institute.html"
+
+    def version(self, executable):
+        return self._version_from_tool(executable, arg="-v")
+
+    def program_files(self, executable):
+        return self._program_files_from_executable(
+            executable, self.REQUIRED_PATHS, parent_dir=False
+        )
 
     def cmdline(self, executable, options, task, rlimits):
         cmd = [executable] + options

--- a/benchexec/tools/swat.py
+++ b/benchexec/tools/swat.py
@@ -20,7 +20,7 @@ class Tool(BaseTool2):
         "local_z3_installation",
         "WitnessCreator",
         "run-swat.sh",
-        "run_swat.py"
+        "run_swat.py",
     ]
 
     def executable(self, tool_locator):

--- a/benchexec/tools/swat.py
+++ b/benchexec/tools/swat.py
@@ -16,8 +16,7 @@ class Tool(BaseTool2):
     """
 
     REQUIRED_PATHS = [
-        "knife-fuzzer/symbolic-executor/lib/symbolic-executor.jar",
-        "knife-fuzzer/symbolic-explorer",
+        "knife-fuzzer",
         "local_z3_installation",
         "WitnessCreator",
         "run-swat.sh",

--- a/benchexec/tools/swat.py
+++ b/benchexec/tools/swat.py
@@ -20,7 +20,7 @@ class Tool(BaseTool2):
         "local_z3_installation",
         "WitnessCreator",
         "run-swat.sh",
-        "run_swat.py",
+        "run_swat.py"
     ]
 
     def executable(self, tool_locator):
@@ -30,15 +30,10 @@ class Tool(BaseTool2):
         return "SWAT"
 
     def project_url(self):
-        return "https://www.its.uni-luebeck.de/en/institute.html"
+        return "https://www.its.uni-luebeck.de/en/research/tools/swat/"
 
     def version(self, executable):
         return self._version_from_tool(executable, arg="-v")
-
-    def program_files(self, executable):
-        return self._program_files_from_executable(
-            executable, self.REQUIRED_PATHS, parent_dir=False
-        )
 
     def cmdline(self, executable, options, task, rlimits):
         cmd = [executable] + options


### PR DESCRIPTION
Added a version as well as program files in order to comply with [benchexec.test_tool_info](https://gitlab.com/sosy-lab/sv-comp/sv-comp-2024/-/issues/76).

Output of `benchexec.test_tool_info`:
```
# PYTHONPATH=benchexec python3 -m benchexec.test_tool_info --read-only-dir / --hidden-dir /home --overlay-dir ./ --tool-directory bin/swat-verify-0vpofGREXj swat
Name of tool module: “swat”
Full name of tool module: “benchexec.tools.swat”
Documentation of tool module:
	Tool info module for SWAT, a dynamic symbolic execution tool for Java 17.
	SWAT is currently being developed by the Institute for IT Security at the University of Luebeck.
Name of tool: “SWAT”
Webpage: “https://www.its.uni-luebeck.de/en/institute.html”
Executable: “bin/swat-verify-0vpofGREXj/run-swat.sh”
Executable (absolute path): “/mount/bench-defs/bin/swat-verify-0vpofGREXj/run-swat.sh”
Version: “1”
Working directory: “.”
Working directory (absolute path): “/mount/bench-defs”
Program files:
	“bin/swat-verify-0vpofGREXj/knife-fuzzer”
	“bin/swat-verify-0vpofGREXj/local_z3_installation”
	“bin/swat-verify-0vpofGREXj/WitnessCreator”
	“bin/swat-verify-0vpofGREXj/run-swat.sh”
	“bin/swat-verify-0vpofGREXj/run_swat.py”
Program files (absolute paths):
	“/mount/bench-defs/bin/swat-verify-0vpofGREXj/knife-fuzzer”
	“/mount/bench-defs/bin/swat-verify-0vpofGREXj/local_z3_installation”
	“/mount/bench-defs/bin/swat-verify-0vpofGREXj/WitnessCreator”
	“/mount/bench-defs/bin/swat-verify-0vpofGREXj/run-swat.sh”
	“/mount/bench-defs/bin/swat-verify-0vpofGREXj/run_swat.py”
Minimal command line:
	“['bin/swat-verify-0vpofGREXj/run-swat.sh', 'INPUT.FILE']”
Command line with parameter:
	“['bin/swat-verify-0vpofGREXj/run-swat.sh', '-SOME_OPTION', 'INPUT.FILE']”
Command line with property file:
	“['bin/swat-verify-0vpofGREXj/run-swat.sh', 'PROPERTY.PRP', 'INPUT.FILE']”
Command line with multiple input files:
	“['bin/swat-verify-0vpofGREXj/run-swat.sh', 'INPUT1.FILE', 'INPUT2.FILE']”
Command line CPU-time limit:
	“['bin/swat-verify-0vpofGREXj/run-swat.sh', 'INPUT.FILE']”
Command line SV-Benchmarks task:
	“['bin/swat-verify-0vpofGREXj/run-swat.sh', 'PROPERTY.PRP', 'INPUT.FILE']”
```
