### PR TITLE
Add key tool info module

### DIFF
--- a/benchexec/tools/key_cli.py
+++ b/benchexec/tools/key_cli.py
@@ -39,5 +39,8 @@ class Tool(template.BaseTool2):
     def name(self):
         return "KeY"
 
+    def project_url(self):
+        return "https://www.key-project.org/"
+
     def cmdline(self, executable, options, task, rlimits):
-        return super().cmdline(executable, options, task, rlimits)
+        return [executable, *options, task.single_input_file]

--- a/benchexec/tools/key_cli.py
+++ b/benchexec/tools/key_cli.py
@@ -1,3 +1,10 @@
+# This file is part of BenchExec, a framework for reliable benchmarking:
+# https://github.com/sosy-lab/benchexec
+#
+# SPDX-FileCopyrightText: 2007-2024 Dirk Beyer <https://www.sosy-lab.org>
+#
+# SPDX-License-Identifier: Apache-2.0
+
 import re
 from pathlib import Path
 

--- a/benchexec/tools/key_cli.py
+++ b/benchexec/tools/key_cli.py
@@ -1,0 +1,37 @@
+import re
+from pathlib import Path
+
+from benchexec.tools import template
+
+
+class Tool(template.BaseTool2):
+    """
+    This tool-info module runs Cheetah, a parallel portfolio
+    of natively compiled CPAchecker instances.
+    """
+
+    REQUIRED_PATHS = ["bin", "lib"]
+
+    def executable(self, tool_locator):
+        return tool_locator.find_executable("key-cli", subdir="bin")
+
+    def version(self, executable):
+        lib = Path(executable).parent.parent / "lib"
+        for file in lib.glob("key-*-exe.jar"):
+            match = re.match(r"key-(.*)-exe.jar", file.name)
+
+            if match:
+                return match.group(1)
+
+        return "unknown"
+
+    def program_files(self, executable):
+        return self._program_files_from_executable(
+            executable, self.REQUIRED_PATHS, parent_dir=True
+        )
+
+    def name(self):
+        return "KeY"
+
+    def cmdline(self, executable, options, task, rlimits):
+        return super().cmdline(executable, options, task, rlimits)

--- a/benchexec/tools/key_cli.py
+++ b/benchexec/tools/key_cli.py
@@ -6,8 +6,7 @@ from benchexec.tools import template
 
 class Tool(template.BaseTool2):
     """
-    This tool-info module runs Cheetah, a parallel portfolio
-    of natively compiled CPAchecker instances.
+    This tool-info module runs KeY CLI, a cli version of the KeY deductive verifier.
     """
 
     REQUIRED_PATHS = ["bin", "lib"]

--- a/benchexec/tools/key_cli.py
+++ b/benchexec/tools/key_cli.py
@@ -29,7 +29,7 @@ class Tool(template.BaseTool2):
             if match:
                 return match.group(1)
 
-        return "unknown"
+        return ""
 
     def program_files(self, executable):
         return self._program_files_from_executable(


### PR DESCRIPTION
This MR adds the tool info module for the KeY CLI (a non interactive mode of the KeY Verifier)