### PR TITLE
fix: correct remaining typos found by codespell

### DIFF
--- a/benchexec/tablegenerator/columns.py
+++ b/benchexec/tablegenerator/columns.py
@@ -17,7 +17,7 @@ from benchexec.util import print_decimal
 
 __all__ = ["Column", "ColumnMeasureType", "ColumnType"]
 
-# It's important to make sure on *all* entry points / methods which perform arithmetics that the correct
+# It's important to make sure on *all* entry points / methods which perform arithmetic that the correct
 # rounding / context is used by using a local context.
 DECIMAL_CONTEXT = decimal.Context(rounding=decimal.ROUND_HALF_UP)
 

--- a/benchexec/tablegenerator/statistics.py
+++ b/benchexec/tablegenerator/statistics.py
@@ -14,7 +14,7 @@ from benchexec import result
 from benchexec.tablegenerator import util
 from benchexec.tablegenerator.columns import ColumnType
 
-# It's important to make sure on *all* entry points / methods which perform arithmetics that the correct
+# It's important to make sure on *all* entry points / methods which perform arithmetic that the correct
 # rounding / context is used.
 DECIMAL_CONTEXT = decimal.Context(rounding=decimal.ROUND_HALF_UP)
 

--- a/benchexec/test_pqos.py
+++ b/benchexec/test_pqos.py
@@ -54,19 +54,19 @@ mock_pqos_wrapper_output = {
         "returncode": 0,
         "function": "monitor_events",
         "error": False,
-        "message": "Event monitoring successfull",
+        "message": "Event monitoring successful",
     },
     "reset_monitoring": {
         "returncode": 0,
         "function": "reset_monitoring",
         "error": False,
-        "message": "Reset monitoring successfull",
+        "message": "Reset monitoring successful",
     },
     "reset_resources": {
         "returncode": 0,
         "function": "reset_resources",
         "error": False,
-        "message": "Resource reset successfull",
+        "message": "Resource reset successful",
     },
 }
 

--- a/benchexec/tools/cpachecker.py
+++ b/benchexec/tools/cpachecker.py
@@ -81,11 +81,11 @@ class Tool(benchexec.tools.template.BaseTool2):
 
                 if has_jar:
                     if src_mtime > os.stat(jar_file).st_mtime:
-                        sys.exit("CPAchecker JAR is not uptodate, run 'ant jar'!")
+                        sys.exit("CPAchecker JAR is not up-to-date, run 'ant jar'!")
 
                 elif has_cls:
                     if src_mtime > self._find_newest_mtime(cls_dir):
-                        sys.exit("CPAchecker build is not uptodate, run 'ant'!")
+                        sys.exit("CPAchecker build is not up-to-date, run 'ant'!")
         except OSError as e:
             logging.warning(
                 "Could not determine whether CPAchecker needs to be rebuilt: %s", e

--- a/benchexec/tools/template.py
+++ b/benchexec/tools/template.py
@@ -693,7 +693,7 @@ class BaseTool:
         This function should always be overridden.
         @return a non-empty string
         """
-        return "UNKOWN"
+        return "UNKNOWN"
 
     def cmdline(self, executable, options, tasks, propertyfile=None, rlimits={}):
         """


### PR DESCRIPTION
## Summary
Corrected 8 typos identified by `codespell` that were not covered in the existing typo-fix PRs (#1286, #1287, #1288):

- `benchexec/test_pqos.py`: `successfull` → `successful` (3x)
- `benchexec/tools/cpachecker.py`: `uptodate` → `up-to-date` (2x)
- `benchexec/tools/template.py`: `UNKOWN` → `UNKNOWN` (1x)
- `benchexec/tablegenerator/columns.py`: `arithmetics` → `arithmetic` (1x)
- `benchexec/tablegenerator/statistics.py`: `arithmetics` → `arithmetic` (1x)

Refs: #1289