### PR TITLE
Make tests more robust and require all to pass in CI

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -48,7 +48,7 @@ stages:
     # Start lxcfs
     - lxcfs /var/lib/lxcfs &
   script:
-    - sudo -u $PRIMARY_USER python -m pytest -ra --cov -k "not tablegenerator"
+    - sudo -u $PRIMARY_USER python -m pytest --runxfail -ra --cov -k "not tablegenerator"
   after_script:
     - sudo -u $PRIMARY_USER coverage xml
   tags:
@@ -80,7 +80,7 @@ tests:cgroupsv1:python-3.14:
     # Install BenchExec with `dev` dependencies
     - pip install --user ".[dev]"
   script:
-    - python -m pytest -ra --cov
+    - python -m pytest --runxfail -ra --cov
   after_script:
     - coverage xml
   tags:

--- a/benchexec/tablegenerator/test_integration/__init__.py
+++ b/benchexec/tablegenerator/test_integration/__init__.py
@@ -758,6 +758,8 @@ class TableGeneratorIntegrationTests(unittest.TestCase):
             )
         except subprocess.CalledProcessError as e:
             if "HTTP Error" in e.output or "urlopen error" in e.output:
+                # Need to use "skip" instead of "xfail" because in CI we use "--runxfail"
+                # but do not want the test to break CI # if GitHub is unreachable.
                 self.skipTest("HTTP access to GitHub failed")
             else:
                 raise

--- a/benchexec/tablegenerator/test_util.py
+++ b/benchexec/tablegenerator/test_util.py
@@ -74,7 +74,6 @@ class TestUnit(unittest.TestCase):
 
         for k, v in test_data.items():
             self.assertEqual(v, util.number_to_roman_string(k))
-            self.assertEqual(str(v), util.number_to_roman_string(k))
 
         self.assertRaises(ValueError, util.number_to_roman_string, -1)
         self.assertRaises(ValueError, util.number_to_roman_string, 0)

--- a/benchexec/test_analyze_run_result.py
+++ b/benchexec/test_analyze_run_result.py
@@ -7,6 +7,7 @@
 
 import types
 import unittest
+import unittest.mock
 
 from benchexec.model import Run
 from benchexec.result import (
@@ -15,7 +16,6 @@ from benchexec.result import (
     RESULT_TRUE_PROP,
     RESULT_UNKNOWN,
 )
-from benchexec.tools.template import BaseTool
 from benchexec.util import ProcessExitCode
 
 normal_result = ProcessExitCode(raw=0, value=0, signal=None)
@@ -36,12 +36,8 @@ class TestResult(unittest.TestCase):
         runSet.benchmark.name = "Test"
         runSet.benchmark.instance = "Test"
         runSet.benchmark.rlimits = {}
-        runSet.benchmark.tool = BaseTool()
-
-        def determine_result(run):
-            return info_result
-
-        runSet.benchmark.tool.determine_result = determine_result
+        runSet.benchmark.tool = unittest.mock.NonCallableMock()
+        runSet.benchmark.tool.determine_result.return_value = info_result
 
         run = Run(
             identifier="test.c",

--- a/benchexec/test_cgroups.py
+++ b/benchexec/test_cgroups.py
@@ -8,6 +8,7 @@
 import subprocess
 import sys
 import unittest
+from unittest.mock import patch
 
 from benchexec import check_cgroups
 
@@ -43,17 +44,14 @@ class TestCheckCgroups(unittest.TestCase):
             # expected if cgroups are not available
             self.skipTest(e)
 
+    @patch(
+        "benchexec.check_cgroups.check_cgroup_availability",
+        new=lambda wait: sys.exit(1),
+    )
     def test_thread_result_is_returned(self):
         """
         Test that an error raised by check_cgroup_availability is correctly
         re-raised in the main thread by replacing this function temporarily.
         """
-        tmp = check_cgroups.check_cgroup_availability
-        try:
-            check_cgroups.check_cgroup_availability = lambda wait: sys.exit(1)
-
-            with self.assertRaises(SystemExit):
-                check_cgroups.main([])
-
-        finally:
-            check_cgroups.check_cgroup_availability = tmp
+        with self.assertRaises(SystemExit):
+            check_cgroups.main([])

--- a/benchexec/test_cgroups.py
+++ b/benchexec/test_cgroups.py
@@ -10,6 +10,8 @@ import sys
 import unittest
 from unittest.mock import patch
 
+import pytest
+
 from benchexec import check_cgroups
 
 
@@ -23,26 +25,20 @@ class TestCheckCgroups(unittest.TestCase):
                 **kwargs,
             )
         except subprocess.CalledProcessError as e:
-            if e.returncode != 1:  # 1 is expected if cgroups are not available
-                print(e.output)
-                raise e
+            if e.returncode == 1:
+                pytest.xfail("cgroups not availalle")
+            raise e
 
     def test_extern_command(self):
         self.execute_run_extern()
 
+    @pytest.mark.xfail(raises=SystemExit, reason="cgroups not available")
     def test_simple(self):
-        try:
-            check_cgroups.main(["--no-thread"])
-        except SystemExit as e:
-            # expected if cgroups are not available
-            self.skipTest(e)
+        check_cgroups.main(["--no-thread"])
 
+    @pytest.mark.xfail(raises=SystemExit, reason="cgroups not available")
     def test_threaded(self):
-        try:
-            check_cgroups.main([])
-        except SystemExit as e:
-            # expected if cgroups are not available
-            self.skipTest(e)
+        check_cgroups.main([])
 
     @patch(
         "benchexec.check_cgroups.check_cgroup_availability",

--- a/benchexec/test_integration/__init__.py
+++ b/benchexec/test_integration/__init__.py
@@ -367,10 +367,7 @@ class BenchExecIntegrationTests(unittest.TestCase):
         parser.resolvers.add(DTDResolver())
 
         for xml_file in xml_files:
-            try:
-                etree.parse(xml_file, parser=parser)
-            except etree.XMLSyntaxError as e:
-                self.assertIsNone(e)
+            etree.parse(xml_file, parser=parser)
 
     def test_run_results_information(self):
         expected_xml = os.path.join(

--- a/benchexec/test_runexecutor.py
+++ b/benchexec/test_runexecutor.py
@@ -39,9 +39,6 @@ trivial_run_grace_time = 0.2
 class TestRunExecutor(unittest.TestCase):
     @classmethod
     def setUpClass(cls):
-        if not hasattr(cls, "assertRegex"):
-            cls.assertRegex = cls.assertRegexpMatches
-
         cls.cgroups = Cgroups.initialize()
 
         cls.echo = shutil.which("echo") or "/bin/echo"

--- a/benchexec/test_runexecutor.py
+++ b/benchexec/test_runexecutor.py
@@ -429,9 +429,12 @@ class TestRunExecutor(unittest.TestCase):
             f"obs={memlimit}",
             "count=1",
         ]
-        (result, output) = self.execute_run(
-            *cmd, memlimit=memlimit, expect_terminationreason="memory"
-        )
+        with self.skip_if_logs(
+            "Memory limit specified, but cannot be implemented without cgroup support"
+        ):
+            (result, output) = self.execute_run(
+                *cmd, memlimit=memlimit, expect_terminationreason="memory"
+            )
 
         self.check_exitcode(result, 9, "exit code of killed process is not 9")
         self.assertAlmostEqual(
@@ -888,8 +891,14 @@ wait $child_pid
             "-c",
             script_v1 if self.cgroups.version == 1 else script_v2,
             walltimelimit=1,
-            expect_terminationreason="walltime",
+            expect_terminationreason=["walltime", None],
         )
+        if (
+            "mkdir: cannot create directory" in output[-1]
+            and "/sys/fs/cgroup" in output[-1]
+        ):
+            pytest.xfail(output[-1])
+        self.assertEqual(result.get("terminationreason"), "walltime")
         self.check_exitcode(result, 9, "exit code of killed process is not 9")
         self.assertAlmostEqual(
             result["walltime"],
@@ -1173,9 +1182,10 @@ class TestRunExecutorWithContainer(TestRunExecutor):
     @requires_grep
     @requires_lxcfs
     def test_cpuinfo_with_lxcfs(self):
-        result, output = self.execute_run(
-            grep, "^processor", "/proc/cpuinfo", cores=[0]
-        )
+        with self.skip_if_logs("Cannot limit CPU cores without cpuset cgroup"):
+            result, output = self.execute_run(
+                grep, "^processor", "/proc/cpuinfo", cores=[0]
+            )
         self.check_result_keys(result)
         self.check_exitcode(result, 0, "exit code for reading cpuinfo is not zero")
         cpus = [int(line.split()[2]) for line in output if line.startswith("processor")]
@@ -1183,9 +1193,10 @@ class TestRunExecutorWithContainer(TestRunExecutor):
 
     @requires_lxcfs
     def test_sys_cpu_with_lxcfs(self):
-        result, output = self.execute_run(
-            cat, "/sys/devices/system/cpu/online", cores=[0]
-        )
+        with self.skip_if_logs("Cannot limit CPU cores without cpuset cgroup"):
+            result, output = self.execute_run(
+                cat, "/sys/devices/system/cpu/online", cores=[0]
+            )
         self.check_result_keys(result)
         self.check_exitcode(result, 0, "exit code for reading online CPUs is not zero")
         cpus = util.parse_int_list(output[-1])

--- a/benchexec/test_runexecutor.py
+++ b/benchexec/test_runexecutor.py
@@ -18,6 +18,8 @@ import threading
 import time
 import unittest
 
+import pytest
+
 from benchexec import (
     container,
     containerexecutor,
@@ -40,6 +42,28 @@ dd = shutil.which("dd") or "/bin/dd"
 echo = shutil.which("echo") or "/bin/echo"
 grep = shutil.which("grep") or "/bin/grep"
 sleep = shutil.which("sleep") or "/bin/sleep"
+
+
+requires_fuse_overlayfs = pytest.mark.skipif(
+    not container.get_fuse_overlayfs_executable(), reason="requires fuse-overlayfs"
+)
+requires_lxcfs = pytest.mark.skipif(
+    not os.path.exists("/var/lib/lxcfs/proc"), reason="requires LXCFS"
+)
+requires_cat = pytest.mark.skipif(not os.path.exists(cat), reason="requires /bin/cat")
+requires_dd = pytest.mark.skipif(not os.path.exists(dd), reason="requires /bin/dd")
+requires_echo = pytest.mark.skipif(
+    not os.path.exists(echo), reason="requires /bin/echo"
+)
+requires_grep = pytest.mark.skipif(
+    not os.path.exists(grep), reason="requires /bin/grep"
+)
+requires_sh = pytest.mark.skipif(
+    not os.path.exists("/bin/sh"), reason="requires /bin/sh"
+)
+requires_sleep = pytest.mark.skipif(
+    not os.path.exists(sleep), reason="requires /bin/sleep"
+)
 
 
 class TestRunExecutor(unittest.TestCase):
@@ -187,20 +211,17 @@ class TestRunExecutor(unittest.TestCase):
         else:
             self.assertEqual(int(result["exitsignal"]), exitcode.signal, msg)
 
+    @requires_echo
     def test_command_output(self):
-        if not os.path.exists(echo):
-            self.skipTest("missing echo")
         (_, output) = self.execute_run(echo, "TEST_TOKEN")
         self.check_command_in_output(output, f"{echo} TEST_TOKEN")
         self.assertEqual(output[-1], "TEST_TOKEN", "run output misses command output")
         for line in output[1:-1]:
             self.assertRegex(line, "^-*$", "unexpected text in run output")
 
+    @requires_echo
+    @requires_sh
     def test_command_error_output(self):
-        if not os.path.exists(echo):
-            self.skipTest("missing echo")
-        if not os.path.exists("/bin/sh"):
-            self.skipTest("missing /bin/sh")
 
         def execute_Run_intern(*args, **kwargs):
             (error_fd, error_filename) = tempfile.mkstemp(".log", "error_", text=True)
@@ -236,9 +257,8 @@ class TestRunExecutor(unittest.TestCase):
         for line in error_lines[1:]:
             self.assertRegex(line, "^-*$", "unexpected text in run error output")
 
+    @requires_echo
     def test_command_result(self):
-        if not os.path.exists(echo):
-            self.skipTest("missing echo")
         (result, _) = self.execute_run(echo, "TEST_TOKEN")
         self.check_exitcode(result, 0, "exit code of echo is not zero")
         self.assertAlmostEqual(
@@ -262,9 +282,8 @@ class TestRunExecutor(unittest.TestCase):
     def test_wrong_command_extern(self):
         self.execute_run("/does/not/exist", expect_terminationreason="failed")
 
+    @requires_sh
     def test_cputime_hardlimit(self):
-        if not os.path.exists("/bin/sh"):
-            self.skipTest("missing /bin/sh")
         with self.skip_if_logs("Time limit cannot be specified without cpuacct cgroup"):
             (result, output) = self.execute_run(
                 "/bin/sh",
@@ -290,9 +309,8 @@ class TestRunExecutor(unittest.TestCase):
         for line in output[1:]:
             self.assertRegex(line, "^-*$", "unexpected text in run output")
 
+    @requires_sh
     def test_cputime_softlimit(self):
-        if not os.path.exists("/bin/sh"):
-            self.skipTest("missing /bin/sh")
         with self.skip_if_logs(
             "Soft time limit cannot be specified without cpuacct cgroup"
         ):
@@ -320,9 +338,8 @@ class TestRunExecutor(unittest.TestCase):
         for line in output[1:]:
             self.assertRegex(line, "^-*$", "unexpected text in run output")
 
+    @requires_sleep
     def test_walltime_limit(self):
-        if not os.path.exists(sleep):
-            self.skipTest("missing sleep")
         (result, output) = self.execute_run(
             sleep, "10", walltimelimit=1, expect_terminationreason="walltime"
         )
@@ -346,9 +363,8 @@ class TestRunExecutor(unittest.TestCase):
         for line in output[1:]:
             self.assertRegex(line, "^-*$", "unexpected text in run output")
 
+    @requires_sh
     def test_cputime_walltime_limit(self):
-        if not os.path.exists("/bin/sh"):
-            self.skipTest("missing /bin/sh")
         with self.skip_if_logs("Time limit cannot be specified without cpuacct cgroup"):
             (result, output) = self.execute_run(
                 "/bin/sh",
@@ -376,9 +392,8 @@ class TestRunExecutor(unittest.TestCase):
         for line in output[1:]:
             self.assertRegex(line, "^-*$", "unexpected text in run output")
 
+    @requires_sh
     def test_all_timelimits(self):
-        if not os.path.exists("/bin/sh"):
-            self.skipTest("missing /bin/sh")
         with self.skip_if_logs("Time limit cannot be specified without cpuacct cgroup"):
             (result, output) = self.execute_run(
                 "/bin/sh",
@@ -407,9 +422,8 @@ class TestRunExecutor(unittest.TestCase):
         for line in output[1:]:
             self.assertRegex(line, "^-*$", "unexpected text in run output")
 
+    @requires_dd
     def test_memory_limit(self):
-        if not os.path.exists(dd):
-            self.skipTest("missing dd")
         memlimit = 100_000_000
         cmd = [
             dd,
@@ -435,9 +449,8 @@ class TestRunExecutor(unittest.TestCase):
         for line in output[1:]:
             self.assertRegex(line, "^-*$", "unexpected text in run output")
 
+    @requires_cat
     def test_input_is_redirected_from_devnull(self):
-        if not os.path.exists(cat):
-            self.skipTest("missing cat")
         (result, output) = self.execute_run(cat, walltimelimit=1)
 
         self.check_exitcode(result, 0, "exit code of process is not 0")
@@ -460,9 +473,8 @@ class TestRunExecutor(unittest.TestCase):
         for line in output[1:]:
             self.assertRegex(line, "^-*$", "unexpected text in run output")
 
+    @requires_cat
     def test_input_is_redirected_from_file(self):
-        if not os.path.exists(cat):
-            self.skipTest("missing cat")
         with tempfile.TemporaryFile() as tmp:
             tmp.write(b"TEST_TOKEN")
             tmp.flush()
@@ -490,10 +502,8 @@ class TestRunExecutor(unittest.TestCase):
         for line in output[1:-1]:
             self.assertRegex(line, "^-*$", "unexpected text in run output")
 
+    @requires_cat
     def test_input_is_redirected_from_stdin(self):
-        if not os.path.exists(cat):
-            self.skipTest("missing cat")
-
         (output_fd, output_filename) = tempfile.mkstemp(".log", "output_", text=True)
         cmd = self.get_runexec_cmdline(
             "--input",
@@ -555,9 +565,8 @@ class TestRunExecutor(unittest.TestCase):
         for line in output[1:-1]:
             self.assertRegex(line, "^-*$", "unexpected text in run output")
 
+    @requires_sh
     def test_append_environment_variable(self):
-        if not os.path.exists("/bin/sh"):
-            self.skipTest("missing /bin/sh")
         (_, output) = self.execute_run("/bin/sh", "-c", "echo $PATH")
         path = output[-1]
         (_, output) = self.execute_run(
@@ -568,17 +577,15 @@ class TestRunExecutor(unittest.TestCase):
         )
         self.assertEqual(output[-1], path + ":TEST_TOKEN")
 
+    @requires_sh
     def test_new_environment_variable(self):
-        if not os.path.exists("/bin/sh"):
-            self.skipTest("missing /bin/sh")
         (_, output) = self.execute_run(
             "/bin/sh", "-c", "echo $PATH", environments={"newEnv": {"PATH": "/usr/bin"}}
         )
         self.assertEqual(output[-1], "/usr/bin")
 
+    @requires_sleep
     def test_stop_run(self):
-        if not os.path.exists(sleep):
-            self.skipTest("missing sleep")
         thread = _StopRunThread(1, self.runexecutor)
         thread.start()
         (result, output) = self.execute_run(
@@ -657,9 +664,8 @@ class TestRunExecutor(unittest.TestCase):
         self.assertIn(self.REDUCE_WARNING_MSG, new_content)
         self.assertTrue(new_content.startswith(line))
 
+    @requires_sh
     def test_append_crash_dump_info(self):
-        if not os.path.exists("/bin/sh"):
-            self.skipTest("missing /bin/sh")
         (_result, output) = self.execute_run(
             "/bin/sh",
             "-c",
@@ -672,9 +678,8 @@ class TestRunExecutor(unittest.TestCase):
             output[-1], "TEST_TOKEN", "log file misses content from crash dump file"
         )
 
+    @requires_echo
     def test_integration(self):
-        if not os.path.exists(echo):
-            self.skipTest("missing echo")
         (result, output) = self.execute_run_extern(echo, "TEST_TOKEN")
         self.check_exitcode_extern(result, 0, "exit code of echo is not zero")
         self.check_result_keys(result, "returnvalue")
@@ -684,9 +689,8 @@ class TestRunExecutor(unittest.TestCase):
         for line in output[1:-1]:
             self.assertRegex(line, "^-*$", "unexpected text in run output")
 
+    @requires_sh
     def test_home_and_tmp_is_separate(self):
-        if not os.path.exists("/bin/sh"):
-            self.skipTest("missing /bin/sh")
         (result, output) = self.execute_run("/bin/sh", "-c", "echo $HOME $TMPDIR")
         self.check_exitcode(result, 0, "exit code of /bin/sh is not zero")
         self.assertRegex(
@@ -695,9 +699,8 @@ class TestRunExecutor(unittest.TestCase):
             "HOME or TMPDIR variable does not contain expected temporary directory",
         )
 
+    @requires_sh
     def test_temp_dirs_are_removed(self):
-        if not os.path.exists("/bin/sh"):
-            self.skipTest("missing /bin/sh")
         (result, output) = self.execute_run("/bin/sh", "-c", "echo $HOME $TMPDIR")
         self.check_exitcode(result, 0, "exit code of /bin/sh is not zero")
         home_dir = output[-1].split(" ")[0]
@@ -711,9 +714,8 @@ class TestRunExecutor(unittest.TestCase):
             f"temporary temp directory {temp_dir} was not cleaned up",
         )
 
+    @requires_sh
     def test_home_is_writable(self):
-        if not os.path.exists("/bin/sh"):
-            self.skipTest("missing /bin/sh")
         (result, output) = self.execute_run("/bin/sh", "-c", "touch $HOME/TEST_FILE")
         self.check_exitcode(
             result,
@@ -721,9 +723,8 @@ class TestRunExecutor(unittest.TestCase):
             f"Failed to write to $HOME/TEST_FILE, output was\n{output}",
         )
 
+    @requires_sh
     def test_no_cleanup_temp(self):
-        if not os.path.exists("/bin/sh"):
-            self.skipTest("missing /bin/sh")
         self.setUp(cleanup_temp_dir=False)  # create RunExecutor with desired parameter
         (result, output) = self.execute_run(
             "/bin/sh", "-c", 'echo "$TMPDIR"; echo "" > "$TMPDIR/test"'
@@ -753,13 +754,12 @@ class TestRunExecutor(unittest.TestCase):
             "\n".join(log.output),
         )
 
+    @requires_cat
     def test_require_cgroup_cpu(self):
         try:
             self.setUp(additional_cgroup_subsystems=["cpu"])
         except SystemExit as e:
             self.skipTest(e)
-        if not os.path.exists(cat):
-            self.skipTest("missing cat")
         if self.cgroups.version != 1:
             self.skipTest("not relevant in unified hierarchy")
         (result, output) = self.execute_run(cat, "/proc/self/cgroup")
@@ -769,9 +769,8 @@ class TestRunExecutor(unittest.TestCase):
                 return  # Success
         self.fail("Not in expected cgroup for subsystem cpu:\n" + "\n".join(output))
 
+    @requires_echo
     def test_set_cgroup_cpu_shares(self):
-        if not os.path.exists(echo):
-            self.skipTest("missing echo")
         try:
             if self.cgroups.version == 1:
                 self.setUp(additional_cgroup_subsystems=["cpu"])
@@ -788,9 +787,8 @@ class TestRunExecutor(unittest.TestCase):
         # Just assert that execution was successful,
         # testing that the value was actually set is much more difficult.
 
+    @requires_echo
     def test_nested_runexec(self):
-        if not os.path.exists(echo):
-            self.skipTest("missing echo")
         self.setUp(
             dir_modes={
                 # Do not mark /home hidden, would fail with python from virtualenv
@@ -819,9 +817,8 @@ class TestRunExecutor(unittest.TestCase):
             inner_output[-1], "TEST_TOKEN", "run output misses command output"
         )
 
+    @requires_echo
     def test_starttime(self):
-        if not os.path.exists(echo):
-            self.skipTest("missing echo")
         before = util.read_local_time()
         (result, _) = self.execute_run(echo)
         after = util.read_local_time()
@@ -831,10 +828,11 @@ class TestRunExecutor(unittest.TestCase):
         self.assertLessEqual(before, run_starttime)
         self.assertLessEqual(run_starttime, after)
 
+    @requires_grep
+    @requires_sh
+    @requires_sleep
     def test_frozen_process(self):
         # https://github.com/sosy-lab/benchexec/issues/840
-        if not os.path.exists(sleep):
-            self.skipTest("missing sleep")
         if self.cgroups.version == 1 and not os.path.exists("/sys/fs/cgroup/freezer"):
             self.skipTest("missing freezer cgroup")
         self.setUp(
@@ -963,6 +961,7 @@ class TestRunExecutorWithContainer(TestRunExecutor):
     def test_no_cleanup_temp(self):
         self.skipTest("not relevant in container")
 
+    @requires_sh
     def check_result_files(
         self, shell_cmd, result_files_patterns, expected_result_files
     ):
@@ -1112,9 +1111,8 @@ class TestRunExecutorWithContainer(TestRunExecutor):
         count_msg = next(msg for msg in log.output if " output files matched" in msg)
         self.assertIn(f"{file_count} output files matched", count_msg)
 
+    @requires_sh
     def test_file_count_limit(self):
-        if not os.path.exists("/bin/sh"):
-            self.skipTest("missing /bin/sh")
         self.setUp(container_tmpfs=False)  # create RunExecutor with desired parameter
         filehierarchylimit._CHECK_INTERVAL_SECONDS = 0.1
         (result, output) = self.execute_run(
@@ -1131,9 +1129,8 @@ class TestRunExecutorWithContainer(TestRunExecutor):
         for line in output[1:]:
             self.assertRegex(line, "^-*$", "unexpected text in run output")
 
+    @requires_sh
     def test_file_size_limit(self):
-        if not os.path.exists("/bin/sh"):
-            self.skipTest("missing /bin/sh")
         self.setUp(container_tmpfs=False)  # create RunExecutor with desired parameter
         filehierarchylimit._CHECK_INTERVAL_SECONDS = 0.1
         (result, output) = self.execute_run(
@@ -1177,9 +1174,9 @@ class TestRunExecutorWithContainer(TestRunExecutor):
         finally:
             shutil.rmtree(temp_dir)
 
+    @requires_grep
+    @requires_lxcfs
     def test_cpuinfo_with_lxcfs(self):
-        if not os.path.exists("/var/lib/lxcfs/proc"):
-            self.skipTest("missing lxcfs")
         result, output = self.execute_run(
             grep, "^processor", "/proc/cpuinfo", cores=[0]
         )
@@ -1188,9 +1185,8 @@ class TestRunExecutorWithContainer(TestRunExecutor):
         cpus = [int(line.split()[2]) for line in output if line.startswith("processor")]
         self.assertListEqual(cpus, [0], "Unexpected CPU cores visible in container")
 
+    @requires_lxcfs
     def test_sys_cpu_with_lxcfs(self):
-        if not os.path.exists("/var/lib/lxcfs/proc"):
-            self.skipTest("missing lxcfs")
         result, output = self.execute_run(
             cat, "/sys/devices/system/cpu/online", cores=[0]
         )
@@ -1199,9 +1195,8 @@ class TestRunExecutorWithContainer(TestRunExecutor):
         cpus = util.parse_int_list(output[-1])
         self.assertListEqual(cpus, [0], "Unexpected CPU cores online in container")
 
+    @requires_lxcfs
     def test_uptime_with_lxcfs(self):
-        if not os.path.exists("/var/lib/lxcfs/proc"):
-            self.skipTest("missing lxcfs")
         result, output = self.execute_run(cat, "/proc/uptime")
         self.check_result_keys(result)
         self.check_exitcode(result, 0, "exit code for reading uptime is not zero")
@@ -1210,9 +1205,8 @@ class TestRunExecutorWithContainer(TestRunExecutor):
             uptime, 10, f"Uptime {uptime}s unexpectedly high in container"
         )
 
+    @requires_lxcfs
     def test_uptime_without_lxcfs(self):
-        if not os.path.exists("/var/lib/lxcfs/proc"):
-            self.skipTest("missing lxcfs")
         # create RunExecutor with desired parameter
         self.setUp(container_system_config=False)
         result, output = self.execute_run(cat, "/proc/uptime")
@@ -1224,9 +1218,8 @@ class TestRunExecutorWithContainer(TestRunExecutor):
             uptime, 10, f"Uptime {uptime}s unexpectedly low in container"
         )
 
+    @requires_fuse_overlayfs
     def test_fuse_overlay(self):
-        if not container.get_fuse_overlayfs_executable():
-            self.skipTest("fuse-overlayfs not available")
         with tempfile.TemporaryDirectory(prefix="BenchExec_test_") as temp_dir:
             test_file_path = os.path.join(temp_dir, "test_file")
             with open(test_file_path, "wb") as test_file:
@@ -1260,10 +1253,8 @@ class TestRunExecutorWithContainer(TestRunExecutor):
                 f"File '{test_file_path}' content is incorrect. Expected 'TEST_TOKEN', but got:\n{test_token}",
             )
 
+    @requires_fuse_overlayfs
     def test_triple_nested_runexec(self):
-        if not container.get_fuse_overlayfs_executable():
-            self.skipTest("missing fuse-overlayfs")
-
         # Check if COV_CORE_SOURCE environment variable is set and remove it.
         # This is necessary because the coverage tool will not work in the nested runexec.
         coverage_env_var = os.environ.pop("COV_CORE_SOURCE", None)

--- a/benchexec/test_runexecutor.py
+++ b/benchexec/test_runexecutor.py
@@ -44,24 +44,20 @@ grep = shutil.which("grep") or "/bin/grep"
 sleep = shutil.which("sleep") or "/bin/sleep"
 
 
-requires_fuse_overlayfs = pytest.mark.skipif(
+requires_fuse_overlayfs = pytest.mark.xfail(
     not container.get_fuse_overlayfs_executable(), reason="requires fuse-overlayfs"
 )
-requires_lxcfs = pytest.mark.skipif(
+requires_lxcfs = pytest.mark.xfail(
     not os.path.exists("/var/lib/lxcfs/proc"), reason="requires LXCFS"
 )
-requires_cat = pytest.mark.skipif(not os.path.exists(cat), reason="requires /bin/cat")
-requires_dd = pytest.mark.skipif(not os.path.exists(dd), reason="requires /bin/dd")
-requires_echo = pytest.mark.skipif(
-    not os.path.exists(echo), reason="requires /bin/echo"
-)
-requires_grep = pytest.mark.skipif(
-    not os.path.exists(grep), reason="requires /bin/grep"
-)
-requires_sh = pytest.mark.skipif(
+requires_cat = pytest.mark.xfail(not os.path.exists(cat), reason="requires /bin/cat")
+requires_dd = pytest.mark.xfail(not os.path.exists(dd), reason="requires /bin/dd")
+requires_echo = pytest.mark.xfail(not os.path.exists(echo), reason="requires /bin/echo")
+requires_grep = pytest.mark.xfail(not os.path.exists(grep), reason="requires /bin/grep")
+requires_sh = pytest.mark.xfail(
     not os.path.exists("/bin/sh"), reason="requires /bin/sh"
 )
-requires_sleep = pytest.mark.skipif(
+requires_sleep = pytest.mark.xfail(
     not os.path.exists(sleep), reason="requires /bin/sleep"
 )
 
@@ -91,7 +87,7 @@ class TestRunExecutor(unittest.TestCase):
                 record.levelno == logging.ERROR and record.msg.startswith(error_msg)
                 for record in log.records
             ):
-                self.skipTest(e)
+                pytest.xfail(str(e))
             raise e
 
     def execute_run(self, *args, expect_terminationreason=None, **kwargs):
@@ -758,8 +754,8 @@ class TestRunExecutor(unittest.TestCase):
     def test_require_cgroup_cpu(self):
         try:
             self.setUp(additional_cgroup_subsystems=["cpu"])
-        except SystemExit as e:
-            self.skipTest(e)
+        except SystemExit:
+            pytest.xfail("cgroups not available")
         if self.cgroups.version != 1:
             self.skipTest("not relevant in unified hierarchy")
         (result, output) = self.execute_run(cat, "/proc/self/cgroup")
@@ -776,8 +772,8 @@ class TestRunExecutor(unittest.TestCase):
                 self.setUp(additional_cgroup_subsystems=["cpu"])
             else:
                 self.setUp(additional_cgroup_subsystems=["memory"])
-        except SystemExit as e:
-            self.skipTest(e)
+        except SystemExit:
+            pytest.xfail("cgroups not available")
         if self.cgroups.version == 1:
             cgValues = {("cpu", "shares"): 42}
         else:
@@ -834,7 +830,7 @@ class TestRunExecutor(unittest.TestCase):
     def test_frozen_process(self):
         # https://github.com/sosy-lab/benchexec/issues/840
         if self.cgroups.version == 1 and not os.path.exists("/sys/fs/cgroup/freezer"):
-            self.skipTest("missing freezer cgroup")
+            pytest.xfail("missing freezer cgroup")
         self.setUp(
             dir_modes={
                 "/": containerexecutor.DIR_READ_ONLY,
@@ -913,7 +909,7 @@ class TestRunExecutorWithContainer(TestRunExecutor):
         try:
             container.execute_in_namespace(lambda: 0)
         except OSError as e:
-            self.skipTest(f"Namespaces not supported: {e.strerror}")
+            pytest.xfail(reason=f"Namespaces not supported: {e.strerror}")
 
         dir_modes = kwargs.pop(
             "dir_modes",

--- a/benchexec/test_runexecutor.py
+++ b/benchexec/test_runexecutor.py
@@ -915,7 +915,7 @@ class TestRunExecutorWithContainer(TestRunExecutor):
         try:
             container.execute_in_namespace(lambda: 0)
         except OSError as e:
-            self.skipTest(f"Namespaces not supported: {os.strerror(e.errno)}")
+            self.skipTest(f"Namespaces not supported: {e.strerror}")
 
         dir_modes = kwargs.pop(
             "dir_modes",

--- a/benchexec/test_runexecutor.py
+++ b/benchexec/test_runexecutor.py
@@ -35,17 +35,17 @@ runexec = os.path.join(bin_dir, "runexec")
 
 trivial_run_grace_time = 0.2
 
+cat = shutil.which("cat") or "/bin/cat"
+dd = shutil.which("dd") or "/bin/dd"
+echo = shutil.which("echo") or "/bin/echo"
+grep = shutil.which("grep") or "/bin/grep"
+sleep = shutil.which("sleep") or "/bin/sleep"
+
 
 class TestRunExecutor(unittest.TestCase):
     @classmethod
     def setUpClass(cls):
         cls.cgroups = Cgroups.initialize()
-
-        cls.echo = shutil.which("echo") or "/bin/echo"
-        cls.sleep = shutil.which("sleep") or "/bin/sleep"
-        cls.cat = shutil.which("cat") or "/bin/cat"
-        cls.dd = shutil.which("dd") or "/bin/dd"
-        cls.grep = shutil.which("grep") or "/bin/grep"
 
     def setUp(self, *args, **kwargs):
         with self.skip_if_logs(
@@ -188,16 +188,16 @@ class TestRunExecutor(unittest.TestCase):
             self.assertEqual(int(result["exitsignal"]), exitcode.signal, msg)
 
     def test_command_output(self):
-        if not os.path.exists(self.echo):
+        if not os.path.exists(echo):
             self.skipTest("missing echo")
-        (_, output) = self.execute_run(self.echo, "TEST_TOKEN")
-        self.check_command_in_output(output, f"{self.echo} TEST_TOKEN")
+        (_, output) = self.execute_run(echo, "TEST_TOKEN")
+        self.check_command_in_output(output, f"{echo} TEST_TOKEN")
         self.assertEqual(output[-1], "TEST_TOKEN", "run output misses command output")
         for line in output[1:-1]:
             self.assertRegex(line, "^-*$", "unexpected text in run output")
 
     def test_command_error_output(self):
-        if not os.path.exists(self.echo):
+        if not os.path.exists(echo):
             self.skipTest("missing echo")
         if not os.path.exists("/bin/sh"):
             self.skipTest("missing /bin/sh")
@@ -215,7 +215,7 @@ class TestRunExecutor(unittest.TestCase):
                 os.remove(error_filename)
 
         (output_lines, error_lines) = execute_Run_intern(
-            "/bin/sh", "-c", f"{self.echo} ERROR_TOKEN >&2"
+            "/bin/sh", "-c", f"{echo} ERROR_TOKEN >&2"
         )
         self.assertEqual(
             error_lines[-1], "ERROR_TOKEN", "run error output misses command output"
@@ -225,9 +225,9 @@ class TestRunExecutor(unittest.TestCase):
         for line in error_lines[1:-1]:
             self.assertRegex(line, "^-*$", "unexpected text in run error output")
 
-        (output_lines, error_lines) = execute_Run_intern(self.echo, "OUT_TOKEN")
-        self.check_command_in_output(output_lines, f"{self.echo} OUT_TOKEN")
-        self.check_command_in_output(error_lines, f"{self.echo} OUT_TOKEN")
+        (output_lines, error_lines) = execute_Run_intern(echo, "OUT_TOKEN")
+        self.check_command_in_output(output_lines, f"{echo} OUT_TOKEN")
+        self.check_command_in_output(error_lines, f"{echo} OUT_TOKEN")
         self.assertEqual(
             output_lines[-1], "OUT_TOKEN", "run output misses command output"
         )
@@ -237,9 +237,9 @@ class TestRunExecutor(unittest.TestCase):
             self.assertRegex(line, "^-*$", "unexpected text in run error output")
 
     def test_command_result(self):
-        if not os.path.exists(self.echo):
+        if not os.path.exists(echo):
             self.skipTest("missing echo")
-        (result, _) = self.execute_run(self.echo, "TEST_TOKEN")
+        (result, _) = self.execute_run(echo, "TEST_TOKEN")
         self.check_exitcode(result, 0, "exit code of echo is not zero")
         self.assertAlmostEqual(
             result["walltime"],
@@ -321,10 +321,10 @@ class TestRunExecutor(unittest.TestCase):
             self.assertRegex(line, "^-*$", "unexpected text in run output")
 
     def test_walltime_limit(self):
-        if not os.path.exists(self.sleep):
+        if not os.path.exists(sleep):
             self.skipTest("missing sleep")
         (result, output) = self.execute_run(
-            self.sleep, "10", walltimelimit=1, expect_terminationreason="walltime"
+            sleep, "10", walltimelimit=1, expect_terminationreason="walltime"
         )
 
         self.check_exitcode(result, 9, "exit code of killed process is not 9")
@@ -342,7 +342,7 @@ class TestRunExecutor(unittest.TestCase):
                 msg="cputime of sleep is not approximately zero",
             )
 
-        self.check_command_in_output(output, f"{self.sleep} 10")
+        self.check_command_in_output(output, f"{sleep} 10")
         for line in output[1:]:
             self.assertRegex(line, "^-*$", "unexpected text in run output")
 
@@ -408,11 +408,11 @@ class TestRunExecutor(unittest.TestCase):
             self.assertRegex(line, "^-*$", "unexpected text in run output")
 
     def test_memory_limit(self):
-        if not os.path.exists(self.dd):
+        if not os.path.exists(dd):
             self.skipTest("missing dd")
         memlimit = 100_000_000
         cmd = [
-            self.dd,
+            dd,
             "if=/dev/zero",
             "of=/dev/null",
             f"ibs={memlimit}",
@@ -436,9 +436,9 @@ class TestRunExecutor(unittest.TestCase):
             self.assertRegex(line, "^-*$", "unexpected text in run output")
 
     def test_input_is_redirected_from_devnull(self):
-        if not os.path.exists(self.cat):
+        if not os.path.exists(cat):
             self.skipTest("missing cat")
-        (result, output) = self.execute_run(self.cat, walltimelimit=1)
+        (result, output) = self.execute_run(cat, walltimelimit=1)
 
         self.check_exitcode(result, 0, "exit code of process is not 0")
         self.assertAlmostEqual(
@@ -456,18 +456,18 @@ class TestRunExecutor(unittest.TestCase):
             )
         self.check_result_keys(result)
 
-        self.check_command_in_output(output, self.cat)
+        self.check_command_in_output(output, cat)
         for line in output[1:]:
             self.assertRegex(line, "^-*$", "unexpected text in run output")
 
     def test_input_is_redirected_from_file(self):
-        if not os.path.exists(self.cat):
+        if not os.path.exists(cat):
             self.skipTest("missing cat")
         with tempfile.TemporaryFile() as tmp:
             tmp.write(b"TEST_TOKEN")
             tmp.flush()
             tmp.seek(0)
-            (result, output) = self.execute_run(self.cat, stdin=tmp, walltimelimit=1)
+            (result, output) = self.execute_run(cat, stdin=tmp, walltimelimit=1)
 
         self.check_exitcode(result, 0, "exit code of process is not 0")
         self.assertAlmostEqual(
@@ -485,13 +485,13 @@ class TestRunExecutor(unittest.TestCase):
             )
         self.check_result_keys(result)
 
-        self.check_command_in_output(output, self.cat)
+        self.check_command_in_output(output, cat)
         self.assertEqual(output[-1], "TEST_TOKEN", "run output misses command output")
         for line in output[1:-1]:
             self.assertRegex(line, "^-*$", "unexpected text in run output")
 
     def test_input_is_redirected_from_stdin(self):
-        if not os.path.exists(self.cat):
+        if not os.path.exists(cat):
             self.skipTest("missing cat")
 
         (output_fd, output_filename) = tempfile.mkstemp(".log", "output_", text=True)
@@ -500,7 +500,7 @@ class TestRunExecutor(unittest.TestCase):
             "-",
             "--walltime",
             "1",
-            self.cat,
+            cat,
             output_filename=output_filename,
         )
         try:
@@ -550,7 +550,7 @@ class TestRunExecutor(unittest.TestCase):
             )
         self.check_result_keys(result, "returnvalue")
 
-        self.check_command_in_output(output, self.cat)
+        self.check_command_in_output(output, cat)
         self.assertEqual(output[-1], "TEST_TOKEN", "run output misses command output")
         for line in output[1:-1]:
             self.assertRegex(line, "^-*$", "unexpected text in run output")
@@ -577,12 +577,12 @@ class TestRunExecutor(unittest.TestCase):
         self.assertEqual(output[-1], "/usr/bin")
 
     def test_stop_run(self):
-        if not os.path.exists(self.sleep):
+        if not os.path.exists(sleep):
             self.skipTest("missing sleep")
         thread = _StopRunThread(1, self.runexecutor)
         thread.start()
         (result, output) = self.execute_run(
-            self.sleep, "10", expect_terminationreason="killed"
+            sleep, "10", expect_terminationreason="killed"
         )
         thread.join()
 
@@ -601,7 +601,7 @@ class TestRunExecutor(unittest.TestCase):
                 msg="cputime of sleep is not approximately zero",
             )
 
-        self.check_command_in_output(output, f"{self.sleep} 10")
+        self.check_command_in_output(output, f"{sleep} 10")
         for line in output[1:]:
             self.assertRegex(line, "^-*$", "unexpected text in run output")
 
@@ -673,13 +673,13 @@ class TestRunExecutor(unittest.TestCase):
         )
 
     def test_integration(self):
-        if not os.path.exists(self.echo):
+        if not os.path.exists(echo):
             self.skipTest("missing echo")
-        (result, output) = self.execute_run_extern(self.echo, "TEST_TOKEN")
+        (result, output) = self.execute_run_extern(echo, "TEST_TOKEN")
         self.check_exitcode_extern(result, 0, "exit code of echo is not zero")
         self.check_result_keys(result, "returnvalue")
 
-        self.check_command_in_output(output, f"{self.echo} TEST_TOKEN")
+        self.check_command_in_output(output, f"{echo} TEST_TOKEN")
         self.assertEqual(output[-1], "TEST_TOKEN", "run output misses command output")
         for line in output[1:-1]:
             self.assertRegex(line, "^-*$", "unexpected text in run output")
@@ -758,11 +758,11 @@ class TestRunExecutor(unittest.TestCase):
             self.setUp(additional_cgroup_subsystems=["cpu"])
         except SystemExit as e:
             self.skipTest(e)
-        if not os.path.exists(self.cat):
+        if not os.path.exists(cat):
             self.skipTest("missing cat")
         if self.cgroups.version != 1:
             self.skipTest("not relevant in unified hierarchy")
-        (result, output) = self.execute_run(self.cat, "/proc/self/cgroup")
+        (result, output) = self.execute_run(cat, "/proc/self/cgroup")
         self.check_exitcode(result, 0, "exit code of cat is not zero")
         for line in output:
             if re.match(r"^[0-9]*:([^:]*,)?cpu(,[^:]*)?:/(.*/)?benchmark_.*$", line):
@@ -770,7 +770,7 @@ class TestRunExecutor(unittest.TestCase):
         self.fail("Not in expected cgroup for subsystem cpu:\n" + "\n".join(output))
 
     def test_set_cgroup_cpu_shares(self):
-        if not os.path.exists(self.echo):
+        if not os.path.exists(echo):
             self.skipTest("missing echo")
         try:
             if self.cgroups.version == 1:
@@ -783,13 +783,13 @@ class TestRunExecutor(unittest.TestCase):
             cgValues = {("cpu", "shares"): 42}
         else:
             cgValues = {("memory", "high"): 420000000}
-        (result, _) = self.execute_run(self.echo, cgroupValues=cgValues)
+        (result, _) = self.execute_run(echo, cgroupValues=cgValues)
         self.check_exitcode(result, 0, "exit code of echo is not zero")
         # Just assert that execution was successful,
         # testing that the value was actually set is much more difficult.
 
     def test_nested_runexec(self):
-        if not os.path.exists(self.echo):
+        if not os.path.exists(echo):
             self.skipTest("missing echo")
         self.setUp(
             dir_modes={
@@ -799,7 +799,7 @@ class TestRunExecutor(unittest.TestCase):
                 "/sys/fs/cgroup": containerexecutor.DIR_FULL_ACCESS,
             }
         )
-        inner_args = ["--", self.echo, "TEST_TOKEN"]
+        inner_args = ["--", echo, "TEST_TOKEN"]
 
         with tempfile.NamedTemporaryFile(
             mode="r", prefix="inner_output_", suffix=".log"
@@ -814,16 +814,16 @@ class TestRunExecutor(unittest.TestCase):
         logging.info("Inner output:\n%s", "\n".join(inner_output))
         self.check_result_keys(outer_result, "returnvalue")
         self.check_exitcode(outer_result, 0, "exit code of inner runexec is not zero")
-        self.check_command_in_output(inner_output, f"{self.echo} TEST_TOKEN")
+        self.check_command_in_output(inner_output, f"{echo} TEST_TOKEN")
         self.assertEqual(
             inner_output[-1], "TEST_TOKEN", "run output misses command output"
         )
 
     def test_starttime(self):
-        if not os.path.exists(self.echo):
+        if not os.path.exists(echo):
             self.skipTest("missing echo")
         before = util.read_local_time()
-        (result, _) = self.execute_run(self.echo)
+        (result, _) = self.execute_run(echo)
         after = util.read_local_time()
         self.check_result_keys(result)
         run_starttime = result["starttime"]
@@ -833,7 +833,7 @@ class TestRunExecutor(unittest.TestCase):
 
     def test_frozen_process(self):
         # https://github.com/sosy-lab/benchexec/issues/840
-        if not os.path.exists(self.sleep):
+        if not os.path.exists(sleep):
             self.skipTest("missing sleep")
         if self.cgroups.version == 1 and not os.path.exists("/sys/fs/cgroup/freezer"):
             self.skipTest("missing freezer cgroup")
@@ -1181,7 +1181,7 @@ class TestRunExecutorWithContainer(TestRunExecutor):
         if not os.path.exists("/var/lib/lxcfs/proc"):
             self.skipTest("missing lxcfs")
         result, output = self.execute_run(
-            self.grep, "^processor", "/proc/cpuinfo", cores=[0]
+            grep, "^processor", "/proc/cpuinfo", cores=[0]
         )
         self.check_result_keys(result)
         self.check_exitcode(result, 0, "exit code for reading cpuinfo is not zero")
@@ -1192,7 +1192,7 @@ class TestRunExecutorWithContainer(TestRunExecutor):
         if not os.path.exists("/var/lib/lxcfs/proc"):
             self.skipTest("missing lxcfs")
         result, output = self.execute_run(
-            self.cat, "/sys/devices/system/cpu/online", cores=[0]
+            cat, "/sys/devices/system/cpu/online", cores=[0]
         )
         self.check_result_keys(result)
         self.check_exitcode(result, 0, "exit code for reading online CPUs is not zero")
@@ -1202,7 +1202,7 @@ class TestRunExecutorWithContainer(TestRunExecutor):
     def test_uptime_with_lxcfs(self):
         if not os.path.exists("/var/lib/lxcfs/proc"):
             self.skipTest("missing lxcfs")
-        result, output = self.execute_run(self.cat, "/proc/uptime")
+        result, output = self.execute_run(cat, "/proc/uptime")
         self.check_result_keys(result)
         self.check_exitcode(result, 0, "exit code for reading uptime is not zero")
         uptime = float(output[-1].split(" ")[0])
@@ -1215,7 +1215,7 @@ class TestRunExecutorWithContainer(TestRunExecutor):
             self.skipTest("missing lxcfs")
         # create RunExecutor with desired parameter
         self.setUp(container_system_config=False)
-        result, output = self.execute_run(self.cat, "/proc/uptime")
+        result, output = self.execute_run(cat, "/proc/uptime")
         self.check_result_keys(result)
         self.check_exitcode(result, 0, "exit code for reading uptime is not zero")
         uptime = float(output[-1].split(" ")[0])
@@ -1243,8 +1243,8 @@ class TestRunExecutorWithContainer(TestRunExecutor):
             result, output = self.execute_run(
                 "/bin/sh",
                 "-c",
-                f"if [ $({self.cat} {test_file_path}) != TEST_TOKEN ]; then exit 1; fi; \
-                {self.echo} TOKEN_CHANGED >{test_file_path}",
+                f"if [ $({cat} {test_file_path}) != TEST_TOKEN ]; then exit 1; fi; \
+                {echo} TOKEN_CHANGED >{test_file_path}",
             )
             self.check_result_keys(result, "returnvalue")
             self.check_exitcode(result, 0, "exit code of inner runexec is not zero")
@@ -1317,7 +1317,7 @@ class TestRunExecutorWithContainer(TestRunExecutor):
             inner_cmd = [
                 "/bin/sh",
                 "-c",
-                f"if [ $({self.cat} {test_file}) != TEST_TOKEN ]; then exit 1; fi; {self.echo} TOKEN_CHANGED >{test_file}",
+                f"if [ $({cat} {test_file}) != TEST_TOKEN ]; then exit 1; fi; {echo} TOKEN_CHANGED >{test_file}",
             ]
             combined_cmd = outer_cmd + mid_cmd + inner_cmd
 


### PR DESCRIPTION
- Use test utilities for mocking instead of manual monkey-patching.
- Make use of the distinction between "xfail" (expected to fail) and "skipped" tests in pytest: We mark those tests as "xfail" that are expected to fail sometimes, e.g., when cgroups or namespaces are missing, but never in CI. Then in CI we use `--runxfail` such that "xfail" tests become regular tests in CI. This has no effect for users but would allow us to detect if there are some tests that accidentally do not run in CI.
- Mark more tests that require cgroups as expected to fail in such cases.
- Some cleanups and simplifications.

Marking tests as "skipped" in case of failure and catching exceptions in tests are both somewhat dangerous because it is easy to introduce a bug that hides problems (example: d572cffe475574473eddd4aac3bf4eaab57dca86). With these changes we have now reduced the number of `skipTest()` calls and the number of `try: ... except` blocks in tests considerably, and all such instances were reviewed and considered ok. This is a nice improvement of the confidence in our test suite.