### PR TITLE
Fix Python version label in Gitlab CI job

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -107,7 +107,7 @@ tests:cgroupsv2:python-3.12:
   variables:
     PYTHON_VERSION: '3.12'
 
-tests:cgroupsv2:python-3.15:
+tests:cgroupsv2:python-3.13:
   <<: *tests-cgroupsv2
   variables:
     PYTHON_VERSION: '3.13'


### PR DESCRIPTION
Rename the cgroupsv2 test job from `python-3.15` to `python-3.13` so the job name matches the configured `PYTHON_VERSION` value.