### PR TITLE
Fix regression of runs marked as failed on OOM for cgroupsv2

### DIFF
--- a/benchexec/containerexecutor.py
+++ b/benchexec/containerexecutor.py
@@ -975,6 +975,10 @@ class ContainerExecutor(baseexecutor.BaseExecutor):
             # - We want to move our child process (the init process of the container)
             #   into a cgroups where the limits apply because LXCFS reports the limits
             #   of the init process of the container.
+            #   This has the disadvantage that in principle the memory limit also
+            #   includes and applies to our child process, but there is no other way
+            #   to make LXCFS report the limits correctly. And at least we do not
+            #   include our child process in the measurements.
             # - On cgroupsv2 we want to move the grandchild process (the started tool)
             #   into a cgroup that becomes the root of the cgroup ns,
             #   such that no other cgroup (in particular the one with the limits)

--- a/benchexec/runexecutor.py
+++ b/benchexec/runexecutor.py
@@ -1007,8 +1007,9 @@ class RunExecutor(containerexecutor.ContainerExecutor):
                 }
         if self._termination_reason:
             result["terminationreason"] = self._termination_reason
-        elif self.cgroups.version == 2 and result.get("oom_kill_count"):
+        elif self.cgroups.version == 2 and (oom_kills := result.get("oom_kill_count")):
             # At least one process was killed by the kernel due to OOM.
+            logging.debug("Kernel killed %s processes due to OOM.", oom_kills)
             result["terminationreason"] = "memory"
         elif self.cgroups.version == 1 and (
             memlimit and result.get("memory", 0) >= memlimit


### PR DESCRIPTION
Because in 1049c395db17b5fc9ff8f2f4e45ebc71eba4ddbe we changed the cgroup hierarchy such that the memory limit (deliberately) also applies to the init process of our container, the kernel would kill our own child process together with the benchmarked process together on OOM.

This closes #1098, and adds a test that would have caught this.

Unfortunately, there is no hard guarantee that the kernel will not kill our own child process, even after this improvement (there seems to be no solution for this that allows LXCFS to be used). But it should fix this in practice (depending on how well the OOM killer chooses its targets), especially if the memory limit is not really small (larger than a few MB should suffice).