### PR TITLE
The wrong variable was passed to filter the options

### DIFF
--- a/benchexec/tools/cpachecker.py
+++ b/benchexec/tools/cpachecker.py
@@ -183,7 +183,7 @@ class Tool(benchexec.tools.template.BaseTool2):
                         f"Unsupported data_model '{data_model}' defined for task '{task}'"
                     )
 
-        options += get_witness_options(options, task, [f"{prefix}witness"])
+        options += get_witness_options(existing_options, task, [f"{prefix}witness"])
 
         return options
 


### PR DESCRIPTION
We want to filter out the witness options using the existing options and not the new options we are building

This only has an effect when the witness option is given and a validation task is used

