### PR TITLE
refactor: Use logging.INFO instead of "INFO" in setup_logging

### DIFF
--- a/benchexec/util.py
+++ b/benchexec/util.py
@@ -728,7 +728,7 @@ def should_color_output():
     return sys.stdout.isatty() and "NO_COLOR" not in os.environ
 
 
-def setup_logging(fmt="%(asctime)s - %(levelname)s - %(message)s", level="INFO"):
+def setup_logging(fmt="%(asctime)s - %(levelname)s - %(message)s", level=logging.INFO):
     """Setup the logging framework with a basic configuration"""
     if should_color_output():
         try:


### PR DESCRIPTION
Passing logging.INFO to setup_logging(level) will cause a type error: Argument of type "int" cannot be assigned to parameter "level" of type "str", because logging.INFO/Debug/etc. defined in logging lib are all ints while setup_logging expects it to be a string by default (although this will not cause any runtime errors).