### PR TITLE
Adjust required path for CPV

### DIFF
--- a/benchexec/tools/cpv.py
+++ b/benchexec/tools/cpv.py
@@ -20,7 +20,6 @@ class Tool(benchexec.tools.template.BaseTool2):
         "cpv/",
         "kratos2/",
         "lib/",
-        "witness.tmpl",
     ]
 
     def executable(self, tool_locator):


### PR DESCRIPTION
The witness template file is now moved into the `cpv/` folder (following https://gitlab.com/sosy-lab/software/cpv/-/commit/945ecacaeae9e497d36891b8ac4d085e6d245cb4).