### PR TITLE
Ultimate: fix output for data race violations

### DIFF
--- a/benchexec/tools/ultimate.py
+++ b/benchexec/tools/ultimate.py
@@ -363,6 +363,7 @@ class UltimateTool(benchexec.tools.template.BaseTool2):
         ltl_false_string = "execution that violates the LTL property"
         ltl_true_string = "Buchi Automizer proved that the LTL property"
         overflow_false_string = "overflow possible"
+        datarace_false_string = "DataRaceFoundResult"
 
         for line in run.output:
             if unsupported_syntax_errorstring in line:
@@ -385,6 +386,8 @@ class UltimateTool(benchexec.tools.template.BaseTool2):
                 return "FALSE(valid-ltl)"
             if ltl_true_string in line:
                 return result.RESULT_TRUE_PROP
+            if datarace_false_string in line:
+                return result.RESULT_FALSE_DATARACE
             if unsafety_string in line:
                 return result.RESULT_FALSE_REACH
             if mem_deref_false_string in line:
@@ -441,6 +444,8 @@ class UltimateTool(benchexec.tools.template.BaseTool2):
                 return result.RESULT_FALSE_TERMINATION
             elif line.startswith("FALSE(OVERFLOW)"):
                 return result.RESULT_FALSE_OVERFLOW
+            elif line.startswith("FALSE(DATA-RACE)"):
+                return result.RESULT_FALSE_DATARACE
             elif line.startswith("FALSE"):
                 return result.RESULT_FALSE_REACH
             elif line.startswith("TRUE"):


### PR DESCRIPTION
Reports `false(no-data-race)` instead of `false(unreach-call)` when a data race was found.

This should be compatible across Ultimate versions:
- old tool info module / any Ultimate version: result is `false(unreach-call)`, which is however recognized by benchexec as the correct result
- new tool info module / old Ultimate versions: result is still `false(unreach-call)`, because Ultimate prints `FALSE` instead of `FALSE(DATA-RACE)`
- new tool info module / new Ultimate versions (as of commit [e4d1a50](https://github.com/ultimate-pa/ultimate/commit/e4d1a509ae37954c7bb0aaae287e8df0e430bc40): result is now `false(no-data-race)`, as Ultimate prints `FALSE(DATA-RACE)`