### PR TITLE
goblint: fix missing warning identifier in `get_value_from_output`

### DIFF
--- a/benchexec/tools/goblint.py
+++ b/benchexec/tools/goblint.py
@@ -137,5 +137,7 @@ class Tool(benchexec.tools.template.BaseTool2):
                 if result is None or last:
                     result = match.group(1)
                 elif not first:
-                    logging.warning("repeated match of identifier '%s', using first")
+                    logging.warning(
+                        "repeated match of identifier '%s', using first", identifier
+                    )
         return result


### PR DESCRIPTION
In #1238 I accidentally removed the identifier argument used in the warning format string, causing `%s` to be printed literally.