### PR TITLE
Fix bogus warning message "subprocess is still running"

### DIFF
--- a/benchexec/baseexecutor.py
+++ b/benchexec/baseexecutor.py
@@ -124,6 +124,7 @@ class BaseExecutor(object):
 
         def wait_and_get_result():
             exitcode, ru_child = self._wait_for_process(p.pid, args[0])
+            p.poll()
 
             parent_cleanup = parent_cleanup_fn(
                 parent_setup, util.ProcessExitCode.from_raw(exitcode), "", cgroups

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -74,9 +74,6 @@ ignore = [
 [tool.pytest.ini_options]
 filterwarnings = [
     "error",
-    # TODO cf. https://github.com/sosy-lab/benchexec/issues/1073
-    # To make warning visible change "ignore" to "default".
-    "ignore:subprocess .* is still running:ResourceWarning",
 ]
 python_files = ["test_*.py", "test_integration/__init__.py", "test.py"]
 norecursedirs = ["contrib/p4/docker_files", "build", "benchexec/tablegenerator/react-table"]


### PR DESCRIPTION
Fixes #1073. `Popen` in the `subprocess` module holds the exit code of the process in its internal state, which is only set if the provided methods to wait for process termination in the Popen class are used or `poll` is called.

If the exit code is not set, a bogus warning message occurs on destruction of the object - to prevent it, we can explicitly call poll after process termination to update the exit code.