### PR TITLE
Cache some functions used when parsing benchmark definitions

### DIFF
--- a/benchexec/model.py
+++ b/benchexec/model.py
@@ -6,6 +6,7 @@
 # SPDX-License-Identifier: Apache-2.0
 
 import collections.abc
+import functools
 import logging
 import os
 import re
@@ -84,9 +85,10 @@ def substitute_vars(oldList, runSet=None, task_file=None):
     # do not use keys twice
     assert len({key for (key, value) in keyValueList}) == len(keyValueList)
 
-    return [util.substitute_vars(s, keyValueList) for s in oldList]
+    return [util.substitute_vars(s, tuple(keyValueList)) for s in oldList]
 
 
+@functools.cache
 def load_task_definition_file(task_def_file):
     """Open and parse a task-definition file in YAML format."""
     try:

--- a/benchexec/tablegenerator/htmltable.py
+++ b/benchexec/tablegenerator/htmltable.py
@@ -455,12 +455,12 @@ def _prepare_rows_for_js(rows, base_dir, href_base, relevant_id_columns):
 def _create_link(href, base_dir, runResult=None, href_base=None):
     def get_replacements(task_file):
         var_prefix = "taskdef_" if task_file.endswith(".yml") else "inputfile_"
-        return [
+        return (
             (var_prefix + "name", os.path.basename(task_file)),
             (var_prefix + "path", os.path.dirname(task_file) or "."),
             (var_prefix + "path_abs", os.path.dirname(os.path.abspath(task_file))),
-        ] + (
-            [
+        ) + (
+            (
                 ("logfile_name", os.path.basename(runResult.log_file)),
                 (
                     "logfile_path",
@@ -473,9 +473,9 @@ def _create_link(href, base_dir, runResult=None, href_base=None):
                     "logfile_path_abs",
                     os.path.dirname(os.path.abspath(runResult.log_file)),
                 ),
-            ]
+            )
             if runResult.log_file
-            else []
+            else ()
         )
 
     source_file = (

--- a/benchexec/util.py
+++ b/benchexec/util.py
@@ -14,6 +14,7 @@ import collections
 import datetime
 import errno
 import fnmatch
+import functools
 import glob
 import logging
 import os
@@ -292,6 +293,7 @@ def print_decimal(d):
     )
 
 
+@functools.cache
 def expand_filename_pattern(pattern, base_dir):
     """
     Expand a file name pattern containing wildcards, environment variables etc.
@@ -330,6 +332,7 @@ def get_files(paths):
     return result if changed else paths
 
 
+@functools.cache
 def substitute_vars(template, replacements):
     """Replace certain keys with respective values in a string.
     @param template: the string in which replacements should be made


### PR DESCRIPTION
This helps performance especially if there are some run definitions that refer to the same task definitions.
For example, we parse every task definition file only once now.

For [this benchmark definition](https://gitlab.com/sosy-lab/software/cpachecker/-/blob/b103bea5fdc8d0239d5e98bae73474779d169f81/test/test-sets/svcomp-test-sets/memcleanup-all.xml), the function `extract_runs_from_xml` can be sped up from 1140s to 195s on my machine.
(cProfile data before and after: [profile.zip](https://github.com/user-attachments/files/22904685/profile.zip)).

Most of the remaining time (120s) is now spent in `benchmark.model.substitute_vars`, but here caching is not as trivial as for the functions where 79c74b2bf00ba1d56cc13b27dd1f5be363ff3742 adds it. Maybe it is also optimized enough for practical use now @baierd?

I think this caching should be safe. I made sure that `Run` objects are still created for every run separately, because they are mutable and store the result data.