### PR TITLE
Adjust how the command line is build, the function

### DIFF
--- a/benchexec/tools/metaval++.py
+++ b/benchexec/tools/metaval++.py
@@ -52,7 +52,7 @@ class Tool(BaseTool2):
             task, options, "--witness", TaskFilesConsidered.SINGLE_INPUT_FILE
         )
 
-        return [executable] + options + witness_options + [input_file]
+        return [executable] + options + witness_options + input_file
 
     def determine_result(self, run):
         separator = ":"


### PR DESCRIPTION
handle_witness_of_task always returns a list of input_files