### PR TITLE
Update SeaHorn's tool-info module

### DIFF
--- a/benchexec/tools/seahorn.py
+++ b/benchexec/tools/seahorn.py
@@ -16,7 +16,7 @@ import benchexec.result as result
 
 
 class Tool(benchexec.tools.template.BaseTool2):
-    REQUIRED_PATHS = ["bin", "crab", "include", "lib", "share"]
+    REQUIRED_PATHS = ["bin", "include", "lib", "share"]
 
     def executable(self, tool_locator):
         self.use_svcomp_wrapper = False

--- a/benchexec/tools/seahorn.py
+++ b/benchexec/tools/seahorn.py
@@ -40,7 +40,9 @@ class Tool(benchexec.tools.template.BaseTool):
         return [executable] + options + spec + tasks
 
     def version(self, executable):
-        return self._version_from_tool(executable)
+        return self._version_from_tool(
+            f"{str(executable)}horn", line_prefix="  SeaHorn version"
+        )
 
     def determine_result(self, returncode, returnsignal, output, isTimeout):
         output = "\n".join(output)

--- a/benchexec/tools/seahorn.py
+++ b/benchexec/tools/seahorn.py
@@ -17,10 +17,10 @@ import os
 
 
 class Tool(benchexec.tools.template.BaseTool):
-    REQUIRED_PATHS = ["bin", "include", "lib", "share"]
+    REQUIRED_PATHS = ["bin", "crab", "include", "lib", "share"]
 
-    def executable(self):
-        return util.find_executable("sea_svcomp", os.path.join("bin", "sea_svcomp"))
+    def executable(self, tool_locator):
+        return tool_locator.find_executable("sea", subdir="bin")
 
     def program_files(self, executable):
         return self._program_files_from_executable(

--- a/benchexec/tools/seahorn.py
+++ b/benchexec/tools/seahorn.py
@@ -9,11 +9,8 @@
 # SeaHorn Verification Framework
 # DM-0002198
 
-import benchexec.util as util
 import benchexec.tools.template
 import benchexec.result as result
-
-import os
 
 
 class Tool(benchexec.tools.template.BaseTool2):

--- a/benchexec/tools/seahorn.py
+++ b/benchexec/tools/seahorn.py
@@ -16,7 +16,7 @@ import benchexec.result as result
 import os
 
 
-class Tool(benchexec.tools.template.BaseTool):
+class Tool(benchexec.tools.template.BaseTool2):
     REQUIRED_PATHS = ["bin", "crab", "include", "lib", "share"]
 
     def executable(self, tool_locator):
@@ -33,11 +33,8 @@ class Tool(benchexec.tools.template.BaseTool):
     def project_url(self):
         return "https://github.com/seahorn/seahorn"
 
-    def cmdline(self, executable, options, tasks, propertyfile, rlimits):
-        assert len(tasks) == 1
-        assert propertyfile is not None
-        spec = ["--spec=" + propertyfile]
-        return [executable] + options + spec + tasks
+    def cmdline(self, executable, options, task, rlimits):
+        return [executable] + options + [task.single_input_file]
 
     def version(self, executable):
         return self._version_from_tool(

--- a/benchexec/tools/seahorn.py
+++ b/benchexec/tools/seahorn.py
@@ -41,23 +41,9 @@ class Tool(benchexec.tools.template.BaseTool2):
             f"{str(executable)}horn", line_prefix="  SeaHorn version"
         )
 
-    def determine_result(self, returncode, returnsignal, output, isTimeout):
-        output = "\n".join(output)
-        if "BRUNCH_STAT Result TRUE" in output:
-            status = result.RESULT_TRUE_PROP
-        elif "BRUNCH_STAT Result FALSE" in output:
-            if "BRUNCH_STAT Termination" in output:
-                status = result.RESULT_FALSE_TERMINATION
-            else:
-                status = result.RESULT_FALSE_REACH
-        elif returnsignal == 9 or returnsignal == (128 + 9):
-            if isTimeout:
-                status = result.RESULT_TIMEOUT
-            else:
-                status = "KILLED BY SIGNAL 9"
-        elif returncode != 0:
-            status = f"ERROR ({returncode})"
-        else:
-            status = "FAILURE"
-
-        return status
+    def determine_result(self, run):
+        if run.output[-1].startswith("sat"):
+            return result.RESULT_FALSE_PROP
+        if run.output[-1].startswith("unsat"):
+            return result.RESULT_TRUE_PROP
+        return result.RESULT_ERROR

--- a/benchexec/tools/seahorn.py
+++ b/benchexec/tools/seahorn.py
@@ -28,7 +28,10 @@ class Tool(benchexec.tools.template.BaseTool):
         )
 
     def name(self):
-        return "SeaHorn-F16"
+        return "SeaHorn"
+
+    def project_url(self):
+        return "https://github.com/seahorn/seahorn"
 
     def cmdline(self, executable, options, tasks, propertyfile, rlimits):
         assert len(tasks) == 1


### PR DESCRIPTION
The existing tool-info module for SeaHorn was created for the version submitted to SV-COMP 2016.
This PR updates the module to work with the latest [version](https://github.com/seahorn/seahorn/tree/36a30812ba8a2921802a648ca171703c98a69a1e).