### PR TITLE
Fix race condition when creating a systemd scope for cgroups v2 usage

### DIFF
--- a/benchexec/cgroupsv2.py
+++ b/benchexec/cgroupsv2.py
@@ -193,9 +193,9 @@ def _create_systemd_scope_for_us():
             with Unit(name, bus=bus) as unit:
                 # We need to register for signals before we call StartTransientUnit
                 bus.match_signal(
-                    b"org.freedesktop.systemd1",
-                    b"/org/freedesktop/systemd1",
-                    None,
+                    manager.destination,
+                    manager.path,
+                    b"org.freedesktop.systemd1.Manager",
                     b"JobRemoved",
                     process_signal,
                     None,


### PR DESCRIPTION
This race condition, which was suspected before already, was not seen in practice, so we need to fix it.
The way how to wait for starting a unit is luckily described in a man page of systemd, so we "just" need to implement that.

Fixes #1096