### PR TITLE
Migrate some tools to BaseTool2

### DIFF
--- a/benchexec/tools/coastal.py
+++ b/benchexec/tools/coastal.py
@@ -5,20 +5,20 @@
 #
 # SPDX-License-Identifier: Apache-2.0
 
-import benchexec.util as util
-import benchexec.tools.template
 import benchexec.result as result
+import benchexec.tools.template
+import benchexec.util as util
 
 
-class Tool(benchexec.tools.template.BaseTool):
+class Tool(benchexec.tools.template.BaseTool2):
     """
     Tool info for COASTAL
     """
 
     REQUIRED_PATHS = ["coastal", "coastal-sv-comp"]
 
-    def executable(self):
-        return util.find_executable("coastal-sv-comp")
+    def executable(self, tool_locator):
+        return tool_locator.find_executable("coastal-sv-comp")
 
     def name(self):
         return "COASTAL"
@@ -31,15 +31,15 @@ class Tool(benchexec.tools.template.BaseTool):
         first_line = output.splitlines()[0]
         return first_line.strip()
 
-    def cmdline(self, executable, options, tasks, propertyfile, rlimits):
-        options = options + ["--propertyfile", propertyfile]
-        return [executable] + options + tasks
+    def cmdline(self, executable, options, task, rlimits):
+        options = options + ["--propertyfile", task.property_file]
+        return [executable] + options + list(task.input_files_or_identifier)
 
-    def determine_result(self, returncode, returnsignal, output, isTimeout):
+    def determine_result(self, run):
         # parse output
         status = result.RESULT_UNKNOWN
 
-        for line in output:
+        for line in run.output:
             if "UNSAFE" in line:
                 status = result.RESULT_FALSE_PROP
             elif "SAFE" in line:

--- a/benchexec/tools/coastal.py
+++ b/benchexec/tools/coastal.py
@@ -7,7 +7,6 @@
 
 import benchexec.result as result
 import benchexec.tools.template
-import benchexec.util as util
 
 
 class Tool(benchexec.tools.template.BaseTool2):

--- a/benchexec/tools/java-ranger.py
+++ b/benchexec/tools/java-ranger.py
@@ -5,18 +5,17 @@
 #
 # SPDX-License-Identifier: Apache-2.0
 
-import benchexec.util as util
-import benchexec.tools.template
 import benchexec.result as result
+import benchexec.tools.template
 
 
-class Tool(benchexec.tools.template.BaseTool):
+class Tool(benchexec.tools.template.BaseTool2):
     """
     Tool info for Java Ranger that is based on the symbolic extension (SPF) of Java PathFinder (JPF)
     """
 
-    def executable(self):
-        return util.find_executable("jr-sv-comp")
+    def executable(self, tool_locator):
+        return tool_locator.find_executable("jr-sv-comp")
 
     def name(self):
         return "Java Ranger"
@@ -29,15 +28,15 @@ class Tool(benchexec.tools.template.BaseTool):
         first_line = output.splitlines()[0]
         return first_line.strip()
 
-    def cmdline(self, executable, options, tasks, propertyfile, rlimits):
-        options = options + ["--propertyfile", propertyfile]
-        return [executable] + options + tasks
+    def cmdline(self, executable, options, task, rlimits):
+        options = options + ["--propertyfile", task.property_file]
+        return [executable] + options + list(task.input_files_or_identifier)
 
-    def determine_result(self, returncode, returnsignal, output, isTimeout):
+    def determine_result(self, run):
         # parse output
         status = result.RESULT_UNKNOWN
 
-        for line in output:
+        for line in run.output:
             if "UNSAFE" in line:
                 status = result.RESULT_FALSE_PROP
             elif "SAFE" in line:

--- a/benchexec/tools/jdart.py
+++ b/benchexec/tools/jdart.py
@@ -5,18 +5,17 @@
 #
 # SPDX-License-Identifier: Apache-2.0
 
-import benchexec.util as util
-import benchexec.tools.template
 import benchexec.result as result
+import benchexec.tools.template
 
 
-class Tool(benchexec.tools.template.BaseTool):
+class Tool(benchexec.tools.template.BaseTool2):
     """
     Tool info for JDart modified by TU Dortmund
     """
 
-    def executable(self):
-        return util.find_executable("run-jdart.sh")
+    def executable(self, tool_locator):
+        return tool_locator.find_executable("run-jdart.sh")
 
     def version(self, executable):
         return self._version_from_tool(executable, arg="-v")
@@ -27,18 +26,18 @@ class Tool(benchexec.tools.template.BaseTool):
     def project_url(self):
         return "https://github.com/tudo-aqua/jdart"
 
-    def cmdline(self, executable, options, tasks, propertyfile, rlimits):
+    def cmdline(self, executable, options, task, rlimits):
         cmd = [executable]
         if options:
             cmd = cmd + options
-        if propertyfile:
-            cmd.append(propertyfile)
-        return cmd + tasks
+        if task.property_file:
+            cmd.append(task.property_file)
+        return cmd + list(task.input_files_or_identifier)
 
-    def determine_result(self, returncode, returnsignal, output, isTimeout):
+    def determine_result(self, run):
         # parse output
         status = result.RESULT_UNKNOWN
-        for line in output:
+        for line in run.output:
             if "== ERROR" in line:
                 status = result.RESULT_FALSE_PROP
             elif "== OK" in line:

--- a/benchexec/tools/jpf.py
+++ b/benchexec/tools/jpf.py
@@ -7,18 +7,17 @@
 
 import os
 
-import benchexec.util as util
-import benchexec.tools.template
 import benchexec.result as result
+import benchexec.tools.template
 
 
-class Tool(benchexec.tools.template.BaseTool):
+class Tool(benchexec.tools.template.BaseTool2):
     """
     Tool info for JPF (plain jpf-core)
     """
 
-    def executable(self):
-        return util.find_executable("bin/jpf-core-sv-comp")
+    def executable(self, tool_locator):
+        return tool_locator.find_executable("bin/jpf-core-sv-comp")
 
     def version(self, executable):
         jpf = os.path.join(os.path.dirname(executable), "jpf")
@@ -32,15 +31,15 @@ class Tool(benchexec.tools.template.BaseTool):
     def project_url(self):
         return "https://github.com/javapathfinder/jpf-core/"
 
-    def cmdline(self, executable, options, tasks, propertyfile, rlimits):
-        options = options + ["--propertyfile", propertyfile]
-        return [executable] + options + tasks
+    def cmdline(self, executable, options, task, rlimits):
+        options = options + ["--propertyfile", task.property_file]
+        return [executable] + options + list(task.input_files_or_identifier)
 
-    def determine_result(self, returncode, returnsignal, output, isTimeout):
+    def determine_result(self, run):
         # parse output
         status = result.RESULT_UNKNOWN
 
-        for line in output:
+        for line in run.output:
             if "UNSAFE" in line:
                 status = result.RESULT_FALSE_PROP
             elif "SAFE" in line:


### PR DESCRIPTION
In SV-COMP we want to execute tools with podman containers. For this it is necessary, that the tools can handle the use of the `--tool-directory` parameter of benchexec. Migrating the tool info modules to use the modern BaseTool2 instead of BaseTool remedies this issue.

@dbeyer let me know if you encounter more tools that have this issue. 