### PR TITLE
Add toolinfo module for SvLibChecker

### DIFF
--- a/benchexec/tools/svlibchecker.py
+++ b/benchexec/tools/svlibchecker.py
@@ -39,7 +39,7 @@ class Tool(benchexec.tools.template.BaseTool2):
 
     def cmdline(self, executable, options, task, rlimits):
         input_files, mapping_options = handle_witness_of_task(
-            task, options, "--witness", TaskFilesConsidered.INPUT_FILES_OR_IDENTIFIER
+            task, options, "--witness", TaskFilesConsidered.INPUT_FILES
         )
 
         return [executable, *options, *mapping_options, *input_files]


### PR DESCRIPTION
Add the toolinfo module for the new model checker [SvLibChecker](https://gitlab.com/sosy-lab/software/svlibchecker). 

~~Currently marked as draft until experiments have finished and I'm sure that the toolinfo module works as intended.~~

I have tested the toolinfo module with experiments and it works as intended.