### PR TITLE
Fizzer: New version

### DIFF
--- a/benchexec/tools/fizzer.py
+++ b/benchexec/tools/fizzer.py
@@ -103,11 +103,10 @@ class Tool(benchexec.tools.template.BaseTool2):
             return result.RESULT_UNKNOWN
 
         mark = "--- TestCompResult ---"
-        txt:str = run.output.text
+        txt = run.output.text
         mark_idx = txt.find(mark)
         if mark_idx != -1:
             return txt[mark_idx + len(mark) :].strip().splitlines()[-1]
-
 
         compilation = None
         instrumentation = None


### PR DESCRIPTION
There is however an issue with `REQUIRED_PATHS`. While old version uses `["lib", "lib32", "tools"]`, the new one `["fizzer"]`. I resolved this issue by merging both to `["lib", "lib32", "tools", "fizzer"]` and hoping that if some dir is not present, then it is ignored.