### PR TITLE
feat: add javascript workflows via GitHub Workflows

### DIFF
--- a/.github/workflows/javascript.yml
+++ b/.github/workflows/javascript.yml
@@ -1,0 +1,97 @@
+name: JavaScript Pipeline
+
+on:
+  push:
+    branches:
+      - main
+  pull_request:
+    branches:
+      - main
+  workflow_dispatch:
+
+jobs:
+  lint:
+    name: Linting JavaScript code
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v2
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v2
+        with:
+          node-version: "12"
+
+      - name: Cache node modules
+        uses: actions/cache@v2
+        with:
+          path: benchexec/tablegenerator/react-table/node_modules
+          key: ${{ runner.os }}-node-modules-${{ hashFiles('**/package-lock.json') }}
+          restore-keys: |
+            ${{ runner.os }}-node-modules-
+
+      - name: Install dependencies
+        run: npm ci
+        working-directory: benchexec/tablegenerator/react-table
+
+      - name: Lint
+        run: npm run lint
+        working-directory: benchexec/tablegenerator/react-table
+
+  tests:
+    name: Run JavaScript tests
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v2
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v2
+        with:
+          node-version: "12"
+
+      - name: Cache node modules
+        uses: actions/cache@v2
+        with:
+          path: benchexec/tablegenerator/react-table/node_modules
+          key: ${{ runner.os }}-node-modules-${{ hashFiles('**/package-lock.json') }}
+          restore-keys: |
+            ${{ runner.os }}-node-modules-
+
+      - name: Install dependencies
+        run: npm ci
+        working-directory: benchexec/tablegenerator/react-table
+
+      - name: Run tests
+        run: npm run test
+        working-directory: benchexec/tablegenerator/react-table
+
+  javascript-build:
+    name: Build JavaScript
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v2
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v2
+        with:
+          node-version: "12"
+
+      - name: Cache node modules
+        uses: actions/cache@v2
+        with:
+          path: benchexec/tablegenerator/react-table/node_modules
+          key: ${{ runner.os }}-node-modules-${{ hashFiles('**/package-lock.json') }}
+          restore-keys: |
+            ${{ runner.os }}-node-modules-
+
+      - name: Install dependencies
+        run: npm ci
+        working-directory: benchexec/tablegenerator/react-table
+
+      - name: Build
+        run: |
+          npm run build
+          git diff --stat --exit-code
+        working-directory: benchexec/tablegenerator/react-table

--- a/.github/workflows/javascript.yml
+++ b/.github/workflows/javascript.yml
@@ -26,7 +26,7 @@ jobs:
         uses: actions/cache@v3
         with:
           path: ~/.npm
-          key: npm-${{ hashFiles('package-lock.json') }}
+          key: npm-${{ hashFiles('benchexec/tablegenerator/react-table/package-lock.json') }}
           restore-keys: npm-
 
       - name: Install dependencies
@@ -53,7 +53,7 @@ jobs:
         uses: actions/cache@v3
         with:
           path: ~/.npm
-          key: npm-${{ hashFiles('package-lock.json') }}
+          key: npm-${{ hashFiles('benchexec/tablegenerator/react-table/package-lock.json') }}
           restore-keys: npm-
 
       - name: Install dependencies
@@ -80,7 +80,7 @@ jobs:
         uses: actions/cache@v3
         with:
           path: ~/.npm
-          key: npm-${{ hashFiles('package-lock.json') }}
+          key: npm-${{ hashFiles('benchexec/tablegenerator/react-table/package-lock.json') }}
           restore-keys: npm-
 
       - name: Install dependencies

--- a/.github/workflows/javascript.yml
+++ b/.github/workflows/javascript.yml
@@ -26,8 +26,6 @@ jobs:
 
       - name: Setup Node.js
         uses: actions/setup-node@v2
-        with:
-          node-version: "12"
 
       - name: Cache node modules
         uses: actions/cache@v2
@@ -54,8 +52,6 @@ jobs:
 
       - name: Setup Node.js
         uses: actions/setup-node@v2
-        with:
-          node-version: "12"
 
       - name: Cache node modules
         uses: actions/cache@v2
@@ -82,8 +78,6 @@ jobs:
 
       - name: Setup Node.js
         uses: actions/setup-node@v2
-        with:
-          node-version: "12"
 
       - name: Cache node modules
         uses: actions/cache@v2

--- a/.github/workflows/javascript.yml
+++ b/.github/workflows/javascript.yml
@@ -1,3 +1,10 @@
+# This file is part of BenchExec, a framework for reliable benchmarking:
+# https://github.com/sosy-lab/benchexec
+#
+# SPDX-FileCopyrightText: 2023 Dirk Beyer <https://www.sosy-lab.org>
+#
+# SPDX-License-Identifier: Apache-2.0
+
 name: JavaScript Pipeline
 
 on:
@@ -11,7 +18,7 @@ on:
 
 jobs:
   lint:
-    name: Linting JavaScript code
+    name: Perform linting
     runs-on: ubuntu-latest
     steps:
       - name: Checkout repository
@@ -39,7 +46,7 @@ jobs:
         working-directory: benchexec/tablegenerator/react-table
 
   tests:
-    name: Run JavaScript tests
+    name: Running tests
     runs-on: ubuntu-latest
     steps:
       - name: Checkout repository
@@ -67,7 +74,7 @@ jobs:
         working-directory: benchexec/tablegenerator/react-table
 
   javascript-build:
-    name: Build JavaScript
+    name: Building the application
     runs-on: ubuntu-latest
     steps:
       - name: Checkout repository

--- a/.github/workflows/javascript.yml
+++ b/.github/workflows/javascript.yml
@@ -20,13 +20,14 @@ jobs:
       - name: Setup Node.js
         uses: actions/setup-node@v4
         with:
-          node-version: "18.12.0"
+          node-version: "lts/iron"
 
       - name: Cache dependencies
         uses: actions/cache@v3
         with:
           path: ~/.npm
           key: npm-${{ hashFiles('package-lock.json') }}
+          restore-keys: npm-
 
       - name: Install dependencies
         run: npm ci
@@ -46,13 +47,14 @@ jobs:
       - name: Setup Node.js
         uses: actions/setup-node@v4
         with:
-          node-version: "18.12.0"
+          node-version: "lts/iron"
 
       - name: Cache dependencies
         uses: actions/cache@v3
         with:
           path: ~/.npm
           key: npm-${{ hashFiles('package-lock.json') }}
+          restore-keys: npm-
 
       - name: Install dependencies
         run: npm ci
@@ -72,13 +74,14 @@ jobs:
       - name: Setup Node.js
         uses: actions/setup-node@v4
         with:
-          node-version: "18.12.0"
+          node-version: "lts/iron"
 
       - name: Cache dependencies
         uses: actions/cache@v3
         with:
           path: ~/.npm
           key: npm-${{ hashFiles('package-lock.json') }}
+          restore-keys: npm-
 
       - name: Install dependencies
         run: npm ci

--- a/.github/workflows/javascript.yml
+++ b/.github/workflows/javascript.yml
@@ -22,15 +22,11 @@ jobs:
         with:
           node-version: "lts"
 
-      - name: Cache node modules
+      - name: Cache dependencies
         uses: actions/cache@v3
         with:
-          # npm cache files are stored in `~/.npm` on Linux/macOS
           path: ~/.npm
-          key: ${{ runner.os }}-cache-node-modules-${{ hashFiles('**/package-lock.json') }}
-          restore-keys: |
-            ${{ runner.os }}-cache-node-modules-
-            ${{ runner.os }}-
+          key: npm-${{ hashFiles('package-lock.json') }}
 
       - name: Install dependencies
         run: npm ci
@@ -50,13 +46,11 @@ jobs:
       - name: Setup Node.js
         uses: actions/setup-node@v2
 
-      - name: Cache node modules
-        uses: actions/cache@v2
+      - name: Cache dependencies
+        uses: actions/cache@v3
         with:
-          path: benchexec/tablegenerator/react-table/node_modules
-          key: ${{ runner.os }}-node-modules-${{ hashFiles('**/package-lock.json') }}
-          restore-keys: |
-            ${{ runner.os }}-node-modules-
+          path: ~/.npm
+          key: npm-${{ hashFiles('package-lock.json') }}
 
       - name: Install dependencies
         run: npm ci
@@ -76,13 +70,11 @@ jobs:
       - name: Setup Node.js
         uses: actions/setup-node@v2
 
-      - name: Cache node modules
-        uses: actions/cache@v2
+      - name: Cache dependencies
+        uses: actions/cache@v3
         with:
-          path: benchexec/tablegenerator/react-table/node_modules
-          key: ${{ runner.os }}-node-modules-${{ hashFiles('**/package-lock.json') }}
-          restore-keys: |
-            ${{ runner.os }}-node-modules-
+          path: ~/.npm
+          key: npm-${{ hashFiles('package-lock.json') }}
 
       - name: Install dependencies
         run: npm ci

--- a/.github/workflows/javascript.yml
+++ b/.github/workflows/javascript.yml
@@ -7,14 +7,7 @@
 
 name: JavaScript Pipeline
 
-on:
-  push:
-    branches:
-      - main
-  pull_request:
-    branches:
-      - main
-  workflow_dispatch:
+on: [push, pull_request, workflow_dispatch]
 
 jobs:
   lint:
@@ -22,18 +15,22 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v2
+        uses: actions/checkout@v4
 
       - name: Setup Node.js
-        uses: actions/setup-node@v2
+        uses: actions/setup-node@v4
+        with:
+          node-version: "lts"
 
       - name: Cache node modules
-        uses: actions/cache@v2
+        uses: actions/cache@v3
         with:
-          path: benchexec/tablegenerator/react-table/node_modules
-          key: ${{ runner.os }}-node-modules-${{ hashFiles('**/package-lock.json') }}
+          # npm cache files are stored in `~/.npm` on Linux/macOS
+          path: ~/.npm
+          key: ${{ runner.os }}-cache-node-modules-${{ hashFiles('**/package-lock.json') }}
           restore-keys: |
-            ${{ runner.os }}-node-modules-
+            ${{ runner.os }}-cache-node-modules-
+            ${{ runner.os }}-
 
       - name: Install dependencies
         run: npm ci

--- a/.github/workflows/javascript.yml
+++ b/.github/workflows/javascript.yml
@@ -20,7 +20,7 @@ jobs:
       - name: Setup Node.js
         uses: actions/setup-node@v4
         with:
-          node-version: "lts"
+          node-version: "18.12.0"
 
       - name: Cache dependencies
         uses: actions/cache@v3
@@ -41,10 +41,12 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v2
+        uses: actions/checkout@v4
 
       - name: Setup Node.js
-        uses: actions/setup-node@v2
+        uses: actions/setup-node@v4
+        with:
+          node-version: "18.12.0"
 
       - name: Cache dependencies
         uses: actions/cache@v3
@@ -65,10 +67,12 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v2
+        uses: actions/checkout@v4
 
       - name: Setup Node.js
-        uses: actions/setup-node@v2
+        uses: actions/setup-node@v4
+        with:
+          node-version: "18.12.0"
 
       - name: Cache dependencies
         uses: actions/cache@v3


### PR DESCRIPTION
Fixes part of #1007 
Adds the JavaScript workflows for
- Linting
- Running the tests
- Building the application

It also makes sure that the `node_modules` folder is cached between runs so that the workflows run in parallel and quickly.