### PR TITLE
Add a missing required path for CPV

### DIFF
--- a/benchexec/tools/cpv.py
+++ b/benchexec/tools/cpv.py
@@ -16,10 +16,11 @@ class Tool(benchexec.tools.template.BaseTool2):
     """
 
     REQUIRED_PATHS = [
+        "actors/",
         "bin/",
         "cpv/",
-        "kratos2/",
         "lib/",
+        "kratos2/",
     ]
 
     def executable(self, tool_locator):


### PR DESCRIPTION
The `actors/` folder stores the actor definitions used by CoVeriTeam.