### PR TITLE
Enable Deagle to output various FALSE types

### DIFF
--- a/benchexec/tools/deagle.py
+++ b/benchexec/tools/deagle.py
@@ -60,6 +60,15 @@ class Tool(benchexec.tools.template.BaseTool2):
             status = result.RESULT_TRUE_PROP
         elif run.output.any_line_contains("FAILED"):
             status = result.RESULT_FALSE_REACH
+            for line in run.output:
+                if "nodatarace.assertion." in line and "FAILURE" in line:
+                    status = result.RESULT_FALSE_DATARACE
+                if ("alloc.assertion." in line or "pointer_dereference." in line) and "FAILURE" in line:
+                    status = result.RESULT_FALSE_DEREF
+                if "memory-leak." in line and "FAILURE" in line:
+                    status = result.RESULT_FALSE_MEMTRACK
+                if "overflow." in line and "FAILURE" in line:
+                    status = result.RESULT_FALSE_OVERFLOW
         elif run.exit_code.value == 1:
             status = result.RESULT_UNKNOWN
         else:

--- a/benchexec/tools/deagle.py
+++ b/benchexec/tools/deagle.py
@@ -63,7 +63,9 @@ class Tool(benchexec.tools.template.BaseTool2):
             for line in run.output:
                 if "nodatarace.assertion." in line and "FAILURE" in line:
                     status = result.RESULT_FALSE_DATARACE
-                if ("alloc.assertion." in line or "pointer_dereference." in line) and "FAILURE" in line:
+                if (
+                    "alloc.assertion." in line or "pointer_dereference." in line
+                ) and "FAILURE" in line:
                     status = result.RESULT_FALSE_DEREF
                 if "memory-leak." in line and "FAILURE" in line:
                     status = result.RESULT_FALSE_MEMTRACK


### PR DESCRIPTION
We eventually realize that Deagle's tool-info module only reports false(unreach-call) even though Deagle also detects data races and more bugs!

This pull request fixes this.