### PR TITLE
fix: Add error message output to respond to the impact of Ubuntu 24.04

### DIFF
--- a/benchexec/container.py
+++ b/benchexec/container.py
@@ -115,6 +115,14 @@ NATIVE_CLONE_CALLBACK_SUPPORTED = (
 )
 """Whether we use generated native code for clone or an unsafe Python fallback"""
 
+_ERROR_MSG_USER_NS_RESTRICTION = (
+    "Unprivileged user namespaces forbidden on this system, please "
+    "enable them with 'sysctl -w kernel.apparmor_restrict_unprivileged_userns=0'. "
+    "Ubuntu disables them by default since 24.04, refer to "
+    "https://ubuntu.com/blog/ubuntu-23-10-restricted-unprivileged-user-namespaces "
+    "for more information."
+)
+
 
 @contextlib.contextmanager
 def allocate_stack(size=DEFAULT_STACK_SIZE):

--- a/benchexec/container.py
+++ b/benchexec/container.py
@@ -44,6 +44,7 @@ __all__ = [
     "CONTAINER_GID",
     "CONTAINER_HOME",
     "CONTAINER_HOSTNAME",
+    "check_apparmor_userns_restriction",
 ]
 
 
@@ -122,6 +123,20 @@ _ERROR_MSG_USER_NS_RESTRICTION = (
     "https://ubuntu.com/blog/ubuntu-23-10-restricted-unprivileged-user-namespaces "
     "for more information."
 )
+
+
+def check_apparmor_userns_restriction(error: OSError):
+    """Check whether the passed OSError was likely caused by Ubuntu's AppArmor-based
+    restriction of user namespaces."""
+    return (
+        error.errno
+        in [
+            errno.EPERM,
+            errno.EACCES,
+        ]
+        and util.try_read_file("/proc/sys/kernel/apparmor_restrict_unprivileged_userns")
+        == "1"
+    )
 
 
 @contextlib.contextmanager

--- a/benchexec/containerexecutor.py
+++ b/benchexec/containerexecutor.py
@@ -754,12 +754,7 @@ class ContainerExecutor(baseexecutor.BaseExecutor):
                         traceback.extract_tb(e.__traceback__, limit=-1)[0].line,
                         e,
                     )
-                    if util.try_read_file(
-                        "/proc/sys/kernel/apparmor_restrict_unprivileged_userns"
-                    ) == "1" and e.errno in [
-                        errno.EPERM,
-                        errno.EACCES,
-                    ]:
+                    if container.check_apparmor_userns_restriction(e):
                         logging.critical(container._ERROR_MSG_USER_NS_RESTRICTION)
                     return CHILD_OSERROR
 

--- a/benchexec/containerexecutor.py
+++ b/benchexec/containerexecutor.py
@@ -754,6 +754,13 @@ class ContainerExecutor(baseexecutor.BaseExecutor):
                         traceback.extract_tb(e.__traceback__, limit=-1)[0].line,
                         e,
                     )
+                    if util.try_read_file(
+                        "/proc/sys/kernel/apparmor_restrict_unprivileged_userns"
+                    ) == "1" and e.errno in [
+                        errno.EPERM,
+                        errno.EACCES,
+                    ]:
+                        logging.critical(container._ERROR_MSG_USER_NS_RESTRICTION)
                     return CHILD_OSERROR
 
                 try:

--- a/benchexec/containerized_tool.py
+++ b/benchexec/containerized_tool.py
@@ -124,6 +124,14 @@ def _init_container_and_load_tool(tool_module, *args, **kwargs):
     try:
         _init_container(*args, **kwargs)
     except OSError as e:
+        if (
+            util.try_read_file("/proc/sys/kernel/apparmor_restrict_unprivileged_userns")
+            == "1"
+        ) and e.errno in [
+            errno.EPERM,
+            errno.EACCES,
+        ]:
+            raise BenchExecException(container._ERROR_MSG_USER_NS_RESTRICTION)
         raise BenchExecException(f"Failed to configure container: {e}")
     return _load_tool(tool_module)
 

--- a/benchexec/containerized_tool.py
+++ b/benchexec/containerized_tool.py
@@ -124,13 +124,7 @@ def _init_container_and_load_tool(tool_module, *args, **kwargs):
     try:
         _init_container(*args, **kwargs)
     except OSError as e:
-        if (
-            util.try_read_file("/proc/sys/kernel/apparmor_restrict_unprivileged_userns")
-            == "1"
-        ) and e.errno in [
-            errno.EPERM,
-            errno.EACCES,
-        ]:
+        if container.check_apparmor_userns_restriction(e):
             raise BenchExecException(container._ERROR_MSG_USER_NS_RESTRICTION)
         raise BenchExecException(f"Failed to configure container: {e}")
     return _load_tool(tool_module)

--- a/doc/INSTALL.md
+++ b/doc/INSTALL.md
@@ -169,6 +169,10 @@ that are not usable on all distributions by default:
   On CentOS it can be necessary to enable this feature with
   `sudo sysctl -w user.max_user_namespaces=10000` or a respective entry
   in `/etc/sysctl.conf` (the exact value is not important).
+  On Ubuntu 24.04 (or newer versions) it can be necessary to enable this feature with
+  `sysctl -w kernel.apparmor_restrict_unprivileged_userns=0` or a respective entry
+  in `/etc/sysctl.conf`.
+  
 
 - **Unprivileged Overlay Filesystem**: This is only available since Linux 5.11
   (kernel option `CONFIG_OVERLAY_FS`),

--- a/doc/container.md
+++ b/doc/container.md
@@ -211,7 +211,7 @@ in a container with `containerexec` than using `benchexec` or `runexec`.
 
 #### `Cannot execute ...: Unprivileged user namespaces forbidden on this system...`
 Unprivileged user namespaces are forbidden on your system
-(this is the default on some distributions like Debian, Arch Linux, and CentOS).
+(this is the default on some distributions like Debian, Arch Linux, CentOS, and Ubuntu since 24.04).
 Please check the [system requirements](INSTALL.md#kernel-requirements)
 how to enable them.
 


### PR DESCRIPTION
- Updated `container.py` and `containerexecutor.py` to detect whether BenchExec is being used with container mode enabled on Ubuntu 24.04 and the use of unprivileged user namespaces is restricted in system configuration, output the corresponding error message if so.
- Updated the relevant documentation.

Part of #1041