### PR TITLE
WitnessMap always returns the version directl

### DIFF
--- a/benchexec/tools/witnessmap.py
+++ b/benchexec/tools/witnessmap.py
@@ -30,7 +30,7 @@ class Tool(benchexec.tools.template.BaseTool2):
 
     def version(self, executable):
         version_string = self._version_from_tool(executable)
-        return version_string.partition("version")[2].strip().split(" ")[0]
+        return version_string
 
     def cmdline(self, executable, options, task, rlimits):
         # The input files are irrelevant, since the goal of WitnessMap


### PR DESCRIPTION
The previous implementation was a bug, since WitnessMap does produces `0.0.1-dev` for the following:

```
./witness_map.py --version
```