### PR TITLE
Refactor witness output interpretation

### DIFF
--- a/benchexec/tools/witnesslint.py
+++ b/benchexec/tools/witnesslint.py
@@ -43,11 +43,10 @@ class Tool(benchexec.tools.template.BaseTool2):
         witness_version_match = self.get_value_from_output(
             run.output, "Witness Version-Match"
         )
-        if (
-            len(run.output) == 0
-            or "witnesslint finished" not in run.output[-1]
-            or exit_code == 7
-        ):
+
+        if not run.output:
+            return result.RESULT_ERROR + "(no output)"
+        elif "witnesslint finished" not in run.output[-1] or exit_code == 7:
             return "EXCEPTION"
         elif exit_code == 1:
             return result.RESULT_ERROR + " (invalid witness syntax)"

--- a/benchexec/tools/witnesslint.py
+++ b/benchexec/tools/witnesslint.py
@@ -46,8 +46,10 @@ class Tool(benchexec.tools.template.BaseTool2):
 
         if not run.output:
             return result.RESULT_ERROR + " (no output)"
-        elif "witnesslint finished" not in run.output[-1] or exit_code == 7:
+        elif exit_code == 7 or any(line.startswith("Traceback") for line in run.output):
             return "EXCEPTION"
+        elif "witnesslint finished" not in run.output[-1]:
+            return result.RESULT_ERROR + " (linter did not finish)"
         elif exit_code == 1:
             return result.RESULT_ERROR + " (invalid witness syntax)"
         elif exit_code == 5:

--- a/benchexec/tools/witnesslint.py
+++ b/benchexec/tools/witnesslint.py
@@ -45,7 +45,7 @@ class Tool(benchexec.tools.template.BaseTool2):
         )
 
         if not run.output:
-            return result.RESULT_ERROR + "(no output)"
+            return result.RESULT_ERROR + " (no output)"
         elif "witnesslint finished" not in run.output[-1] or exit_code == 7:
             return "EXCEPTION"
         elif exit_code == 1:
@@ -61,5 +61,4 @@ class Tool(benchexec.tools.template.BaseTool2):
         elif exit_code == 0:
             return result.RESULT_DONE
 
-        else:
-            return result.UNKNOWN
+        return result.RESULT_ERROR + " (could not determine output)"


### PR DESCRIPTION
In order to make it easier to understand the output of the witness linter we sepparate the exception case from the case where there was no output