### PR TITLE
Fix version retrieval method for CPA-witness2test

### DIFF
--- a/benchexec/tools/cpa-witness2test.py
+++ b/benchexec/tools/cpa-witness2test.py
@@ -41,14 +41,10 @@ class Tool(cpachecker.Tool):
                 raise e1
 
     def version(self, executable):
-        stdout = ""
-        if executable.endswith(".py"):
-            # if the executable is a python script,
-            # it is likely that CPA-witness2test is an older version that takes `-version`
-            stdout = self._version_from_tool(executable, "-version")
+        # try the new version flag first, else fallback to the old one
+        stdout = self._version_from_tool(executable, "--version")
         if not stdout:
-            # try the newer version flag
-            stdout = self._version_from_tool(executable, "--version")
+            stdout = self._version_from_tool(executable, "-version")
         version = stdout.split("(")[0].strip()
         return version
 


### PR DESCRIPTION
`bin/cpa-witness2test -version` does not work in newer versions of CPA-witness2test.

```bash
./bin/cpa-witness2test -version
usage: cpa-witness2test [--help] [--version] [--32 | --64] [--output-path OUTPUT_PATH] [--stats]
                        [--gcc-args ...] --spec SPECIFICATION_FILE --witness WITNESS_FILE
                        file
cpa-witness2test: error: the following arguments are required: --spec, --witness/-w, file
```