### PR TITLE
Extend LXCFS integration

### DIFF
--- a/benchexec/baseexecutor.py
+++ b/benchexec/baseexecutor.py
@@ -80,9 +80,10 @@ class BaseExecutor(object):
         @param child_setup_fn a function without parameters that is called in the child process
             before the tool is started
         @param parent_cleanup_fn a function that is called in the parent process
-            immediately after the tool terminated, with three parameters:
+            immediately after the tool terminated, with four parameters:
             the result of parent_setup_fn, the result of the executed process as ProcessExitCode,
-            and the base path for looking up files as parameter values
+            the base path for looking up files as parameter values,
+            and the cgroup of the tool
         @return: a tuple of PID of process and a blocking function, which waits for the process
             and a triple of the exit code and the resource usage of the process
             and the result of parent_cleanup_fn (do not use os.wait)
@@ -125,11 +126,11 @@ class BaseExecutor(object):
             exitcode, ru_child = self._wait_for_process(p.pid, args[0])
 
             parent_cleanup = parent_cleanup_fn(
-                parent_setup, util.ProcessExitCode.from_raw(exitcode), ""
+                parent_setup, util.ProcessExitCode.from_raw(exitcode), "", cgroups
             )
             return exitcode, ru_child, parent_cleanup
 
-        return p.pid, wait_and_get_result
+        return p.pid, cgroups, wait_and_get_result
 
     def _wait_for_process(self, pid, name):
         """Wait for the given process to terminate.

--- a/benchexec/cgroups.py
+++ b/benchexec/cgroups.py
@@ -171,6 +171,10 @@ class Cgroups(ABC):
         pass
 
     @abstractmethod
+    def create_fresh_child_cgroup_for_delegation(self):
+        pass
+
+    @abstractmethod
     def add_task(self, pid):
         pass
 

--- a/benchexec/cgroupsv1.py
+++ b/benchexec/cgroupsv1.py
@@ -357,7 +357,7 @@ class CgroupsV1(Cgroups):
         else:
             sys.exit(_ERROR_MSG_OTHER)  # e.g., subsystem not mounted
 
-    def create_fresh_child_cgroup(self, subsystems):
+    def create_fresh_child_cgroup(self, subsystems, prefix=CGROUP_NAME_PREFIX):
         """
         Create child cgroups of the current cgroup for at least the given subsystems.
         @return: A Cgroup instance representing the new child cgroup(s).
@@ -374,7 +374,7 @@ class CgroupsV1(Cgroups):
                 ]
                 continue
 
-            cgroup = tempfile.mkdtemp(prefix=CGROUP_NAME_PREFIX, dir=parentCgroup)
+            cgroup = tempfile.mkdtemp(prefix=prefix, dir=parentCgroup)
             createdCgroupsPerSubsystem[subsystem] = cgroup
             createdCgroupsPerParent[parentCgroup] = cgroup
 
@@ -394,6 +394,18 @@ class CgroupsV1(Cgroups):
                 pass
 
         return CgroupsV1(createdCgroupsPerSubsystem)
+
+    def create_fresh_child_cgroup_for_delegation(self, prefix="delegate_"):
+        """
+        Create a child cgroup with all controllers.
+        On cgroupsv1 there is no difference to a regular child cgroup.
+        """
+        child_cgroup = self.create_fresh_child_cgroup(self.subsystems.keys(), prefix)
+        assert (
+            self.subsystems.keys() == child_cgroup.subsystems.keys()
+        ), "delegation failed for at least one controller"
+
+        return child_cgroup
 
     def add_task(self, pid):
         """

--- a/benchexec/container.py
+++ b/benchexec/container.py
@@ -107,7 +107,9 @@ DIR_FULL_ACCESS = "full-access"
 DIR_MODES = [DIR_HIDDEN, DIR_READ_ONLY, DIR_OVERLAY, DIR_FULL_ACCESS]
 """modes how a directory can be mounted in the container"""
 
-LXCFS_PROC_DIR = b"/var/lib/lxcfs/proc"
+LXCFS_BASE_DIR = b"/var/lib/lxcfs"
+LXCFS_PROC_DIR = LXCFS_BASE_DIR + b"/proc"
+SYS_CPU_DIR = b"/sys/devices/system/cpu"
 
 _CLONE_NESTED_CALLBACK = ctypes.CFUNCTYPE(ctypes.c_int)
 """Type for callback of execute_in_namespace, nested in our primary callback."""
@@ -966,6 +968,15 @@ def setup_container_system_config(basedir, mountdir, dir_modes):
             "It is recommended to use '--overlay-dir %(p)s' or '--hidden-dir %(p)s' "
             "and overwrite directory modes for subdirectories where necessary.",
             {"h": CONTAINER_HOME, "p": os.path.dirname(CONTAINER_HOME)},
+        )
+
+    # Virtualize CPU info with LXCFS if directory is not hidden nor full-access
+    if (
+        os.access(LXCFS_BASE_DIR + SYS_CPU_DIR, os.R_OK)
+        and determine_directory_mode(dir_modes, SYS_CPU_DIR) == DIR_READ_ONLY
+    ):
+        make_bind_mount(
+            LXCFS_BASE_DIR + SYS_CPU_DIR, mountdir + SYS_CPU_DIR, private=True
         )
 
 

--- a/benchexec/containerexecutor.py
+++ b/benchexec/containerexecutor.py
@@ -974,10 +974,8 @@ class ContainerExecutor(baseexecutor.BaseExecutor):
             # So for isolation, we need to create a child cgroup that becomes the root
             # of the cgroup ns, such that the limit settings are not accessible in the
             # container and cannot be changed.
-            if use_cgroup_ns:
-                grandchild_cgroups = cgroups.create_fresh_child_cgroup_for_delegation()
-            else:
-                grandchild_cgroups = cgroups
+            # We also do this for cgroups v1 for consistency.
+            grandchild_cgroups = cgroups.create_fresh_child_cgroup_for_delegation()
 
             # start measurements
             grandchild_cgroups.add_task(grandchild_pid)

--- a/benchexec/containerexecutor.py
+++ b/benchexec/containerexecutor.py
@@ -457,13 +457,13 @@ class ContainerExecutor(baseexecutor.BaseExecutor):
         cgroups = self._cgroups.create_fresh_child_cgroup(
             self._cgroups.subsystems.keys()
         )
-        pid = None
+        tool_pid = None
         returnvalue = 0
 
         logging.debug("Starting process.")
 
         try:
-            pid, result_fn = self._start_execution(
+            tool_pid, result_fn = self._start_execution(
                 args=args,
                 stdin=None,
                 stdout=None,
@@ -481,7 +481,7 @@ class ContainerExecutor(baseexecutor.BaseExecutor):
             )
 
             with self.SUB_PROCESS_PIDS_LOCK:
-                self.SUB_PROCESS_PIDS.add(pid)
+                self.SUB_PROCESS_PIDS.add(tool_pid)
 
             # wait until process has terminated
             returnvalue, unused_ru_child, unused = result_fn()
@@ -491,7 +491,7 @@ class ContainerExecutor(baseexecutor.BaseExecutor):
             logging.debug("Process terminated, exit code %s.", returnvalue)
 
             with self.SUB_PROCESS_PIDS_LOCK:
-                self.SUB_PROCESS_PIDS.discard(pid)
+                self.SUB_PROCESS_PIDS.discard(tool_pid)
 
             if temp_dir is not None:
                 logging.debug("Cleaning up temporary directory.")

--- a/benchexec/containerexecutor.py
+++ b/benchexec/containerexecutor.py
@@ -1019,7 +1019,7 @@ class ContainerExecutor(baseexecutor.BaseExecutor):
                 parent_setup,
                 util.ProcessExitCode.from_raw(exitcode),
                 base_path,
-                cgroups,
+                grandchild_cgroups,
             )
 
             if result_files_patterns:
@@ -1036,7 +1036,7 @@ class ContainerExecutor(baseexecutor.BaseExecutor):
 
             return exitcode, ru_child, parent_cleanup
 
-        return grandchild_pid, cgroups, wait_for_grandchild
+        return grandchild_pid, grandchild_cgroups, wait_for_grandchild
 
     def _setup_container_filesystem(self, temp_dir, output_dir, memlimit, memory_nodes):
         """Setup the filesystem layout in the container.

--- a/benchexec/runexecutor.py
+++ b/benchexec/runexecutor.py
@@ -911,7 +911,6 @@ class RunExecutor(containerexecutor.ContainerExecutor):
                 parent_cleanup_fn=postParent,
                 **kwargs,
             )
-            assert cgroups == tool_cgroups  # temporarily
 
             with self.SUB_PROCESS_PIDS_LOCK:
                 self.SUB_PROCESS_PIDS.add(tool_pid)

--- a/benchexec/test_runexecutor.py
+++ b/benchexec/test_runexecutor.py
@@ -1163,6 +1163,17 @@ class TestRunExecutorWithContainer(TestRunExecutor):
         cpus = [int(line.split()[2]) for line in output if line.startswith("processor")]
         self.assertListEqual(cpus, [0], "Unexpected CPU cores visible in container")
 
+    def test_sys_cpu_with_lxcfs(self):
+        if not os.path.exists("/var/lib/lxcfs/proc"):
+            self.skipTest("missing lxcfs")
+        result, output = self.execute_run(
+            self.cat, "/sys/devices/system/cpu/online", cores=[0]
+        )
+        self.check_result_keys(result)
+        self.check_exitcode(result, 0, "exit code for reading online CPUs is not zero")
+        cpus = util.parse_int_list(output[-1])
+        self.assertListEqual(cpus, [0], "Unexpected CPU cores online in container")
+
     def test_uptime_with_lxcfs(self):
         if not os.path.exists("/var/lib/lxcfs/proc"):
             self.skipTest("missing lxcfs")


### PR DESCRIPTION
We already use LXCFS to provide better isolation of the containers, and virtualize `/proc/uptime`. But LXCFS can do more and for example also provide a virtualized view on the CPU-core information provided by the kernel, such that applications see only cores that they are allowed to use. This was incompletely implemented and not working so far.