### PR TITLE
Add a path existence check, and if not, create the directory

### DIFF
--- a/benchexec/container.py
+++ b/benchexec/container.py
@@ -563,6 +563,8 @@ def duplicate_mount_hierarchy(mount_base, temp_base, work_base, dir_modes):
 
             if use_fuse and fuse_overlay_mount_path:
                 fuse_mount_path = fuse_overlay_mount_path + mountpoint
+                if not os.path.exists(fuse_mount_path):
+                    os.makedirs(fuse_mount_path, exist_ok=True)
                 make_bind_mount(fuse_mount_path, mount_path)
             else:
                 overlay_count += 1


### PR DESCRIPTION
Contributes to solving the following issue: https://github.com/sosy-lab/benchexec/issues/1136

The cause of the problem described in the issue is that the source directory is not correctly created when using fuse-overlayfs.