### PR TITLE
Improve avr tool info

### DIFF
--- a/benchexec/tools/abc.py
+++ b/benchexec/tools/abc.py
@@ -51,8 +51,6 @@ class Tool(benchexec.tools.template.BaseTool2):
         """
         @return: status of ABC after executing a run
         """
-        if run.was_timeout:
-            return result.RESULT_TIMEOUT
         for line in run.output[::-1]:
             if line.startswith("Property proved") or line.startswith(
                 "Networks are equivalent"

--- a/benchexec/tools/avr.py
+++ b/benchexec/tools/avr.py
@@ -37,8 +37,6 @@ class Tool(benchexec.tools.template.BaseTool2):
         """
         @return: status of AVR after executing a run
         """
-        if run.was_timeout:
-            return result.RESULT_TIMEOUT
         for line in run.output[::-1]:
             # skip the lines that do not contain verification result
             if not line.startswith("Verification result:"):

--- a/benchexec/tools/avr.py
+++ b/benchexec/tools/avr.py
@@ -28,7 +28,15 @@ class Tool(benchexec.tools.template.BaseTool2):
 
     def cmdline(self, executable, options, task, rlimits):
         if rlimits.cputime and "--timeout" not in options:
-            options += ["--timeout", str(rlimits.cputime)]
+            # The `--timeout` parameter must be passed to the tool
+            # to prevent it from using its default value,
+            # which could be shorter than the limit set by BenchExec
+            # and cause early termination.
+            # Moreover, in practice the tool sometimes terminates itself prematurely
+            # even when the exact time limit is passed.
+            # To prevent this and ensure the tool utilizes the full time limit,
+            # a factor of 2 is applied to the timeout value.
+            options += ["--timeout", str(rlimits.cputime * 2)]
         if rlimits.memory and "--memout" not in options:
             options += ["--memout", str(ceil(rlimits.memory / 1000000.0))]
         return [executable] + options + [task.single_input_file]

--- a/benchexec/tools/cpv.py
+++ b/benchexec/tools/cpv.py
@@ -47,8 +47,6 @@ class Tool(benchexec.tools.template.BaseTool2):
         return [executable, task.single_input_file, *options]
 
     def determine_result(self, run):
-        if run.was_timeout:
-            return result.RESULT_TIMEOUT
         for line in run.output[::-1]:
             if line.startswith("INFO: Verification result:"):
                 if "TRUE" in line:


### PR DESCRIPTION
When preparing #1133 , I noticed that AVR has a similar issue that it sometimes terminates itself too early (for example, [these cases](https://www.cip.ifi.lmu.de/~chien/benchexec-results/func-encoding/svcomp24/avr.table.html#/table?hidden1=2,3,4&hidden=0,2,3,4,5,6&sort=1_cputime_1,desc&filter=1(0*status*(status(in(ERROR)),category(notIn())),1*cputime*(value(899%3A))))).
Therefore, I applied the same solution as discussed.

This PR also brings some small improvements to the tool-info modules I wrote.