### PR TITLE
Update parsing results of SEAL

### DIFF
--- a/benchexec/tools/seal.py
+++ b/benchexec/tools/seal.py
@@ -26,7 +26,9 @@ class Tool(BaseTool2):
         return tool_locator.find_executable("seal-entrypoint.py")
 
     def cmdline(self, executable, options, task, rlimits):
-        machdep = get_data_model_from_task(task, {ILP32: "x86_32", LP64: "x86_64"})
+        machdep = get_data_model_from_task(
+            task, {ILP32: "gcc_x86_32", LP64: "gcc_x86_64"}
+        )
         machdep_opt = ["-machdep", machdep] if machdep is not None else []
 
         return [executable] + machdep_opt + options + [task.single_input_file]


### PR DESCRIPTION
The new version checks for unknown result before other result kinds to allow printing results even though the verdict is "unknown".