### PR TITLE
Adding (sub)property to violations

### DIFF
--- a/benchexec/tools/theta.py
+++ b/benchexec/tools/theta.py
@@ -55,7 +55,7 @@ class Tool(benchexec.tools.template.BaseTool2):
                 status = result.RESULT_TRUE_PROP
             elif "ParsingResult Success" in line:
                 parsing_status = "after"
-            elif "Property" in line and property:
+            elif "Property" in line and not property:
                 match = re.search("\(Property ([a-z-]*)\)")
                 if match:
                     property = match.group(1)

--- a/benchexec/tools/theta.py
+++ b/benchexec/tools/theta.py
@@ -53,10 +53,12 @@ class Tool(benchexec.tools.template.BaseTool2):
                 status = result.RESULT_FALSE_REACH
             elif "SafetyResult Safe" in line:
                 status = result.RESULT_TRUE_PROP
+            elif "SafetyResult Unknown" in line:
+                status = result.RESULT_UNKNOWN
             elif "ParsingResult Success" in line:
                 parsing_status = "after"
             elif "Property" in line and not property:
-                match = re.search("\(Property ([a-z-]*)\)")
+                match = re.search("\(Property ([a-z-]*)\)", line)
                 if match:
                     property = match.group(1)
 


### PR DESCRIPTION
This change adds subproperties for violation results, parsed from the output of Theta. We expect `(Property <property>)` to exist in the output for this. As older versions do not support this change, we keep the `false(unreach-call)` for outputs not containing the matching string.

We also added a way to annul results by printing `SafetyResult Unknown` after the original (which is useful for using bounded or otherwise incomplete methods and only accepting certain outcomes). We deliberately want to overwrite the `status` flag by later values.