### PR TITLE
Handle validation tasks inside CPAchecker

### DIFF
--- a/benchexec/tools/cpa-witness2test.py
+++ b/benchexec/tools/cpa-witness2test.py
@@ -51,4 +51,4 @@ class Tool(cpachecker.Tool):
     def cmdline(self, executable, options, task, rlimits):
         additional_options = self._get_additional_options(options, task, rlimits)
         # Add additional options in front of existing ones, since -gcc-args ... must be last argument in front of task
-        return [executable] + additional_options + options + [task.single_input_file]
+        return [executable] + additional_options + options + self._get_non_witness_input_files(task)

--- a/benchexec/tools/cpa-witness2test.py
+++ b/benchexec/tools/cpa-witness2test.py
@@ -7,7 +7,7 @@
 
 import benchexec.tools.cpachecker as cpachecker
 
-from benchexec.tools.template import ToolNotFoundException
+from benchexec.tools.template import ToolNotFoundException, UnsupportedFeatureException
 
 
 class Tool(cpachecker.Tool):
@@ -51,4 +51,10 @@ class Tool(cpachecker.Tool):
     def cmdline(self, executable, options, task, rlimits):
         additional_options = self._get_additional_options(options, task, rlimits)
         # Add additional options in front of existing ones, since -gcc-args ... must be last argument in front of task
-        return [executable] + additional_options + options + self._get_non_witness_input_files(task)
+        input_files = self._get_non_witness_input_files(task)
+        if len(input_files) != 1:
+            raise UnsupportedFeatureException(
+                f"{self.name()} does not support tasks with more than one non-witness input file"
+            )
+
+        return [executable] + additional_options + options + input_files

--- a/benchexec/tools/cpachecker.py
+++ b/benchexec/tools/cpachecker.py
@@ -194,8 +194,8 @@ class Tool(benchexec.tools.template.BaseTool2):
                 options += [f"{prefix}witness", possible_witness_files[0]]
             else:
                 raise benchexec.tools.template.UnsupportedFeatureException(
-                    f"You are passing a witness as both an option and through the task definition. "
-                    f"Please remove one of them."
+                    "You are passing a witness as both an option and through the task definition. "
+                    "Please remove one of them."
                 )
 
         return options

--- a/benchexec/tools/cpachecker.py
+++ b/benchexec/tools/cpachecker.py
@@ -188,9 +188,11 @@ class Tool(benchexec.tools.template.BaseTool2):
                         task.input_files_or_empty,
                     )
                 )
-                assert (
-                    len(possible_witness_files) == 1
-                ), f"Expected exactly one witness file, but found {len(possible_witness_files)}: {possible_witness_files}"
+                if len(possible_witness_files) != 1:
+                    raise benchexec.tools.template.UnsupportedFeatureException(
+                        f"Expected exactly one witness file, but found {len(possible_witness_files)}: {possible_witness_files}"
+                    )
+
                 options += [f"{prefix}witness", possible_witness_files[0]]
             else:
                 raise benchexec.tools.template.UnsupportedFeatureException(

--- a/benchexec/tools/cpachecker.py
+++ b/benchexec/tools/cpachecker.py
@@ -200,7 +200,7 @@ class Tool(benchexec.tools.template.BaseTool2):
         return options
 
     def __partition_input_files(self, task):
-        input_files = task.input_files_or_empty
+        input_files = task.input_files_or_identifier
         witness_files = []
         other_files = []
         for file in input_files:


### PR DESCRIPTION
The goal of this MR is to handle validation tasks following the [proposed format](https://gitlab.com/sosy-lab/benchmarking/sv-benchmarks/-/blob/witness-benchmark-set/c/loop-invariants/linear-inequality-inv-c.2.witness-validation.yml?ref_type=heads) in SV-Benchmarks. A short description of the new option is given in the [SV-Benchmarks README](https://gitlab.com/sosy-lab/benchmarking/sv-benchmarks/-/blob/witness-benchmark-set/README.md?ref_type=heads#task-definitions)

The goal is to leave the previous behavior of CPAchecker untouched i.e. it still being able to validate witnesses given explicitly through extra parameters in a benchmark definition file. If both ways to pass witnesses, through the task-definition and through the benchmark file,  are used then CPAchecker fails with an error, as should be expected.