### PR TITLE
adding tool-info for Sikraken

### DIFF
--- a/benchexec/tools/sikraken.py
+++ b/benchexec/tools/sikraken.py
@@ -4,11 +4,7 @@
 # SPDX-FileCopyrightText: 2007-2020 Dirk Beyer <https://www.sosy-lab.org>
 #
 # SPDX-License-Identifier: Apache-2.0
-"""
-This class serves as BenchExec tool adaptor for Sikraken for Test-Comp
-See baseclass documentation at https://github.com/sosy-lab/benchexec/blob/main/benchexec/tools/template.py
-"""
-import os
+
 from benchexec.tools.sv_benchmarks_util import get_data_model_from_task, ILP32, LP64
 import benchexec.tools.template
 import benchexec.result as result
@@ -29,25 +25,13 @@ class Tool(benchexec.tools.template.BaseTool2):
         return tool_locator.find_executable("sikraken.sh", subdir="bin")
 
     def version(self, executable):
-        return self._version_from_tool(executable, "-v")  
-    
-    """
-    #Assuming that the default working directory is the root of the project (i.e. sikraken/) we don't need this
-    def working_directory(self, executable):
-        executableDir = os.path.dirname(executable)
-        return executableDir
-    """
-
-    #Sikraken is currently ignoring property files as we only support "coverage-branches.prp"
-    #I am assuming more options come from the benchmark definition .xml file "The benchmark definition defines the categories that the tester is to be executed on, the parameters to be passed, and the resource limits."
-    #the rlimits for testcomp are passed as options
+        return self._version_from_tool(executable, "-v")
 
     def cmdline(self, executable, options, task, rlimits):
         data_model_param = get_data_model_from_task(task, {ILP32: "-m32", LP64: "-m64"})
         options += [data_model_param]
         return [executable] + options + [task.single_input_file]
         
-    #we are always DONE
     def determine_result(self, run):
         status = result.RESULT_DONE
         return status

--- a/benchexec/tools/sikraken.py
+++ b/benchexec/tools/sikraken.py
@@ -7,7 +7,6 @@
 
 from benchexec.tools.sv_benchmarks_util import get_data_model_from_task, ILP32, LP64
 import benchexec.tools.template
-import benchexec.result as result
 
 
 class Tool(benchexec.tools.template.BaseTool2):

--- a/benchexec/tools/sikraken.py
+++ b/benchexec/tools/sikraken.py
@@ -16,11 +16,11 @@ class Tool(benchexec.tools.template.BaseTool2):
     """
 
     def name(self):
-        return "Sikraken" 
-    
+        return "Sikraken"
+
     def project_url(self):
-        return "https://github.com/echancrure/Sikraken" 
-        
+        return "https://github.com/echancrure/Sikraken"
+
     def executable(self, tool_locator):
         return tool_locator.find_executable("sikraken.sh", subdir="bin")
 
@@ -31,7 +31,7 @@ class Tool(benchexec.tools.template.BaseTool2):
         data_model_param = get_data_model_from_task(task, {ILP32: "-m32", LP64: "-m64"})
         options += [data_model_param]
         return [executable] + options + [task.single_input_file]
-        
+
     def determine_result(self, run):
         status = result.RESULT_DONE
         return status

--- a/benchexec/tools/sikraken.py
+++ b/benchexec/tools/sikraken.py
@@ -29,9 +29,6 @@ class Tool(benchexec.tools.template.BaseTool2):
 
     def cmdline(self, executable, options, task, rlimits):
         data_model_param = get_data_model_from_task(task, {ILP32: "-m32", LP64: "-m64"})
-        options += [data_model_param]
+        if data_model_param and data_model_param not in options:
+            options += [data_model_param]
         return [executable] + options + [task.single_input_file]
-
-    def determine_result(self, run):
-        status = result.RESULT_DONE
-        return status

--- a/benchexec/tools/sikraken.py
+++ b/benchexec/tools/sikraken.py
@@ -1,0 +1,53 @@
+# This file is part of BenchExec, a framework for reliable benchmarking:
+# https://github.com/sosy-lab/benchexec
+#
+# SPDX-FileCopyrightText: 2007-2020 Dirk Beyer <https://www.sosy-lab.org>
+#
+# SPDX-License-Identifier: Apache-2.0
+"""
+This class serves as BenchExec tool adaptor for Sikraken for Test-Comp
+See baseclass documentation at https://github.com/sosy-lab/benchexec/blob/main/benchexec/tools/template.py
+"""
+import os
+from benchexec.tools.sv_benchmarks_util import get_data_model_from_task, ILP32, LP64
+import benchexec.tools.template
+import benchexec.result as result
+
+
+class Tool(benchexec.tools.template.BaseTool2):
+    """
+    BenchExec tool-info for Sikraken
+    """
+
+    def name(self):
+        return "Sikraken" 
+    
+    def project_url(self):
+        return "https://github.com/echancrure/Sikraken" 
+        
+    def executable(self, tool_locator):
+        return tool_locator.find_executable("sikraken.sh", subdir="bin")
+
+    def version(self, executable):
+        return self._version_from_tool(executable, "-v")  
+    
+    """
+    #Assuming that the default working directory is the root of the project (i.e. sikraken/) we don't need this
+    def working_directory(self, executable):
+        executableDir = os.path.dirname(executable)
+        return executableDir
+    """
+
+    #Sikraken is currently ignoring property files as we only support "coverage-branches.prp"
+    #I am assuming more options come from the benchmark definition .xml file "The benchmark definition defines the categories that the tester is to be executed on, the parameters to be passed, and the resource limits."
+    #the rlimits for testcomp are passed as options
+
+    def cmdline(self, executable, options, task, rlimits):
+        data_model_param = get_data_model_from_task(task, {ILP32: "-m32", LP64: "-m64"})
+        options += [data_model_param]
+        return [executable] + options + [task.single_input_file]
+        
+    #we are always DONE
+    def determine_result(self, run):
+        status = result.RESULT_DONE
+        return status


### PR DESCRIPTION
Adding Sikraken tool-info

I am getting warnings when testing running: python3 -m benchexec.test_tool_info --tool-directory ~/Sikraken sikraken

But I don't understand them, so I would appreciate help.

The command line for Sikraken should be:  sikraken.sh release budget[900] [-m32|-m64] $relative_path/$input_file.c

"release budget[900] " is in the benchmark definition under option: I am assuming these are read in and added to options but I am unsure
