### PR TITLE
Increase memlimit when checking for cgroups

### DIFF
--- a/benchexec/check_cgroups.py
+++ b/benchexec/check_cgroups.py
@@ -47,14 +47,15 @@ def check_cgroup_availability(wait=1):
         mems = [0]
 
     with tempfile.NamedTemporaryFile(mode="rt") as tmp:
-        runexecutor.execute_run(
+        execution = runexecutor.execute_run(
             ["sh", "-c", f"sleep {wait}; cat /proc/self/cgroup"],
             tmp.name,
-            memlimit=1024 * 1024,  # set memlimit to force check for swapaccount
+            memlimit=100 * 1024 * 1024,  # set memlimit to force check for swapaccount
             # set cores and memory_nodes to force usage of CPUSET
             cores=cores,
             memory_nodes=mems,
         )
+        assert execution["exitcode"].raw == 0, execution
         lines = []
         for line in tmp:
             line = line.strip()


### PR DESCRIPTION
On my system, this command takes around 1.4MiB (possibly due to large env, many $PATH entries, and statically compiled binaries). There's no reason to be stingy with this limit; the comment indicates it's just there to "force check for swapaccount".

This error manifests itself much later in the code as:

```
Traceback (most recent call last):
  File "/nix/store/8np01kr8qpm49m2gzjbwcjr68f162b9x-python3-3.10.13/lib/python3.10/runpy.py", line 196, in _run_module_as_main
    return _run_code(code, main_globals, None,
  File "/nix/store/8np01kr8qpm49m2gzjbwcjr68f162b9x-python3-3.10.13/lib/python3.10/runpy.py", line 86, in _run_code
    exec(code, run_globals)
  File "/nix/store/hk9vr7k1z9wz02q6sq04qkfdbv92sri2-python3-3.10.13-env/lib/python3.10/site-packages/benchexec/check_cgroups.py", line 153, in <module>
    main()
  File "/nix/store/hk9vr7k1z9wz02q6sq04qkfdbv92sri2-python3-3.10.13-env/lib/python3.10/site-packages/benchexec/check_cgroups.py", line 149, in main
    check_cgroup_availability_in_thread(options)
  File "/nix/store/hk9vr7k1z9wz02q6sq04qkfdbv92sri2-python3-3.10.13-env/lib/python3.10/site-packages/benchexec/check_cgroups.py", line 101, in check_cgroup_availability_in_thread
    raise thread.error
  File "/nix/store/hk9vr7k1z9wz02q6sq04qkfdbv92sri2-python3-3.10.13-env/lib/python3.10/site-packages/benchexec/check_cgroups.py", line 113, in run
    check_cgroup_availability(self.options.wait)
  File "/nix/store/hk9vr7k1z9wz02q6sq04qkfdbv92sri2-python3-3.10.13-env/lib/python3.10/site-packages/benchexec/check_cgroups.py", line 67, in check_cgroup_availability
    task_cgroups = Cgroups.from_system(cgroup_procinfo=lines)
  File "/nix/store/hk9vr7k1z9wz02q6sq04qkfdbv92sri2-python3-3.10.13-env/lib/python3.10/site-packages/benchexec/cgroups.py", line 108, in from_system
    return CgroupsV2.from_system(cgroup_procinfo)
  File "/nix/store/hk9vr7k1z9wz02q6sq04qkfdbv92sri2-python3-3.10.13-env/lib/python3.10/site-packages/benchexec/cgroupsv2.py", line 309, in from_system
    cgroup_path = _parse_proc_pid_cgroup(cgroup_procinfo)
  File "/nix/store/hk9vr7k1z9wz02q6sq04qkfdbv92sri2-python3-3.10.13-env/lib/python3.10/site-packages/benchexec/cgroupsv2.py", line 234, in _parse_proc_pid_cgroup
    return path
UnboundLocalError: local variable 'path' referenced before assignment
```

I also check the return code of the command. This is a good practice and would help debug similar issues in the future.