### PR TITLE
Update concurrentwitness2test.py with better result determination

### DIFF
--- a/benchexec/tools/concurrentwitness2test.py
+++ b/benchexec/tools/concurrentwitness2test.py
@@ -38,11 +38,7 @@ class Tool(benchexec.tools.template.BaseTool2):
                 return result.RESULT_TIMEOUT + "(inner)"
             elif "Verdict: Unknown error" in line:
                 return result.RESULT_ERROR
-            elif "Verdict: Incompatible witness" in line:
-                return result.RESULT_ERROR + "(Incompatible witness)"
-            elif "Verdict: Parsing failed" in line:
-                return result.RESULT_ERROR + "(Parsing failed)"
-            elif "Verdict: Compilation error" in line:
-                return result.RESULT_ERROR + "(Compilation error)"
+            elif "Verdict: " in line:
+                return result.RESULT_ERROR + "(" + line[len("Verdict: "):] + ")"
 
         return result.RESULT_UNKNOWN

--- a/benchexec/tools/concurrentwitness2test.py
+++ b/benchexec/tools/concurrentwitness2test.py
@@ -39,6 +39,6 @@ class Tool(benchexec.tools.template.BaseTool2):
             elif "Verdict: Unknown error" in line:
                 return result.RESULT_ERROR
             elif "Verdict: " in line:
-                return result.RESULT_ERROR + "(" + line[len("Verdict: "):] + ")"
+                return result.RESULT_ERROR + "(" + line[len("Verdict: ") :] + ")"
 
         return result.RESULT_UNKNOWN


### PR DESCRIPTION
This PR adds support for a wider set of statuses as the output of the benchmarks, while preserving backwards compatibility with older logs. 

Instead of separate if-branches to check for statuses beginning with `Verdict: `, we combine them into one branch.