### PR TITLE
Hornix: Get only version number, without the name of the tool

### DIFF
--- a/benchexec/tools/hornix.py
+++ b/benchexec/tools/hornix.py
@@ -6,6 +6,8 @@
 #
 # SPDX-License-Identifier: Apache-2.0
 
+import re
+
 import benchexec
 import benchexec.result as result
 
@@ -21,7 +23,10 @@ class Tool(benchexec.tools.template.BaseTool2):
         return tool_locator.find_executable("hornix")
 
     def version(self, executable):
-        return self._version_from_tool(executable, arg="--version")
+        output = self._version_from_tool(executable, arg="--version")
+        version_pattern = r"\d+\.\d+\.\d+"
+        match = re.search(version_pattern, output)
+        return match.group(0) if match else ""
 
     def name(self):
         """The human-readable name of the tool."""


### PR DESCRIPTION
This seems to be the requirement of fm-tools.
The pipeline check in https://gitlab.com/sosy-lab/benchmarking/fm-tools/-/merge_requests/478 fails because the output from version query contains the name of the tool.