### PR TITLE
Add feature to use podman container when determining version for vcloud-benchmark

### DIFF
--- a/benchexec/containerized_tool.py
+++ b/benchexec/containerized_tool.py
@@ -299,8 +299,8 @@ def _call_tool_func(name, args, kwargs):
 
 
 class ContainerizedTool(ContainerizedToolBase):
-    def __init__(self, tool_module, config, initializer):
-        super().__init__(tool_module, config, initializer, initializer=_init_container)
+    def __init__(self, tool_module, config):
+        super().__init__(tool_module, config, initializer=_init_container)
 
     def _cleanup(self):
         pass

--- a/benchexec/containerized_tool.py
+++ b/benchexec/containerized_tool.py
@@ -62,7 +62,7 @@ class ContainerizedToolBase(object, metaclass=ABCMeta):
         try:
             self.__doc__, self.container_id = self._pool.apply(
                 _init_container_and_load_tool,
-                [initializer] + self.mk_args(tool_module, config, temp_dir),
+                [initializer] + self.mk_args(tool_module, temp_dir),
                 self.mk_kwargs(container_options),
             )
         except BaseException as e:
@@ -74,8 +74,8 @@ class ContainerizedToolBase(object, metaclass=ABCMeta):
             with contextlib.suppress(OSError):
                 os.rmdir(temp_dir)
 
-    def mk_args(self, tool_module, config, tmp_dir):
-        return [tool_module, config, tmp_dir]
+    def mk_args(self, tool_module, tmp_dir):
+        return [tool_module, tmp_dir]
 
     def mk_kwargs(self, container_options):
         return container_options

--- a/benchexec/containerized_tool.py
+++ b/benchexec/containerized_tool.py
@@ -16,7 +16,6 @@ import os
 import signal
 import socket
 import tempfile
-from abc import ABCMeta
 
 from benchexec import (
     BenchExecException,
@@ -31,7 +30,7 @@ tool: tooladapter.CURRENT_BASETOOL = None
 
 
 @tooladapter.CURRENT_BASETOOL.register  # mark as instance of CURRENT_BASETOOL
-class ContainerizedToolBase(object, metaclass=ABCMeta):
+class ContainerizedTool(object):
     """Wrapper for an instance of any subclass of one of the base-tool classes in
     benchexec.tools.template.
     The module and the subclass instance will be loaded in a subprocess that has been
@@ -45,7 +44,7 @@ class ContainerizedToolBase(object, metaclass=ABCMeta):
     But the use of containers in BenchExec is for safety and robustness, not security.
     """
 
-    def __init__(self, tool_module, config, initializer):
+    def __init__(self, tool_module, config):
         """Load tool-info module in subprocess.
         @param tool_module: The name of the module to load.
             Needs to define class named Tool.
@@ -55,16 +54,13 @@ class ContainerizedToolBase(object, metaclass=ABCMeta):
         # We use multiprocessing.Pool as an easy way for RPC with another process.
         self._pool = multiprocessing.Pool(1, _init_worker_process)
 
-        container_options = containerexecutor.handle_basic_container_args(config)
-        temp_dir = tempfile.mkdtemp(prefix="Benchexec_tool_info_container_")
-        self.container_id = None
+        self.container_options = containerexecutor.handle_basic_container_args(config)
+        self.temp_dir = tempfile.mkdtemp(prefix="Benchexec_tool_info_container_")
+
         # Call function that loads tool module and returns its doc
         try:
-            self.__doc__, self.container_id = self._pool.apply(
-                _init_container_and_load_tool,
-                [initializer] + self.mk_args(tool_module, temp_dir),
-                self.mk_kwargs(container_options),
-            )
+            self._setup_container(tool_module)
+
         except BaseException as e:
             self._pool.terminate()
             raise e
@@ -72,17 +68,17 @@ class ContainerizedToolBase(object, metaclass=ABCMeta):
             # Outside the container, the temp_dir is just an empty directory, because
             # the tmpfs mount is only visible inside. We can remove it immediately.
             with contextlib.suppress(OSError):
-                os.rmdir(temp_dir)
+                os.rmdir(self.temp_dir)
 
-    def mk_args(self, tool_module, tmp_dir):
-        return [tool_module, tmp_dir]
-
-    def mk_kwargs(self, container_options):
-        return container_options
+    def _setup_container(self, tool_module):
+        self.__doc__, _ = self._pool.apply(
+            _init_container_and_load_tool,
+            [_init_container, tool_module, self.temp_dir],
+            self.container_options,
+        )
 
     def close(self):
         self._forward_call("close", [], {})
-        self._cleanup()
         self._pool.close()
 
     def _forward_call(self, method_name, args, kwargs):
@@ -116,7 +112,7 @@ for member_name, member in inspect.getmembers(
 ):
     if member_name[0] == "_" or member_name == "close":
         continue
-    ContainerizedToolBase._add_proxy_function(member_name, member)
+    ContainerizedTool._add_proxy_function(member_name, member)
 
 
 def _init_worker_process():
@@ -134,14 +130,13 @@ def _init_worker_process():
 
 def _init_container_and_load_tool(initializer, tool_module, *args, **kwargs):
     """Initialize container for the current process and load given tool-info module."""
-    container_id = None
     try:
-        container_id = initializer(*args, **kwargs)
+        initializer_ret = initializer(*args, **kwargs)
     except OSError as e:
         if container.check_apparmor_userns_restriction(e):
             raise BenchExecException(container._ERROR_MSG_USER_NS_RESTRICTION)
         raise BenchExecException(f"Failed to configure container: {e}")
-    return _load_tool(tool_module), container_id
+    return _load_tool(tool_module), initializer_ret
 
 
 def _init_container(
@@ -296,11 +291,3 @@ def _call_tool_func(name, args, kwargs):
     except SystemExit as e:
         # SystemExit would terminate the worker process instead of being propagated.
         raise BenchExecException(str(e.code))
-
-
-class ContainerizedTool(ContainerizedToolBase):
-    def __init__(self, tool_module, config):
-        super().__init__(tool_module, config, initializer=_init_container)
-
-    def _cleanup(self):
-        pass

--- a/benchexec/libc.py
+++ b/benchexec/libc.py
@@ -70,6 +70,10 @@ unshare = _libc.unshare
 unshare.argtypes = [c_int]
 unshare.errcheck = _check_errno
 
+setns = _libc.setns
+"""Set the current process namespace(s)."""
+setns.argtypes = [c_int, c_int]
+setns.errcheck = _check_errno
 
 mmap = _libc.mmap
 """Map file into memory."""

--- a/contrib/vcloud-benchmark.py
+++ b/contrib/vcloud-benchmark.py
@@ -23,7 +23,7 @@ from vcloud.vcloudbenchmarkbase import VcloudBenchmarkBase  # noqa E402
 import benchexec.benchexec  # noqa E402
 import benchexec.model  # noqa E402
 import benchexec.tools  # noqa E402
-from benchexec import __version__  # noqa E402
+from benchexec import BenchExecException, __version__  # noqa E402
 
 _ROOT_DIR = os.path.abspath(os.path.join(os.path.dirname(__file__), "vcloud"))
 IVY_JAR_NAME = "ivy-2.5.0.jar"
@@ -84,6 +84,13 @@ def hook_load_tool_info(tool_name, config):
     """
     if not config.containerImage:
         return original_load_tool_info(tool_name, config)
+
+    if not config.tool_directory:
+        raise BenchExecException(
+            "Using a container image is currently only supported "
+            "if the tool directory is explicitly provided. Please set it "
+            "using the --tool-directory option."
+        )
 
     tool_module = tool_name if "." in tool_name else f"benchexec.tools.{tool_name}"
 

--- a/contrib/vcloud-benchmark.py
+++ b/contrib/vcloud-benchmark.py
@@ -82,16 +82,15 @@ def hook_load_tool_info(tool_name, config):
     Either a full Python package name or a name within the benchexec.tools package.
     @return: A tuple of the full name of the used tool-info module and an instance of the tool-info class.
     """
-    tool_module = tool_name if "." in tool_name else f"benchexec.tools.{tool_name}"
-    try:
-        if config.containerImage:
-            import vcloud.podman_containerized_tool as pod
+    if not config.containerImage:
+        return real_load_tool_info(tool_name, config)
 
-            tool = pod.PodmanContainerizedTool(
-                tool_module, config, config.containerImage
-            )
-        else:
-            _, tool = real_load_tool_info(tool_module, config)
+    tool_module = tool_name if "." in tool_name else f"benchexec.tools.{tool_name}"
+
+    try:
+        import vcloud.podman_containerized_tool as pod
+
+        tool = pod.PodmanContainerizedTool(tool_module, config, config.containerImage)
 
     except ImportError as ie:
         logging.debug(

--- a/contrib/vcloud-benchmark.py
+++ b/contrib/vcloud-benchmark.py
@@ -21,6 +21,7 @@ from vcloud import vcloudutil  # noqa E402
 from vcloud.vcloudbenchmarkbase import VcloudBenchmarkBase  # noqa E402
 
 import benchexec.benchexec  # noqa E402
+import benchexec.model  # noqa E402
 import benchexec.tools  # noqa E402
 from benchexec import __version__  # noqa E402
 
@@ -28,6 +29,8 @@ _ROOT_DIR = os.path.abspath(os.path.join(os.path.dirname(__file__), "vcloud"))
 IVY_JAR_NAME = "ivy-2.5.0.jar"
 IVY_PATH = os.path.join(_ROOT_DIR, "lib", IVY_JAR_NAME)
 IVY_DOWNLOAD_URL = "https://www.sosy-lab.org/ivy/org.apache.ivy/ivy/" + IVY_JAR_NAME
+
+real_load_tool_info = benchexec.model.load_tool_info
 
 
 def download_required_jars(config):
@@ -70,6 +73,44 @@ def download_required_jars(config):
     finally:
         if temp_dir:
             temp_dir.cleanup()
+
+
+def hook_load_tool_info(tool_name, config):
+    """
+    Load the tool-info class.
+    @param tool_name: The name of the tool-info module.
+    Either a full Python package name or a name within the benchexec.tools package.
+    @return: A tuple of the full name of the used tool-info module and an instance of the tool-info class.
+    """
+    tool_module = tool_name if "." in tool_name else f"benchexec.tools.{tool_name}"
+    try:
+        if config.containerImage:
+            import vcloud.podman_containerized_tool as pod
+
+            tool = pod.PodmanContainerizedTool(
+                tool_module, config, config.containerImage
+            )
+        else:
+            _, tool = real_load_tool_info(tool_module, config)
+
+    except ImportError as ie:
+        logging.debug(
+            "Did not find module '%s'. "
+            "Python probably looked for it in one of the following paths:\n  %s",
+            tool_module,
+            "\n  ".join(path or "." for path in sys.path),
+        )
+        sys.exit(f'Unsupported tool "{tool_name}" specified. ImportError: {ie}')
+    except AttributeError as ae:
+        sys.exit(
+            f'Unsupported tool "{tool_name}" specified, class "Tool" is missing: {ae}'
+        )
+    except TypeError as te:
+        sys.exit(f'Unsupported tool "{tool_name}" specified. TypeError: {te}')
+    return tool_module, tool
+
+
+benchexec.model.load_tool_info = hook_load_tool_info
 
 
 class VcloudBenchmark(VcloudBenchmarkBase):

--- a/contrib/vcloud-benchmark.py
+++ b/contrib/vcloud-benchmark.py
@@ -30,7 +30,7 @@ IVY_JAR_NAME = "ivy-2.5.0.jar"
 IVY_PATH = os.path.join(_ROOT_DIR, "lib", IVY_JAR_NAME)
 IVY_DOWNLOAD_URL = "https://www.sosy-lab.org/ivy/org.apache.ivy/ivy/" + IVY_JAR_NAME
 
-real_load_tool_info = benchexec.model.load_tool_info
+original_load_tool_info = benchexec.model.load_tool_info
 
 
 def download_required_jars(config):
@@ -83,7 +83,7 @@ def hook_load_tool_info(tool_name, config):
     @return: A tuple of the full name of the used tool-info module and an instance of the tool-info class.
     """
     if not config.containerImage:
-        return real_load_tool_info(tool_name, config)
+        return original_load_tool_info(tool_name, config)
 
     tool_module = tool_name if "." in tool_name else f"benchexec.tools.{tool_name}"
 

--- a/contrib/vcloud-benchmark.py
+++ b/contrib/vcloud-benchmark.py
@@ -9,19 +9,20 @@
 
 import logging
 import os
+import subprocess
 import sys
 import tempfile
 import urllib.request
-import subprocess
 
 sys.dont_write_bytecode = True  # prevent creation of .pyc files
 sys.path.insert(0, os.path.join(os.path.dirname(__file__), ".."))
 
-from vcloud.vcloudbenchmarkbase import VcloudBenchmarkBase  # noqa E402
 from vcloud import vcloudutil  # noqa E402
-from benchexec import __version__  # noqa E402
+from vcloud.vcloudbenchmarkbase import VcloudBenchmarkBase  # noqa E402
+
 import benchexec.benchexec  # noqa E402
 import benchexec.tools  # noqa E402
+from benchexec import __version__  # noqa E402
 
 _ROOT_DIR = os.path.abspath(os.path.join(os.path.dirname(__file__), "vcloud"))
 IVY_JAR_NAME = "ivy-2.5.0.jar"

--- a/contrib/vcloud/benchmarkclient_executor.py
+++ b/contrib/vcloud/benchmarkclient_executor.py
@@ -15,6 +15,7 @@ from pathlib import Path
 
 import benchexec.tooladapter
 import benchexec.util
+from benchexec.tools.template import ToolNotFoundException
 
 from . import vcloudutil
 
@@ -36,121 +37,65 @@ def set_vcloud_jar_path(p):
     vcloud_jar = p
 
 
-def find_tool_base_dir(tool_locator, executable):
-    dirs = []
-    if tool_locator.tool_directory:
-        # join automatically handles the case where subdir is the empty string
-        dirs.append(tool_locator.tool_directory)
-    if tool_locator.use_path:
-        dirs.extend(benchexec.util.get_path())
-    if tool_locator.use_current:
-        dirs.append(os.curdir)
+class CustomToolLocator:
+    def __init__(self, tool_directory=None, container_mount_point=None):
+        self.tool_directory = tool_directory
+        self.container_mount_point = container_mount_point
 
-    executable_path = Path(executable).resolve()
-    print(f"executable_path: {executable_path}")
-    for candidate_dir in dirs:
-        print(f"candidate_dir: {candidate_dir}")
-        abs_candidate_dir = Path(candidate_dir).resolve()
-        if executable_path.is_relative_to(abs_candidate_dir):
-            return abs_candidate_dir
+    def find_executable(self, executable_name, subdir=""):
+        logging.debug(
+            "Using custom tool locator to find executable %s", executable_name
+        )
+        assert (
+            os.path.basename(executable_name) == executable_name
+        ), "Executable needs to be a simple file name"
+        dirs = []
 
-    return None
-
-
-class ContainerizedVersionGetter:
-    def __init__(self, tool_base_dir, image, fall_back):
-        self.tool_base_dir: Path = Path(tool_base_dir)
-        self.image = image
-        self.fall_back = fall_back
-
-    def __call__(
-        self,
-        executable,
-        arg="--version",
-        use_stderr=False,
-        ignore_stderr=False,
-        line_prefix=None,
-    ):
-        """
-        This function is a replacement for the get_version_from_tool. It wraps the call to the tool
-        in a container.
-        """
-        if shutil.which("podman") is None:
-            logging.warning(
-                "Podman is not available on the system.\n Determining version will fall back to the default way."
-            )
-            return self.fall_back(
-                executable, arg, use_stderr, ignore_stderr, line_prefix
+        if not self.tool_directory:
+            raise ToolNotFoundException(
+                "Podman containerized tool info module execution is only possible with --tool-directory explicitly set."
             )
 
-        command = [
-            "podman",
-            "run",
-            "--rm",
-            "--entrypoint",
-            '[""]',
-            "--volume",
-            f"{self.tool_base_dir}:{self.tool_base_dir}",
-            "--workdir",
-            str(self.tool_base_dir),
-            self.image,
-            Path(executable).resolve().relative_to(self.tool_base_dir),
-            arg,
-        ]
-        logging.info("Using container with podman to determine version.")
-        logging.debug("Running command: %s", " ".join(map(str, command)))
-        try:
-            process = subprocess.run(
-                command,
-                stdout=subprocess.PIPE,
-                stderr=subprocess.PIPE,
-                stdin=subprocess.DEVNULL,
-                universal_newlines=True,
-            )
-        except OSError as e:
-            logging.warning(
-                "Cannot run %s to determine version: %s", executable, e.strerror
-            )
-            return ""
-        if process.stderr and not use_stderr and not ignore_stderr:
-            logging.warning(
-                "Cannot determine %s version, error output: %s",
-                executable,
-                process.stderr,
-            )
-            return ""
-        if process.returncode:
-            logging.warning(
-                "Cannot determine %s version, exit code %s",
-                executable,
-                process.returncode,
-            )
-            return ""
+        assert self.container_mount_point is not None, "Container mount point not set"
 
-        output = (process.stderr if use_stderr else process.stdout).strip()
-        if line_prefix:
-            matches = (
-                line[len(line_prefix) :].strip()
-                for line in output.splitlines()
-                if line.startswith(line_prefix)
+        dirs.append(os.path.join(self.container_mount_point, subdir))
+        logging.debug("Searching for executable %s in %s", executable_name, dirs)
+
+        executable = benchexec.util.find_executable2(executable_name, dirs)
+        if executable:
+            return os.path.relpath(executable, self.tool_directory)
+
+        other_file = benchexec.util.find_executable2(executable_name, dirs, os.F_OK)
+        if other_file:
+            raise ToolNotFoundException(
+                f"Could not find executable '{executable_name}', "
+                f"but found file '{other_file}' that is not executable."
             )
-            output = next(matches, "")
-        return output
+
+        msg = (
+            f"Could not find executable '{executable_name}'. "
+            f"The searched directories were: " + "".join("\n  " + d for d in dirs)
+        )
+        if not self.tool_directory:
+            msg += "\nYou can specify the tool's directory with --tool-directory."
+
+        raise ToolNotFoundException(msg)
 
 
 def init(config, benchmark):
     global _JustReprocessResults
     _JustReprocessResults = config.reprocessResults
-    tool_locator = benchexec.tooladapter.create_tool_locator(config)
-    benchmark.executable = benchmark.tool.executable(tool_locator)
+
     if config.containerImage:
-        tool_base_dir = find_tool_base_dir(tool_locator, benchmark.executable)
-        if tool_base_dir is not None:
-            benchmark.tool._version_from_tool = ContainerizedVersionGetter(
-                tool_base_dir,
-                config.containerImage,
-                fall_back=benchmark.tool._version_from_tool,
-            )
+        from vcloud.podman_containerized_tool import TOOL_DIRECTORY_MOUNT_POINT
+
+        tool_locator = CustomToolLocator(
+            config.tool_directory, TOOL_DIRECTORY_MOUNT_POINT
+        )
+    else:
+        tool_locator = benchexec.tooladapter.create_tool_locator(config)
+
+    benchmark.executable = benchmark.tool.executable(tool_locator)
 
     benchmark.tool_version = benchmark.tool.version(benchmark.executable)
     environment = benchmark.environment()

--- a/contrib/vcloud/benchmarkclient_executor.py
+++ b/contrib/vcloud/benchmarkclient_executor.py
@@ -114,7 +114,7 @@ def init(config, benchmark):
     else:
         tool_locator = benchexec.tooladapter.create_tool_locator(config)
         benchmark.executable = benchmark.tool.executable(tool_locator)
-        benchmark.tool_version = benchmark.tool.version(executable_for_version)
+        benchmark.tool_version = benchmark.tool.version(benchmark.executable)
 
     environment = benchmark.environment()
     if environment.get("keepEnv", None) or environment.get("additionalEnv", None):

--- a/contrib/vcloud/benchmarkclient_executor.py
+++ b/contrib/vcloud/benchmarkclient_executor.py
@@ -107,7 +107,7 @@ def init(config, benchmark):
 
         # The vcloud uses the tool location later to determine which files need to be uploaded
         # So this needs to point to the actual path where the executable is on the host
-        benchmark.executable = (
+        benchmark.executable = str(
             Path(config.tool_directory) / executable_relative_to_mount_point
         )
 

--- a/contrib/vcloud/benchmarkclient_executor.py
+++ b/contrib/vcloud/benchmarkclient_executor.py
@@ -94,11 +94,13 @@ def init(config, benchmark):
         tool_locator = CustomToolLocator(
             config.tool_directory, TOOL_DIRECTORY_MOUNT_POINT
         )
-    else:
-        tool_locator = benchexec.tooladapter.create_tool_locator(config)
+        executable_for_version = benchmark.tool.executable(tool_locator)
+        benchmark.tool_version = benchmark.tool.version(executable_for_version)
 
+    # The vcloud uses the tool location later to determine which files need to be uploaded
+    tool_locator = benchexec.tooladapter.create_tool_locator(config)
     benchmark.executable = benchmark.tool.executable(tool_locator)
-    benchmark.tool_version = benchmark.tool.version(benchmark.executable)
+
     environment = benchmark.environment()
     if environment.get("keepEnv", None) or environment.get("additionalEnv", None):
         sys.exit(

--- a/contrib/vcloud/benchmarkclient_executor.py
+++ b/contrib/vcloud/benchmarkclient_executor.py
@@ -58,12 +58,14 @@ class CustomToolLocator:
 
         assert self.container_mount_point is not None, "Container mount point not set"
 
+        # At this point we know, that the tool is located at container_mount_point
+        # as the container as the tool_dir mounted to this location
         dirs.append(os.path.join(self.container_mount_point, subdir))
         logging.debug("Searching for executable %s in %s", executable_name, dirs)
 
         executable = benchexec.util.find_executable2(executable_name, dirs)
         if executable:
-            return os.path.relpath(executable, self.tool_directory)
+            return executable
 
         other_file = benchexec.util.find_executable2(executable_name, dirs, os.F_OK)
         if other_file:

--- a/contrib/vcloud/benchmarkclient_executor.py
+++ b/contrib/vcloud/benchmarkclient_executor.py
@@ -38,8 +38,7 @@ def set_vcloud_jar_path(p):
 
 
 class CustomToolLocator:
-    def __init__(self, tool_directory=None, container_mount_point=None):
-        self.tool_directory = tool_directory
+    def __init__(self, container_mount_point=None):
         self.container_mount_point = container_mount_point
 
     def find_executable(self, executable_name, subdir=""):
@@ -50,11 +49,6 @@ class CustomToolLocator:
             os.path.basename(executable_name) == executable_name
         ), "Executable needs to be a simple file name"
         dirs = []
-
-        if not self.tool_directory:
-            raise ToolNotFoundException(
-                "Podman containerized tool info module execution is only possible with --tool-directory explicitly set."
-            )
 
         assert self.container_mount_point is not None, "Container mount point not set"
 
@@ -78,8 +72,6 @@ class CustomToolLocator:
             f"Could not find executable '{executable_name}'. "
             f"The searched directories were: " + "".join("\n  " + d for d in dirs)
         )
-        if not self.tool_directory:
-            msg += "\nYou can specify the tool's directory with --tool-directory."
 
         raise ToolNotFoundException(msg)
 
@@ -91,9 +83,7 @@ def init(config, benchmark):
     if config.containerImage:
         from vcloud.podman_containerized_tool import TOOL_DIRECTORY_MOUNT_POINT
 
-        tool_locator = CustomToolLocator(
-            config.tool_directory, TOOL_DIRECTORY_MOUNT_POINT
-        )
+        tool_locator = CustomToolLocator(TOOL_DIRECTORY_MOUNT_POINT)
         executable_for_version = benchmark.tool.executable(tool_locator)
         benchmark.tool_version = benchmark.tool.version(executable_for_version)
 

--- a/contrib/vcloud/benchmarkclient_executor.py
+++ b/contrib/vcloud/benchmarkclient_executor.py
@@ -54,6 +54,8 @@ def find_tool_base_dir(tool_locator, executable):
         if executable_path.is_relative_to(abs_candidate_dir):
             return abs_candidate_dir
 
+    return None
+
 
 class ContainerizedVersionGetter:
     def __init__(self, tool_base_dir, image, fall_back):
@@ -143,12 +145,12 @@ def init(config, benchmark):
     benchmark.executable = benchmark.tool.executable(tool_locator)
     if config.containerImage:
         tool_base_dir = find_tool_base_dir(tool_locator, benchmark.executable)
-        print(f"tool_base_dir: {tool_base_dir}")
-        benchmark.tool._version_from_tool = ContainerizedVersionGetter(
-            tool_base_dir,
-            config.containerImage,
-            fall_back=benchmark.tool._version_from_tool,
-        )
+        if tool_base_dir is not None:
+            benchmark.tool._version_from_tool = ContainerizedVersionGetter(
+                tool_base_dir,
+                config.containerImage,
+                fall_back=benchmark.tool._version_from_tool,
+            )
 
     benchmark.tool_version = benchmark.tool.version(benchmark.executable)
     environment = benchmark.environment()

--- a/contrib/vcloud/benchmarkclient_executor.py
+++ b/contrib/vcloud/benchmarkclient_executor.py
@@ -96,7 +96,6 @@ def init(config, benchmark):
         tool_locator = benchexec.tooladapter.create_tool_locator(config)
 
     benchmark.executable = benchmark.tool.executable(tool_locator)
-
     benchmark.tool_version = benchmark.tool.version(benchmark.executable)
     environment = benchmark.environment()
     if environment.get("keepEnv", None) or environment.get("additionalEnv", None):

--- a/contrib/vcloud/podman_containerized_tool.py
+++ b/contrib/vcloud/podman_containerized_tool.py
@@ -1,0 +1,297 @@
+# This file is part of BenchExec, a framework for reliable benchmarking:
+# https://github.com/sosy-lab/benchexec
+#
+# SPDX-FileCopyrightText: 2007-2020 Dirk Beyer <https://www.sosy-lab.org>
+#
+# SPDX-License-Identifier: Apache-2.0
+
+import errno
+import functools
+import inspect
+import logging
+import multiprocessing
+import os
+import signal
+import subprocess
+import sys
+
+from benchexec import (
+    BenchExecException,
+    container,
+    libc,
+    tooladapter,
+    util,
+)
+
+tool: tooladapter.CURRENT_BASETOOL = None
+
+TOOL_DIRECTORY_MOUNT_POINT = "/mnt/__benchexec_tool_directory"
+
+
+@tooladapter.CURRENT_BASETOOL.register  # mark as instance of CURRENT_BASETOOL
+class PodmanContainerizedTool(object):
+    """Wrapper for an instance of any subclass of one of the base-tool classes in
+    benchexec.tools.template.
+    The module and the subclass instance will be loaded in a subprocess that has been
+    put into a container. This means, for example, that the code of this module cannot
+    make network connections and that any changes made to files on disk have no effect.
+
+    Because we use the multiprocessing module and thus communication is done
+    via serialization with pickle, this is not a secure solution:
+    Code from the tool-info module can use pickle to execute arbitrary code
+    in the main BenchExec process.
+    But the use of containers in BenchExec is for safety and robustness, not security.
+
+    This class is heavily inspired by ContainerizedTool and it will create a podman
+    container and move the multiprocessing process into the namespace of the podman container.
+    """
+
+    def __init__(self, tool_module, config, image):
+        """Load tool-info module in subprocess.
+        @param tool_module: The name of the module to load.
+            Needs to define class named Tool.
+        @param config: A config object suitable for
+            benchexec.containerexecutor.handle_basic_container_args()
+        """
+        if not config.tool_directory:
+            logging.warning(
+                "Podman continaerized toool currently only works if --tool-directory is set"
+            )
+            raise ValueError(
+                "Podman continaerized toool currently only works if --tool-directory is set"
+            )
+
+        # We use multiprocessing.Pool as an easy way for RPC with another process.
+        self._pool = multiprocessing.Pool(1, _init_worker_process)
+
+        self.container_id = None
+        # Call function that loads tool module and returns its doc
+        try:
+            self.__doc__, self.container_id = self._pool.apply(
+                _init_container_and_load_tool,
+                [tool_module],
+                {
+                    "image": image,
+                    "tool_directory": config.tool_directory,
+                },
+            )
+        except BaseException as e:
+            self._pool.terminate()
+            raise e
+
+    def close(self):
+        self._forward_call("close", [], {})
+        self._pool.close()
+        if self.container_id is None:
+            return
+        try:
+            # FIXME: Unexpected terminations could lead to the container not being stopped and removed
+            # SIGTERM sent by stop does not stop the container running tail -F /dev/null or sleep infinity
+            subprocess.run(
+                ["podman", "kill", "--signal", "SIGKILL", self.container_id],
+                check=True,
+                stdout=subprocess.DEVNULL,
+                stderr=subprocess.PIPE,
+            )
+        except subprocess.CalledProcessError as e:
+            logging.warning(
+                "Failed to stop container %s: %s",
+                self.container_id,
+                e.stderr.decode(),
+            )
+
+    def _forward_call(self, method_name, args, kwargs):
+        """Call given method indirectly on the tool instance in the container."""
+        return self._pool.apply(_call_tool_func, [method_name, list(args), kwargs])
+
+    @classmethod
+    def _add_proxy_function(cls, method_name, method):
+        """Add function to given class that calls the specified method indirectly."""
+
+        @functools.wraps(method)  # lets proxy_function look like method (name and doc)
+        def proxy_function(self, *args, **kwargs):
+            return self._forward_call(method_name, args, kwargs)
+
+        if method_name == "working_directory":
+            # Add a cache. This method is called per run but would always return the
+            # same result. On some systems the calls are slow and this is worth it:
+            # https://github.com/python/cpython/issues/98493
+            proxy_function = functools.lru_cache()(proxy_function)
+
+        setattr(cls, member_name, proxy_function)
+
+
+# The following will automatically add forwarding methods for all methods defined by the
+# current tool-info API. This should work without any version-specific adjustments,
+# so we declare compatibility with the latest version with @CURRENT_BASETOOL.register.
+# We do not inherit from a BaseTool class to ensure that no default methods will be used
+# accidentally.
+for member_name, member in inspect.getmembers(
+    tooladapter.CURRENT_BASETOOL, inspect.isfunction
+):
+    if member_name[0] == "_" or member_name == "close":
+        continue
+    PodmanContainerizedTool._add_proxy_function(member_name, member)
+
+
+def _init_worker_process():
+    """Initial setup of worker process from multiprocessing module."""
+
+    # Need to reset signal handling because multiprocessing relies on SIGTERM
+    # but benchexec adds a handler for it.
+    signal.signal(signal.SIGTERM, signal.SIG_DFL)
+
+    # If Ctrl+C is pressed, each process receives SIGINT. We need to ignore it because
+    # concurrent worker threads of benchexec might still attempt to use the tool-info
+    # module until all of them are stopped, so this process must stay alive.
+    signal.signal(signal.SIGINT, signal.SIG_IGN)
+
+
+def _init_container_and_load_tool(tool_module, *args, **kwargs):
+    """Initialize container for the current process and load given tool-info module."""
+    try:
+        container_id = _init_container(*args, **kwargs)
+    except OSError as e:
+        if container.check_apparmor_userns_restriction(e):
+            raise BenchExecException(container._ERROR_MSG_USER_NS_RESTRICTION)
+        raise BenchExecException(f"Failed to configure container: {e}")
+    return _load_tool(tool_module), container_id
+
+
+def _init_container(
+    image,
+    tool_directory,
+):
+    """
+    Move this process into a container.
+    """
+
+    volumes = []
+
+    tool_directory = os.path.abspath(tool_directory)
+
+    # Mount the python loaded paths into the container
+    # The modules are mounted at the exact same path in the container
+    # because we do not yet know a solution to tell python to use
+    # different paths for the modules in the container.
+    python_paths = [path for path in sys.path if os.path.isdir(path)]
+    for path in python_paths:
+        abs_path = os.path.abspath(path)
+        volumes.extend(["--volume", f"{abs_path}:{abs_path}:ro"])
+
+    # Mount the tool directory into the container at a known location
+    volumes.extend(
+        [
+            "--volume",
+            f"{tool_directory}:{TOOL_DIRECTORY_MOUNT_POINT}:O",
+            # :O creates an overlay mount. The tool can write files in the container
+            # but they are not visible outside the container.
+            "--workdir",
+            "/mnt",
+        ]
+    )
+
+    # Create a container that does nothing but keeps running
+    command = (
+        ["podman", "run", "--entrypoint", "tail", "--rm", "-d"]
+        + volumes
+        + [image, "-F", "/dev/null"]
+    )
+
+    logging.debug(
+        "Command to start container: %s",
+        " ".join(map(str, command)),
+    )
+    res = subprocess.run(
+        command,
+        stdout=subprocess.PIPE,
+    )
+
+    res.check_returncode()
+    container_id = res.stdout.decode().strip()
+
+    container_pid = (
+        subprocess.run(
+            ["podman", "inspect", "--format", "{{.State.Pid}}", container_id],
+            stdout=subprocess.PIPE,
+        )
+        .stdout.decode()
+        .strip()
+    )
+
+    try:
+        logging.debug("Joining user namespace of container %s", container_id)
+
+        # The user namespace must be joined first
+        user_ns = f"/proc/{container_pid}/ns/user"
+        with open(user_ns, "rb") as f:
+            libc.setns(f.fileno(), 0)
+
+        for namespace in os.listdir(f"/proc/{container_pid}/ns"):
+            namespace = os.path.join(f"/proc/{container_pid}/ns", namespace)
+
+            if namespace == user_ns:
+                continue
+            logging.debug("Joining namespace %s", namespace)
+
+            try:
+                # We try to mount all listed namespaces, but some might not be available
+                with open(namespace, "rb") as f:
+                    libc.setns(f.fileno(), 0)
+
+            except OSError as e:
+                logging.debug(
+                    "Failed to join namespace %s: %s", namespace, os.strerror(e.errno)
+                )
+
+        os.chdir("/mnt")
+        return container_id
+
+    except OSError as e:
+        if (
+            e.errno == errno.EPERM
+            and util.try_read_file("/proc/sys/kernel/unprivileged_userns_clone") == "0"
+        ):
+            raise BenchExecException(
+                "Unprivileged user namespaces forbidden on this system, please "
+                "enable them with 'sysctl -w kernel.unprivileged_userns_clone=1' "
+                "or disable container mode"
+            )
+        elif (
+            e.errno in {errno.ENOSPC, errno.EINVAL}
+            and util.try_read_file("/proc/sys/user/max_user_namespaces") == "0"
+        ):
+            # Ubuntu has ENOSPC, Centos seems to produce EINVAL in this case
+            raise BenchExecException(
+                "Unprivileged user namespaces forbidden on this system, please "
+                "enable by using 'sysctl -w user.max_user_namespaces=10000' "
+                "(or another value) or disable container mode"
+            )
+        else:
+            raise BenchExecException(
+                "Creating namespace for container mode failed: " + os.strerror(e.errno)
+            )
+
+
+def _load_tool(tool_module):
+    logging.debug("Loading tool-info module %s in container", tool_module)
+    global tool
+
+    tool = __import__(tool_module, fromlist=["Tool"]).Tool()
+
+    tool = tooladapter.adapt_to_current_version(tool)
+    return tool.__doc__
+
+
+def _call_tool_func(name, args, kwargs):
+    """Call a method on the tool instance.
+    @param name: The method name to call.
+    @param args: List of arguments to be passed as positional arguments.
+    @param kwargs: Dict of arguments to be passed as keyword arguments.
+    """
+    global tool
+    try:
+        return getattr(tool, name)(*args, **kwargs)
+    except SystemExit as e:
+        # SystemExit would terminate the worker process instead of being propagated.
+        raise BenchExecException(str(e.code))

--- a/contrib/vcloud/podman_containerized_tool.py
+++ b/contrib/vcloud/podman_containerized_tool.py
@@ -244,7 +244,7 @@ def _init_container(
                     "Failed to join namespace %s: %s", namespace, os.strerror(e.errno)
                 )
 
-        os.chdir("/mnt")
+        os.chdir(TOOL_DIRECTORY_MOUNT_POINT)
         return container_id
 
     except OSError as e:

--- a/contrib/vcloud/podman_containerized_tool.py
+++ b/contrib/vcloud/podman_containerized_tool.py
@@ -156,7 +156,7 @@ class PodmanContainerizedTool(ContainerizedTool):
 
         super().__init__(tool_module, config)
 
-    def _setup_container(self, tool_module):
+    def _setup_container(self, tool_module, config):
         self.__doc__, self.container_id = self._pool.apply(
             _init_container_and_load_tool,
             [_init_container, tool_module],

--- a/contrib/vcloud/podman_containerized_tool.py
+++ b/contrib/vcloud/podman_containerized_tool.py
@@ -53,13 +53,9 @@ class PodmanContainerizedTool(object):
         @param config: A config object suitable for
             benchexec.containerexecutor.handle_basic_container_args()
         """
-        if not config.tool_directory:
-            logging.warning(
-                "Podman continaerized toool currently only works if --tool-directory is set"
-            )
-            raise ValueError(
-                "Podman continaerized toool currently only works if --tool-directory is set"
-            )
+        assert (
+            config.tool_directory
+        ), "Tool directory must be set when using podman for tool info module."
 
         # We use multiprocessing.Pool as an easy way for RPC with another process.
         self._pool = multiprocessing.Pool(1, _init_worker_process)

--- a/contrib/vcloud/podman_containerized_tool.py
+++ b/contrib/vcloud/podman_containerized_tool.py
@@ -11,6 +11,7 @@ import inspect
 import logging
 import multiprocessing
 import os
+import shlex
 import signal
 import subprocess
 import sys
@@ -196,7 +197,7 @@ def _init_container(
 
     logging.debug(
         "Command to start container: %s",
-        " ".join(map(str, command)),
+        shlex.join(map(str, command)),
     )
     res = subprocess.run(
         command,

--- a/contrib/vcloud/podman_containerized_tool.py
+++ b/contrib/vcloud/podman_containerized_tool.py
@@ -80,10 +80,10 @@ def _init_container(
 
     subprocess.run(
         ["podman", "init", container_id],
-        check=True,
         stdout=subprocess.DEVNULL,
         stderr=subprocess.DEVNULL,
         stdin=subprocess.DEVNULL,
+        check=True,
     )
 
     container_pid = (
@@ -92,6 +92,7 @@ def _init_container(
             stdout=subprocess.PIPE,
             stderr=subprocess.DEVNULL,
             stdin=subprocess.DEVNULL,
+            check=True,
         )
         .stdout.decode()
         .strip()

--- a/contrib/vcloud/podman_containerized_tool.py
+++ b/contrib/vcloud/podman_containerized_tool.py
@@ -135,7 +135,7 @@ class PodmanContainerizedTool(ContainerizedToolBase):
 
         super().__init__(tool_module, config, _init_container)
 
-    def mk_args(self, tool_module, config, tmp_dir):
+    def mk_args(self, tool_module, tmp_dir):
         return [tool_module]
 
     def mk_kwargs(self, container_options):


### PR DESCRIPTION
This MR adds extra functionality for the vcloud-benchmark.py.

Some tools like PeSCo crash under newer linux versions even while obtaining the version.
And in this case the crash even causes the entire benchmark execution to fail (since it causes a index out of bounds directly in the tool info module). These tools are run inside of a podman container in the benchcloud, denoted with the `--vcloudContainerImage` option.

I propose to go ahead and also use this image while obtaining the version of the tool.

I manually tested this code with cpachecker, PeSCo, VeriAbs and nacpa. I also tested the fallback by renaming "podman" to "podmans".

I don't know, if we want to make this way of obtaining a Version optional via yet another flag (or if the `--no-container` should serve double duty here).

@dbeyer is strongly interested in some form of containering the version retrieval for the Hors Concours runs of SV-COMP25.

I am grateful for feedback how to improve, so that we can swiftly incorporate this feature.

PeSCo also needs the full tool_directory mounted to the container. I expect this from other python based tools aswell.
This is why I added the find_tool_base_dir function that mimics how the find_executable works but tries to determine the candidate that actually won.