### PR TITLE
[ESBMC] update input file handling

### DIFF
--- a/benchexec/tools/esbmc.py
+++ b/benchexec/tools/esbmc.py
@@ -9,7 +9,8 @@ import os
 import re
 from benchexec.tools.sv_benchmarks_util import (
     get_data_model_from_task,
-    get_single_non_witness_input_file,
+    handle_witness_of_task,
+    TaskFilesConsidered,
     ILP32,
     LP64,
 )
@@ -43,11 +44,20 @@ class Tool(benchexec.tools.template.BaseTool2):
         data_model_param = get_data_model_from_task(task, {ILP32: "32", LP64: "64"})
         if data_model_param and "--arch" not in options:
             options += ["--arch", data_model_param]
+
+        input_files, witness_options = handle_witness_of_task(
+            task,
+            options,
+            "--witness",
+            TaskFilesConsidered.SINGLE_INPUT_FILE,
+        )
+
         return (
             [executable]
             + ["-p", task.property_file]
             + options
-            + [get_single_non_witness_input_file(task)]
+            + input_files
+            + witness_options
         )
 
     def determine_result(self, run):

--- a/benchexec/tools/esbmc.py
+++ b/benchexec/tools/esbmc.py
@@ -7,7 +7,12 @@
 
 import os
 import re
-from benchexec.tools.sv_benchmarks_util import get_data_model_from_task, ILP32, LP64
+from benchexec.tools.sv_benchmarks_util import (
+    get_data_model_from_task,
+    get_single_non_witness_input_file,
+    ILP32,
+    LP64,
+)
 import benchexec.tools.template
 import benchexec.result as result
 import decimal
@@ -42,7 +47,7 @@ class Tool(benchexec.tools.template.BaseTool2):
             [executable]
             + ["-p", task.property_file]
             + options
-            + [task.single_input_file]
+            + [get_single_non_witness_input_file(task)]
         )
 
     def determine_result(self, run):


### PR DESCRIPTION
Replace `task.single_input_file` with `get_single_non_witness_input_file(task)` to properly filter out witness files when getting the input file.