### PR TITLE
Enable multiple input files for jayhorn

### DIFF
--- a/benchexec/tools/jayhorn.py
+++ b/benchexec/tools/jayhorn.py
@@ -35,7 +35,7 @@ class Tool(benchexec.tools.template.BaseTool2):
         if task.property_file:
             options = options + ["--propertyfile", task.property_file]
 
-        return [executable] + options + [task.single_input_file]
+        return [executable] + options + list(task.input_files)
 
     def determine_result(self, run):
         # parse output


### PR DESCRIPTION
Some benchmarks have more than one input files. Jayhorn script did support these inputs, so I updated benchexec module to be able to run jayhorn with multiple input files.