### PR TITLE
Update Ultimate tool info module

### DIFF
--- a/benchexec/tools/ultimate.py
+++ b/benchexec/tools/ultimate.py
@@ -30,6 +30,7 @@ _ULTIMATE_VERSION_REGEX = re.compile(r"^Version is (.*)$", re.MULTILINE)
 _LAUNCHER_JARS = [
     "plugins/org.eclipse.equinox.launcher_1.5.800.v20200727-1323.jar",
     "plugins/org.eclipse.equinox.launcher_1.3.100.v20150511-1540.jar",
+    "plugins/org.eclipse.equinox.launcher_1.6.800.v20240513-1750.jar",
 ]
 
 

--- a/benchexec/tools/ultimate.py
+++ b/benchexec/tools/ultimate.py
@@ -467,6 +467,8 @@ class UltimateTool(benchexec.tools.template.BaseTool2):
         return None
 
     def get_java_installations(self):
+        # The code in this method is (and should remain) consistent with the method `get_java` in
+        # <https://github.com/ultimate-pa/ultimate/blob/dev/releaseScripts/default/adds/Ultimate.py>.
         candidates = [
             "java",
             "/usr/bin/java",
@@ -475,11 +477,16 @@ class UltimateTool(benchexec.tools.template.BaseTool2):
             "/usr/lib/jvm/java-*-openjdk-amd64/bin/java",
         ]
 
-        candidates = [c for entry in candidates for c in glob.glob(entry)]
+        candidates_extended = []
+        for c in candidates:
+            if "*" in c:
+                candidates_extended += glob.glob(c)
+            else:
+                candidates_extended += [c]
         pattern = r'"(\d+\.\d+).*"'
 
         rtr = {}
-        for c in candidates:
+        for c in candidates_extended:
             candidate = shutil.which(c)
             if not candidate:
                 continue

--- a/benchexec/tools/ultimate.py
+++ b/benchexec/tools/ultimate.py
@@ -10,6 +10,7 @@ import functools
 import glob
 import logging
 import os
+from pathlib import Path
 import re
 import shlex
 import shutil
@@ -72,15 +73,13 @@ class UltimateTool(benchexec.tools.template.BaseTool2):
 
     def executable(self, tool_locator):
         exe = tool_locator.find_executable("Ultimate.py")
-        dir_name = os.path.dirname(exe)
-        logging.debug("Looking in %s for Ultimate and plugins/", dir_name)
-        for _, dir_names, file_names in os.walk(dir_name):
-            if "Ultimate" in file_names and "plugins" in dir_names:
-                return exe
-            break
+        dir_name = Path(os.path.dirname(exe))
+        logging.debug("Checking if %s contains a launcher jar", dir_name)
+        if any([(dir_name / rel_launcher).exists() for rel_launcher in _LAUNCHER_JARS]):
+            return exe
         msg = (
             f"ERROR: Did find a Ultimate.py in {os.path.dirname(exe)} "
-            f"but no 'Ultimate' or no 'plugins' directory besides it"
+            f"but no launcher .jar besides it"
         )
         raise ToolNotFoundException(msg)
 


### PR DESCRIPTION
This PR updates the tool info modules for Ultimate tools such that they are able to run the upcoming Ultimate version 0.3.0.

The second commit also fixes a bug in the detection of the Java version to be used by the tool info module (`glob.glob("java")` always returns `[]`).