### PR TITLE
Add toolinfo module for MetaVal++

### DIFF
--- a/benchexec/tools/metaval++.py
+++ b/benchexec/tools/metaval++.py
@@ -85,8 +85,8 @@ class Tool(BaseTool2):
         # only the first group will be returned.
         match = None
         for line in output:
-            matches = re.search(identifier, line).group()
+            matches = re.search(identifier, line)
             if matches:
-                match = matches
+                match = matches.group()
                 break
         return match

--- a/benchexec/tools/metaval++.py
+++ b/benchexec/tools/metaval++.py
@@ -22,11 +22,6 @@ class Tool(BaseTool2):
     def executable(self, tool_locator: BaseTool2.ToolLocator):
         return tool_locator.find_executable("metaval++.py")
 
-    def program_files(self, executable):
-        return [executable] + self._program_files_from_executable(
-            executable, self.REQUIRED_PATHS, parent_dir=True
-        )
-
     def version(self, executable):
         return self._version_from_tool(executable)
 

--- a/benchexec/tools/metaval++.py
+++ b/benchexec/tools/metaval++.py
@@ -17,10 +17,10 @@ class Tool(BaseTool2):
     Tool info for Deductive Validator.
     """
 
-    REQUIRED_PATHS = ["lib", "src", "metaval_2.0.py"]
+    REQUIRED_PATHS = ["lib", "src", "metaval++.py"]
 
     def executable(self, tool_locator: BaseTool2.ToolLocator):
-        return tool_locator.find_executable("metaval_2.0.py")
+        return tool_locator.find_executable("metaval++.py")
 
     def program_files(self, executable):
         return [executable] + self._program_files_from_executable(
@@ -31,10 +31,10 @@ class Tool(BaseTool2):
         return self._version_from_tool(executable)
 
     def name(self):
-        return "MetaVal 2.0"
+        return "MetaVal++"
 
     def project_url(self):
-        return "https://gitlab.com/sosy-lab/software/metaval-2.0"
+        return "https://gitlab.com/sosy-lab/software/metavalpp"
 
     def cmdline(self, executable, options, task, rlimits):
         if task.property_file:

--- a/benchexec/tools/metaval++.py
+++ b/benchexec/tools/metaval++.py
@@ -54,26 +54,31 @@ class Tool(BaseTool2):
         )
 
     def determine_result(self, run):
+        separator = ":"
         if not run.output:
             return benchexec.result.RESULT_ERROR
         lastline = run.output[-1]
         if lastline.startswith("Witness is correct"):
             return benchexec.result.RESULT_TRUE_PROP
         elif lastline.startswith("Witness could not be validated"):
-            if ":" in lastline:
+            if separator in lastline:
                 return (
                     benchexec.result.RESULT_ERROR
-                    + self.substring_after_identifier(lastline, ":").strip()
+                    + "("
+                    + self.substring_after_identifier(lastline, separator).strip()
+                    + ")"
                 )
             else:
                 return benchexec.result.RESULT_ERROR
         elif lastline.startswith(
             "There was an error validating the witness in the backend verifier"
         ):
-            if ":" in lastline:
+            if separator in lastline:
                 return (
                     benchexec.result.RESULT_ERROR
-                    + self.substring_after_identifier(lastline, ":").strip()
+                    + "("
+                    + +self.substring_after_identifier(lastline, separator).strip()
+                    + ")"
                 )
             else:
                 return benchexec.result.RESULT_ERROR

--- a/benchexec/tools/metaval++.py
+++ b/benchexec/tools/metaval++.py
@@ -57,11 +57,9 @@ class Tool(BaseTool2):
             status = benchexec.result.RESULT_TRUE_PROP
         elif lastline.startswith("Witness could not be validated"):
             if ":" in lastline:
-                status = (
-                    benchexec.result.RESULT_UNKNOWN + lastline.split(":")[1].strip()
-                )
+                status = benchexec.result.RESULT_ERROR + lastline.split(":")[1].strip()
             else:
-                status = benchexec.result.RESULT_UNKNOWN
+                status = benchexec.result.RESULT_ERROR
         elif lastline.startswith(
             "There was an error validating the witness in the backend verifier"
         ):

--- a/benchexec/tools/metaval++.py
+++ b/benchexec/tools/metaval++.py
@@ -54,24 +54,23 @@ class Tool(BaseTool2):
             return benchexec.result.RESULT_ERROR
         lastline = run.output[-1]
         if lastline.startswith("Witness is correct"):
-            status = benchexec.result.RESULT_TRUE_PROP
+            return benchexec.result.RESULT_TRUE_PROP
         elif lastline.startswith("Witness could not be validated"):
             if ":" in lastline:
-                status = benchexec.result.RESULT_ERROR + lastline.split(":")[1].strip()
+                return benchexec.result.RESULT_ERROR + lastline.split(":")[1].strip()
             else:
-                status = benchexec.result.RESULT_ERROR
+                return benchexec.result.RESULT_ERROR
         elif lastline.startswith(
             "There was an error validating the witness in the backend verifier"
         ):
             if ":" in lastline:
-                status = benchexec.result.RESULT_ERROR + lastline.split(":")[1].strip()
+                return benchexec.result.RESULT_ERROR + lastline.split(":")[1].strip()
             else:
-                status = benchexec.result.RESULT_ERROR
+                return benchexec.result.RESULT_ERROR
         elif lastline.startswith("Witness file does not exist"):
-            status = benchexec.result.RESULT_ERROR + "(no witness)"
+            return benchexec.result.RESULT_ERROR + "(no witness)"
         else:
-            status = benchexec.result.RESULT_ERROR
-        return status
+            return benchexec.result.RESULT_ERROR
 
     def get_value_from_output(self, output, identifier):
         # search for the text in output and get its value,

--- a/benchexec/tools/metaval++.py
+++ b/benchexec/tools/metaval++.py
@@ -45,7 +45,8 @@ class Tool(BaseTool2):
         return [executable] + options + list(task.single_input_file)
 
     @staticmethod
-    def substring_after_identifier(string, identifier, occurrences=1):
+    def substring_after_identifier(string, identifier):
+        occurrences = 1
         return (
             identifier.join(string.split(identifier)[occurrences:])
             if occurrences > 0

--- a/benchexec/tools/metaval++.py
+++ b/benchexec/tools/metaval++.py
@@ -45,6 +45,14 @@ class Tool(BaseTool2):
 
         return [executable] + options + list(task.single_input_file)
 
+    @staticmethod
+    def substring_after_identifier(string, identifier, occurrences=1):
+        return (
+            identifier.join(string.split(identifier)[occurrences:])
+            if occurrences > 0
+            else string
+        )
+
     def determine_result(self, run):
         if not run.output:
             return benchexec.result.RESULT_ERROR
@@ -53,14 +61,20 @@ class Tool(BaseTool2):
             return benchexec.result.RESULT_TRUE_PROP
         elif lastline.startswith("Witness could not be validated"):
             if ":" in lastline:
-                return benchexec.result.RESULT_ERROR + lastline.split(":")[1].strip()
+                return (
+                    benchexec.result.RESULT_ERROR
+                    + self.substring_after_identifier(lastline, ":").strip()
+                )
             else:
                 return benchexec.result.RESULT_ERROR
         elif lastline.startswith(
             "There was an error validating the witness in the backend verifier"
         ):
             if ":" in lastline:
-                return benchexec.result.RESULT_ERROR + lastline.split(":")[1].strip()
+                return (
+                    benchexec.result.RESULT_ERROR
+                    + self.substring_after_identifier(lastline, ":").strip()
+                )
             else:
                 return benchexec.result.RESULT_ERROR
         elif lastline.startswith("Witness file does not exist"):

--- a/benchexec/tools/metaval++.py
+++ b/benchexec/tools/metaval++.py
@@ -73,9 +73,8 @@ class Tool(BaseTool2):
     def get_value_from_output(self, output, identifier):
         # Search the text line per line using the regex passed as identifier
         # and return the first match found.
-        match = None
         for line in output:
             matches = re.search(identifier, line)
             if matches:
                 return matches.group()
-        return match
+        return None

--- a/benchexec/tools/metaval++.py
+++ b/benchexec/tools/metaval++.py
@@ -77,6 +77,5 @@ class Tool(BaseTool2):
         for line in output:
             matches = re.search(identifier, line)
             if matches:
-                match = matches.group()
-                break
+                return matches.group()
         return match

--- a/benchexec/tools/metaval++.py
+++ b/benchexec/tools/metaval++.py
@@ -44,15 +44,6 @@ class Tool(BaseTool2):
 
         return [executable] + options + list(task.single_input_file)
 
-    @staticmethod
-    def substring_after_identifier(string, identifier):
-        occurrences = 1
-        return (
-            identifier.join(string.split(identifier)[occurrences:])
-            if occurrences > 0
-            else string
-        )
-
     def determine_result(self, run):
         separator = ":"
         if not run.output:
@@ -69,7 +60,7 @@ class Tool(BaseTool2):
                 return (
                     benchexec.result.RESULT_ERROR
                     + "("
-                    + self.substring_after_identifier(lastline, separator).strip()
+                    + lastline.split(separator, maxsplit=1)[1].strip()
                     + ")"
                 )
             else:

--- a/benchexec/tools/metaval++.py
+++ b/benchexec/tools/metaval++.py
@@ -75,7 +75,7 @@ class Tool(BaseTool2):
         match = None
         for line in output:
             matches = re.findall(identifier, line)
-            if matches is not None and len(matches) > 0:
+            if matches:
                 if isinstance(matches[0], tuple):
                     logging.warning(
                         "The regex '%s' has groups, but only the first group will be returned",

--- a/benchexec/tools/metaval++.py
+++ b/benchexec/tools/metaval++.py
@@ -78,7 +78,7 @@ class Tool(BaseTool2):
     def get_value_from_output(self, output, identifier):
         # search for the text in output and get its value,
         # search the first line, that starts with the searched text
-        # warn if there are more lines (multiple statistics from sequential analysis?)
+        # warn if there are more lines with the searched text
         match = None
         for line in output:
             if line.lstrip().startswith(identifier):

--- a/benchexec/tools/metaval++.py
+++ b/benchexec/tools/metaval++.py
@@ -72,8 +72,7 @@ class Tool(BaseTool2):
 
     def get_value_from_output(self, output, identifier):
         # Search the text line per line using the regex passed as identifier
-        # and return the first match found. If the regex has groups,
-        # only the first group will be returned.
+        # and return the first match found.
         match = None
         for line in output:
             matches = re.search(identifier, line)

--- a/benchexec/tools/metaval++.py
+++ b/benchexec/tools/metaval++.py
@@ -88,15 +88,8 @@ class Tool(BaseTool2):
         # only the first group will be returned.
         match = None
         for line in output:
-            matches = re.findall(identifier, line)
+            matches = re.search(identifier, line).group()
             if matches:
-                if isinstance(matches[0], tuple):
-                    logging.warning(
-                        "The regex '%s' has groups, but only the first group will be returned",
-                        identifier,
-                    )
-                    match = matches[0][0]
-                else:
-                    match = matches[0]
+                match = matches
                 break
         return match

--- a/benchexec/tools/metaval++.py
+++ b/benchexec/tools/metaval++.py
@@ -47,7 +47,7 @@ class Tool(BaseTool2):
         if data_model_param and "--data-model" not in options:
             options += ["--data-model", data_model_param]
 
-        return [executable] + options + list(task.input_files_or_identifier)
+        return [executable] + options + list(task.single_input_file)
 
     def determine_result(self, run):
         if not run.output:

--- a/benchexec/tools/metaval++.py
+++ b/benchexec/tools/metaval++.py
@@ -78,9 +78,8 @@ class Tool(BaseTool2):
             if matches is not None and len(matches) > 0:
                 if isinstance(matches[0], tuple):
                     logging.warning(
-                        "The regex '{}' has groups, but only the first group will be returned".format(
-                            identifier
-                        )
+                        "The regex '%s' has groups, but only the first group will be returned",
+                        identifier,
                     )
                     match = matches[0][0]
                 else:

--- a/benchexec/tools/metaval++.py
+++ b/benchexec/tools/metaval++.py
@@ -70,7 +70,7 @@ class Tool(BaseTool2):
 
     def get_value_from_output(self, output, identifier):
         # Search the text line per line using the regex passed as identifier
-        # and return the first match found. If the regex has groups, 
+        # and return the first match found. If the regex has groups,
         # only the first group will be returned.
         match = None
         for line in output:

--- a/benchexec/tools/metaval++.py
+++ b/benchexec/tools/metaval++.py
@@ -5,7 +5,6 @@
 #
 # SPDX-License-Identifier: Apache-2.0
 
-import logging
 import re
 
 import benchexec.result

--- a/benchexec/tools/metaval++.py
+++ b/benchexec/tools/metaval++.py
@@ -17,7 +17,7 @@ class Tool(BaseTool2):
     Tool info for Deductive Validator.
     """
 
-    REQUIRED_PATHS = ["lib", "src", "metaval++.py"]
+    REQUIRED_PATHS = ["lib", "src"]
 
     def executable(self, tool_locator: BaseTool2.ToolLocator):
         return tool_locator.find_executable("metaval++.py")

--- a/benchexec/tools/metaval++.py
+++ b/benchexec/tools/metaval++.py
@@ -60,24 +60,16 @@ class Tool(BaseTool2):
         lastline = run.output[-1]
         if lastline.startswith("Witness is correct"):
             return benchexec.result.RESULT_TRUE_PROP
-        elif lastline.startswith("Witness could not be validated"):
-            if separator in lastline:
-                return (
-                    benchexec.result.RESULT_ERROR
-                    + "("
-                    + self.substring_after_identifier(lastline, separator).strip()
-                    + ")"
-                )
-            else:
-                return benchexec.result.RESULT_ERROR
         elif lastline.startswith(
+            "Witness could not be validated"
+        ) or lastline.startswith(
             "There was an error validating the witness in the backend verifier"
         ):
             if separator in lastline:
                 return (
                     benchexec.result.RESULT_ERROR
                     + "("
-                    + +self.substring_after_identifier(lastline, separator).strip()
+                    + self.substring_after_identifier(lastline, separator).strip()
                     + ")"
                 )
             else:

--- a/benchexec/tools/metaval_2-0.py
+++ b/benchexec/tools/metaval_2-0.py
@@ -1,0 +1,97 @@
+# This file is part of BenchExec, a framework for reliable benchmarking:
+# https://github.com/sosy-lab/benchexec
+#
+# SPDX-FileCopyrightText: 2007-2020 Dirk Beyer <https://www.sosy-lab.org>
+#
+# SPDX-License-Identifier: Apache-2.0
+
+import logging
+
+import benchexec.result
+from benchexec.tools.sv_benchmarks_util import ILP32, LP64, get_data_model_from_task
+from benchexec.tools.template import BaseTool2
+
+
+class Tool(BaseTool2):
+    """
+    Tool info for Deductive Validator.
+    """
+
+    REQUIRED_PATHS = ["lib", "src", "metaval_2.0.py"]
+
+    def executable(self, tool_locator: BaseTool2.ToolLocator):
+        return tool_locator.find_executable("metaval_2.0.py")
+
+    def program_files(self, executable):
+        return [executable] + self._program_files_from_executable(
+            executable, self.REQUIRED_PATHS, parent_dir=True
+        )
+
+    def version(self, executable):
+        return self._version_from_tool(executable)
+
+    def name(self):
+        return "MetaVal 2.0"
+
+    def project_url(self):
+        return "https://gitlab.com/sosy-lab/software/metaval-2.0"
+
+    def cmdline(self, executable, options, task, rlimits):
+        if task.property_file:
+            options = options + ["--property", task.property_file]
+
+        data_model_param = get_data_model_from_task(
+            task, {ILP32: "ILP32", LP64: "LP64"}
+        )
+
+        if data_model_param and "--data-model" not in options:
+            options += ["--data-model", data_model_param]
+
+        return [executable] + options + list(task.input_files_or_identifier)
+
+    def determine_result(self, run):
+        if not run.output:
+            return benchexec.result.RESULT_ERROR
+        lastline = run.output[-1]
+        if lastline.startswith("Witness is correct"):
+            status = benchexec.result.RESULT_TRUE_PROP
+        elif lastline.startswith("Witness could not be validated"):
+            if ":" in lastline:
+                status = (
+                    benchexec.result.RESULT_UNKNOWN + lastline.split(":")[1].strip()
+                )
+            else:
+                status = benchexec.result.RESULT_UNKNOWN
+        elif lastline.startswith(
+            "There was an error validating the witness in the backend verifier"
+        ):
+            if ":" in lastline:
+                status = benchexec.result.RESULT_ERROR + lastline.split(":")[1].strip()
+            else:
+                status = benchexec.result.RESULT_ERROR
+        elif lastline.startswith("Witness file does not exist"):
+            status = benchexec.result.RESULT_ERROR + "(no witness)"
+        else:
+            status = benchexec.result.RESULT_ERROR
+        return status
+
+    def get_value_from_output(self, output, identifier):
+        # search for the text in output and get its value,
+        # search the first line, that starts with the searched text
+        # warn if there are more lines (multiple statistics from sequential analysis?)
+        match = None
+        for line in output:
+            if line.lstrip().startswith(identifier):
+                startPosition = line.find(":") + 1
+                endPosition = line.find("(", startPosition)
+                if endPosition == -1:
+                    endPosition = len(line)
+                if match is None:
+                    match = line[startPosition:endPosition].strip()
+                else:
+                    logging.warning(
+                        "skipping repeated match for identifier '%s': '%s'",
+                        identifier,
+                        line,
+                    )
+        return match


### PR DESCRIPTION
This PR adds the toolinfo module for a new tool called MetaVal++.  It is a witness validator, which is based on the ideas of transforming a task such that a backend tool can validate the witness.

Currently it mostly supports deductive verifiers like Frama-C as backend.