### PR TITLE
Added Support for Walltime limit in Vcloud

### DIFF
--- a/contrib/vcloud/benchmarkclient_executor.py
+++ b/contrib/vcloud/benchmarkclient_executor.py
@@ -275,6 +275,7 @@ def getBenchmarkDataForCloud(benchmark):
     timeLimit = benchmark.rlimits.cputime_hard or DEFAULT_CLOUD_TIMELIMIT
     memLimit = bytes_to_mb(benchmark.rlimits.memory) or memRequirement
     coreLimit = benchmark.rlimits.cpu_cores
+    wallTimeLimit = benchmark.rlimits.walltime
     numberOfRuns = sum(
         len(runSet.runs) for runSet in benchmark.run_sets if runSet.should_be_executed()
     )


### PR DESCRIPTION
Backwards compatible support for walltime.
The optional parameter walltime has to be the 5th parameter.  
If no corelimit is given we write "-" instead.

Older versions will simply not support walltime since they do only provide 4 parameters at most.