### PR TITLE
Add tool-info module for LIV

### DIFF
--- a/benchexec/tools/liv.py
+++ b/benchexec/tools/liv.py
@@ -23,12 +23,6 @@ class Tool(BaseTool2):
         return tool_locator.find_executable("liv", subdir="bin")
 
     def program_files(self, executable):
-        print(
-            [executable]
-            + self._program_files_from_executable(
-                executable, self.REQUIRED_PATHS, parent_dir=True
-            )
-        )
         return [executable] + self._program_files_from_executable(
             executable, self.REQUIRED_PATHS, parent_dir=True
         )
@@ -37,7 +31,10 @@ class Tool(BaseTool2):
         return self._version_from_tool(executable)
 
     def name(self):
-        return "liv"
+        return "LIV"
+
+    def project_url(self):
+        return "https://gitlab.com/sosy-lab/software/liv"
 
     def cmdline(self, executable, options, task, rlimits):
         if task.property_file:
@@ -50,7 +47,6 @@ class Tool(BaseTool2):
         if data_model_param and "--data-model" not in options:
             options += ["--data-model", data_model_param]
 
-        self.options = options
         return [executable] + options + list(task.input_files_or_identifier)
 
     def determine_result(self, run):

--- a/benchexec/tools/liv.py
+++ b/benchexec/tools/liv.py
@@ -6,7 +6,6 @@
 # SPDX-License-Identifier: Apache-2.0
 
 import logging
-from xml.etree import ElementTree
 
 import benchexec.result
 from benchexec.tools.sv_benchmarks_util import ILP32, LP64, get_data_model_from_task
@@ -15,7 +14,7 @@ from benchexec.tools.template import BaseTool2
 
 class Tool(BaseTool2):
     """
-    Tool info for liv.
+    Tool info for LIV.
     """
 
     REQUIRED_PATHS = ["liv", "lib", "bin", "actors", ".venv"]

--- a/benchexec/tools/liv.py
+++ b/benchexec/tools/liv.py
@@ -1,0 +1,89 @@
+# This file is part of BenchExec, a framework for reliable benchmarking:
+# https://github.com/sosy-lab/benchexec
+#
+# SPDX-FileCopyrightText: 2007-2020 Dirk Beyer <https://www.sosy-lab.org>
+#
+# SPDX-License-Identifier: Apache-2.0
+
+import logging
+from xml.etree import ElementTree
+
+import benchexec.result
+from benchexec.tools.sv_benchmarks_util import ILP32, LP64, get_data_model_from_task
+from benchexec.tools.template import BaseTool2
+
+
+class Tool(BaseTool2):
+    """
+    Tool info for liv.
+    """
+
+    REQUIRED_PATHS = ["liv", "lib", "bin", "actors", ".venv"]
+
+    def executable(self, tool_locator: BaseTool2.ToolLocator):
+        return tool_locator.find_executable("liv", subdir="bin")
+
+    def program_files(self, executable):
+        print(
+            [executable]
+            + self._program_files_from_executable(
+                executable, self.REQUIRED_PATHS, parent_dir=True
+            )
+        )
+        return [executable] + self._program_files_from_executable(
+            executable, self.REQUIRED_PATHS, parent_dir=True
+        )
+
+    def version(self, executable):
+        return self._version_from_tool(executable)
+
+    def name(self):
+        return "liv"
+
+    def cmdline(self, executable, options, task, rlimits):
+        if task.property_file:
+            options = options + ["--property", task.property_file]
+
+        data_model_param = get_data_model_from_task(
+            task, {ILP32: "ILP32", LP64: "LP64"}
+        )
+
+        if data_model_param and "--data-model" not in options:
+            options += ["--data-model", data_model_param]
+
+        self.options = options
+        return [executable] + options + list(task.input_files_or_identifier)
+
+    def determine_result(self, run):
+        if not run.output:
+            return benchexec.result.RESULT_ERROR
+        lastline = run.output[-1]
+        if "true" in lastline:
+            return benchexec.result.RESULT_TRUE_PROP
+        elif "false" in lastline:
+            return benchexec.result.RESULT_FALSE_PROP
+        elif "unknown" in lastline:
+            return benchexec.result.RESULT_UNKNOWN
+        else:
+            return benchexec.result.RESULT_ERROR
+
+    def get_value_from_output(self, output, identifier):
+        # search for the text in output and get its value,
+        # search the first line, that starts with the searched text
+        # warn if there are more lines (multiple statistics from sequential analysis?)
+        match = None
+        for line in output:
+            if line.lstrip().startswith(identifier):
+                startPosition = line.find(":") + 1
+                endPosition = line.find("(", startPosition)
+                if endPosition == -1:
+                    endPosition = len(line)
+                if match is None:
+                    match = line[startPosition:endPosition].strip()
+                else:
+                    logging.warning(
+                        "skipping repeated match for identifier '%s': '%s'",
+                        identifier,
+                        line,
+                    )
+        return match


### PR DESCRIPTION
This adds a tool info module for the validator LIV:
https://gitlab.com/sosy-lab/software/liv

Taken from LIVs repository
https://gitlab.com/sosy-lab/software/liv/-/blob/main/liv/toolinfo/liv.py?ref_type=heads

SV-COMP currently does not allow to have this inside the tool and use this as far as I can tell (PYTHONPATH would need to be set to take it from the tool directory).