### PR TITLE
Add the containerImage CLI arg to the BenchCloud Executor

### DIFF
--- a/contrib/vcloud/benchmarkclient_executor.py
+++ b/contrib/vcloud/benchmarkclient_executor.py
@@ -5,14 +5,16 @@
 #
 # SPDX-License-Identifier: Apache-2.0
 
-import sys
 import json
 import logging
 import os
 import shutil
 import subprocess
+import sys
+
 import benchexec.tooladapter
 import benchexec.util
+
 from . import vcloudutil
 
 sys.dont_write_bytecode = True  # prevent creation of .pyc files
@@ -108,8 +110,8 @@ def execute_benchmark(benchmark, output_handler):
             cmdLine.extend(["--try-less-memory", str(benchmark.config.tryLessMemory)])
         if benchmark.config.debug:
             cmdLine.extend(["--print-new-files", "true"])
-
-        start_time = benchexec.util.read_local_time()
+        if benchmark.config.containerImage:
+            cmdLine.extend(["--containerImage", str(benchmark.config.containerImage)])
 
         cloud = subprocess.Popen(
             cmdLine,

--- a/contrib/vcloud/vcloudbenchmarkbase.py
+++ b/contrib/vcloud/vcloudbenchmarkbase.py
@@ -97,6 +97,14 @@ class VcloudBenchmarkBase(benchexec.benchexec.BenchExec):
             action="store_true",
             help="Prevents ivy from caching the downloaded jar files. This prevents clashes due to concurrent access to the cache.",
         )
+        vcloud_args.add_argument(
+            self.get_param_name("cloudContainerImage"),
+            dest="containerImage",
+            metavar="IMAGE",
+            action="store",
+            type=str,
+            help="Use the specified container image for the execution of the benchmark.",
+        )
 
     def get_param_name(self, pname):
         return "--v" + pname


### PR DESCRIPTION
This adds the new CLI argument discussed [here](https://gitlab.com/sosy-lab/software/benchcloud/-/merge_requests/148) to the vcloud-benchmark utility.