### PR TITLE
Fix link to ACM SIGSOFT Empirical Standards

### DIFF
--- a/doc/benchmarking.md
+++ b/doc/benchmarking.md
@@ -16,7 +16,7 @@ e.g., what to do when implementing a benchmarking tool,
 please read our paper [Reliable Benchmarking: Requirements and Solutions](https://www.sosy-lab.org/research/pub/2019-STTT.Reliable_Benchmarking_Requirements_and_Solutions.pdf).
 There are also many other valuable resources about benchmarking,
 for example this list of [Benchmarking Crimes](https://gernot-heiser.org/benchmarking-crimes.html)
-and these [ACM SIGSOFT Empirical Standards for Benchmarking](https://github.com/acmsigsoft/EmpiricalStandards/blob/master/docs/Benchmarking.md).
+and these [ACM SIGSOFT Empirical Standards for Benchmarking](https://github.com/acmsigsoft/EmpiricalStandards/blob/master/docs/standards/Benchmarking.md).
 
 ### Document as much as possible
 For correct interpretation of results, it is important that everything important


### PR DESCRIPTION
In the documentation, [`doc/benchmarking.md`](https://github.com/sosy-lab/benchexec/blob/main/doc/benchmarking.md), the link to "ACM SIGSOFT Empirical Standards for Benchmarking" is broken. I have fixed the link in this PR.