### PR TITLE
Improve user ns error message

### DIFF
--- a/benchexec/container.py
+++ b/benchexec/container.py
@@ -123,11 +123,16 @@ NATIVE_CLONE_CALLBACK_SUPPORTED = (
 """Whether we use generated native code for clone or an unsafe Python fallback"""
 
 _ERROR_MSG_USER_NS_RESTRICTION = (
-    "Unprivileged user namespaces forbidden on this system, please "
-    "enable them with 'sysctl -w kernel.apparmor_restrict_unprivileged_userns=0'. "
-    "Ubuntu disables them by default since 24.04, refer to "
-    "https://ubuntu.com/blog/ubuntu-23-10-restricted-unprivileged-user-namespaces "
-    "for more information."
+    "Unprivileged user namespaces are forbidden on this system. "
+    "You can temporarily enable them with "
+    "'sysctl -w kernel.apparmor_restrict_unprivileged_userns=0', "
+    "but note that this is not a persistent solution. "
+    "For a persistent configuration, please refer to the "
+    "installation instructions at: "
+    "https://github.com/sosy-lab/benchexec/blob/main/doc/INSTALL.md#kernel-requirements. "
+    "Ubuntu disables unprivileged user namespaces by default starting with version 24.04; "
+    "see https://ubuntu.com/blog/ubuntu-23-10-restricted-unprivileged-user-namespaces "
+    "for background information."
 )
 
 


### PR DESCRIPTION
As discussed in #1164, the error message for forbidden unprivileged user namespaces provides a solution to the problem, but does not say that it is only a temporary one (until the next reboot).
