### PR TITLE
Update Btor2C's tool-info module

### DIFF
--- a/benchexec/tools/btor2c.py
+++ b/benchexec/tools/btor2c.py
@@ -12,14 +12,14 @@ import benchexec.tools.template
 
 class Tool(benchexec.tools.template.BaseTool2):
     """
-    Tool info for BTOR2C: A Converter from BTOR2 models to C programs
+    Tool info for Btor2C: A translator from Btor2 circuits to C programs
     """
 
     def executable(self, tool_locator):
-        return tool_locator.find_executable("btor2code", subdir="build")
+        return tool_locator.find_executable("btor2c", subdir="build")
 
     def name(self):
-        return "BTOR2C"
+        return "Btor2C"
 
     def project_url(self):
         return "https://gitlab.com/sosy-lab/software/btor2c"
@@ -30,7 +30,7 @@ class Tool(benchexec.tools.template.BaseTool2):
     def get_value_from_output(self, output, identifier):
         # search for the text in output and get its value,
         # search the first line, that starts with the searched text
-        # warn if there are more lines (multiple statistics from sequential analysis?)
+        # warn if there are more lines
         match = None
         for line in output:
             if line.lstrip().startswith(identifier):

--- a/benchexec/tools/btor2c.py
+++ b/benchexec/tools/btor2c.py
@@ -24,6 +24,9 @@ class Tool(benchexec.tools.template.BaseTool2):
     def project_url(self):
         return "https://gitlab.com/sosy-lab/software/btor2c"
 
+    def version(self, executable):
+        return self._version_from_tool(executable, line_prefix="Btor2C version")
+
     def cmdline(self, executable, options, task, rlimits):
         return [executable] + options + [task.single_input_file]
 


### PR DESCRIPTION
The existing tool-info module for Btor2C is pretty outdated.
The main changes of this PR include:

- Fix executable name
- Update letter cases of tool name
- Support version extraction