### PR TITLE
Update concurrentwitness2test.py

### DIFF
--- a/benchexec/tools/concurrentwitness2test.py
+++ b/benchexec/tools/concurrentwitness2test.py
@@ -40,7 +40,7 @@ class Tool(benchexec.tools.template.BaseTool2):
             if "Verdict: SOMETIMES" in line or "Verdict: ALWAYS" in line:
                 return result.RESULT_FALSE_REACH
             elif "Verdict: NEVER" in line:
-                return result.RESULT_TRUE_PROP
+                return result.RESULT_ERROR + "(ineffective  witness)"
             elif "Verdict: TIMEOUT" in line:
                 return result.RESULT_TIMEOUT + "(inner)"
             elif "Verdict: Unknown error" in line:

--- a/benchexec/tools/concurrentwitness2test.py
+++ b/benchexec/tools/concurrentwitness2test.py
@@ -40,7 +40,7 @@ class Tool(benchexec.tools.template.BaseTool2):
             if "Verdict: SOMETIMES" in line or "Verdict: ALWAYS" in line:
                 return result.RESULT_FALSE_REACH
             elif "Verdict: NEVER" in line:
-                return result.RESULT_ERROR + "(ineffective  witness)"
+                return result.RESULT_ERROR + "(ineffective witness)"
             elif "Verdict: TIMEOUT" in line:
                 return result.RESULT_TIMEOUT + "(inner)"
             elif "Verdict: Unknown error" in line:


### PR DESCRIPTION
Previously, tests that did not produce the desired reach_error() call were classified as 'true'. This corrects this to be error (with "ineffective witness" as the specific error)