### PR TITLE
Update benchmarkclient_executor.py

### DIFF
--- a/contrib/vcloud/benchmarkclient_executor.py
+++ b/contrib/vcloud/benchmarkclient_executor.py
@@ -371,6 +371,7 @@ def handleCloudResults(benchmark, output_handler, start_time, end_time):
         output_handler.output_before_run_set(runSet, start_time=start_time)
 
         for run in runSet.runs:
+            run.cmdline() # ignore result, but necessary, otherwise _cmdline is not set
             dataFile = run.log_file + ".data"
             if os.path.exists(dataFile) and os.path.exists(run.log_file):
                 try:


### PR DESCRIPTION
Reprocessing results with vcloud-benchmark.py (using `--justReprocessResults --startTime `) with a .logfiles folder with all `.log` and `.log.data` files results in the following exception: 

```
  File "benchexec/contrib/vcloud-benchmark.py", line 146, in <module>
    benchexec.benchexec.main(VcloudBenchmark())
  File "benchexec/contrib/../benchexec/benchexec.py", line 506, in main
    sys.exit(benchexec.start(argv or sys.argv))
             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "benchexec/contrib/../benchexec/benchexec.py", line 73, in start
    rc = self.execute_benchmark(arg)
         ^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "benchexec/contrib/../benchexec/benchexec.py", line 390, in execute_benchmark
    result = self.executor.execute_benchmark(benchmark, output_handler)
             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/home/levente/chc-model-artifact/benchexec/contrib/vcloud/benchmarkclient_executor.py", line 199, in execute_benchmark
    handleCloudResults(benchmark, output_handler, start_time, end_time)
  File "/home/levente/chc-model-artifact/benchexec/contrib/vcloud/benchmarkclient_executor.py", line 392, in handleCloudResults
    run.set_result(values, ["host"])
  File "benchexec/contrib/../benchexec/model.py", line 1114, in set_result
    self.status = self._analyze_result(exitcode, output, termination_reason)
                  ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "benchexec/contrib/../benchexec/model.py", line 1136, in _analyze_result
    self._cmdline, exitcode, output, termination_reason
    ^^^^^^^^^^^^^
AttributeError: 'Run' object has no attribute '_cmdline'. Did you mean: 'cmdline'?
```

This is due to `run.cmdline()` not being called in this case, which would set the `_cmdline`. The proposed fix just runs `run.cmdline()`, ignores its result, but as a side effect, sets `_cmdline`.   